### PR TITLE
Alteração no nome do aplicativo sigase para sigade (Dados Externos)  …

### DIFF
--- a/siga-vraptor-module/src/main/resources/META-INF/tags/menuprincipal.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/menuprincipal.tag
@@ -100,7 +100,7 @@
                 </c:if>
                 
                 	<c:if test="${f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;SE:Módulo de Servicos Externos')}">
-						<li><a href="/sigase/">Dados Externos</a>
+						<li><a href="/sigade/">Dados Externos</a>
 						</li>
 					</c:if>
 					


### PR DESCRIPTION
…para não confundir mais com o sigase legado da JFRJ