### PR TITLE
ajuste na disposicao do bloco de codigo ao selecionar tipo modelo fre…

### DIFF
--- a/siga-vraptor-module/src/main/resources/META-INF/tags/escolha.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/escolha.tag
@@ -4,36 +4,35 @@
 <%@ attribute name="var" required="false"%>
 <%@ attribute name="id" required="false"%>
 <%@ attribute name="classSelect"%>
+<%@ attribute name="executarJavascript" required="false"%>
 
-<script language="javascript" type="text/javascript">
-	function muda_escolha(id) {
-		<c:set var="setNull" scope="request" >true</c:set>
-		<jsp:doBody/>
-		<c:remove var="setNull"/>
-		var span = document.getElementById(id.value);
-		span.style.display = "";
-	}
-</script>
+<c:if test="${executarJavascript != 'false'}">
+	<script language="javascript" type="text/javascript">
+		function muda_escolha(id) {
+			<c:set var="setNull" scope="request" >true</c:set>
+			<jsp:doBody/>
+			<c:remove var="setNull"/>
+			var span = document.getElementById(id.value);
+			span.style.display = "";
+		}
+	</script>
+</c:if>
 
 <c:set var="selectedOption" scope="request" value="${requestScope[var]}"></c:set>
 
-<div class="row">
-	<c:set var="createSelect" scope="request">true</c:set>
-	<div class="col col-auto">
-		<select id="${id}" name="${var}"
-			onchange="javascript:muda_escolha(this);" class="form-control">
-			<jsp:doBody />
-		</select>
-	</div>
-	<div class="col">
-		<c:remove var="createSelect" />
+<c:set var="createSelect" scope="request">true</c:set>
 
-		<c:set var="createSpan" scope="request">true</c:set>
-		<c:set var="setFirstStyle" scope="request">true</c:set>
-		<jsp:doBody />
-		<c:remove var="setFirst" />
-		<c:remove var="createSpan" />
+<select id="${id}" name="${var}"
+	onchange="javascript:muda_escolha(this);" class="form-control">
+	<jsp:doBody />
+</select>
 
-		<c:remove var="selectedOption" scope="request" />
-	</div>
-</div>
+<c:remove var="createSelect" />
+
+<c:set var="createSpan" scope="request">true</c:set>
+<c:set var="setFirstStyle" scope="request">true</c:set>
+<jsp:doBody />
+<c:remove var="setFirst" />
+<c:remove var="createSpan" />
+
+<c:remove var="selectedOption" scope="request" />	

--- a/sigaex/src/main/webapp/WEB-INF/page/exModelo/edita.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exModelo/edita.jsp
@@ -133,7 +133,7 @@
 						</div>		
 					</div>
 					<div class="row">						
-						<div class="col-md-2">
+						<div class="col-md-3">
 							<div class="form-group">
 								<label>Marca d'água no documento</label>
 								<input type="text" name="marcaDagua" value="${marcaDagua}" maxlength="13" class="form-control" />
@@ -144,14 +144,13 @@
 						<div class="col-md-2">
 							<div class="form-group">
 								<label>Tipo do Modelo</label>
-								<siga:escolha id="tipoModelo" var="tipoModelo">
+								<siga:escolha id="tipoModelo" var="tipoModelo" executarJavascript="false">
 							</div>
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-sm-12">
-							<div class="form-group">
-								
+							<div class="form-group">								
 									<siga:opcao id="template/freemarker" texto="Freemarker">
 										<textarea id="conteudo" style="width: 100%;" cols="1" rows="1"
 											name="conteudo" class="form-control"><c:out value="${conteudo}"
@@ -159,8 +158,10 @@
 										<p align="right">Ctrl-I: Indentar, Crtl-S: Salvar</p>
 									</siga:opcao>
 									<siga:opcao id="template-file/jsp" texto="JSP">
-									&nbsp;&nbsp;&nbsp;&nbsp;Nome do arquivo:
-									<input type="text" name="arquivo" size="80" value="${arquivo}" />
+									<div class="col-md-8  p-0">
+										<label for="nomeArquivo">Nome do arquivo</label>
+										<input type="text" id="nomeArquivo" class="form-control" name="arquivo" size="80" value="${arquivo}" />
+									</div>
 									</siga:opcao>
 								</siga:escolha>
 							</div>
@@ -296,13 +297,13 @@
 				});	
 			}
 				
-			montaTableCadastradas('tableCadastradasEletronico', 4, 0 ,${id});
-			montaTableCadastradas('tableCadastradasCriar', 2, 0 ,${id});
-			montaTableCadastradas('tableCadastradasAssinar', 1, 11 ,${id});
-			montaTableCadastradas('tableCadastradasAssinarComSenha', 1, 58 ,${id});		
-			montaTableCadastradas('tableCadastradasAcessar', 6, 0 ,${id});
-			montaTableCadastradas('tableCadastradasNivelAcessoMaximo', 18, 0 ,${id});
-			montaTableCadastradas('tableCadastradasNivelAcessoMinimo', 19, 0 ,${id});
+			montaTableCadastradas('tableCadastradasEletronico', 4, 0, ${id});
+			montaTableCadastradas('tableCadastradasCriar', 2, 0, ${id});
+			montaTableCadastradas('tableCadastradasAssinar', 1, 11, ${id});
+			montaTableCadastradas('tableCadastradasAssinarComSenha', 1, 58, ${id});		
+			montaTableCadastradas('tableCadastradasAcessar', 6, 0, ${id});
+			montaTableCadastradas('tableCadastradasNivelAcessoMaximo', 18, 0, ${id});
+			montaTableCadastradas('tableCadastradasNivelAcessoMinimo', 19, 0, ${id});
 		</c:if>
 	</script>
 


### PR DESCRIPTION
Ao cadastrar um novo modelo e selecionar a combo Tipo do Modelo com a opção Freemarker, é carregado o bloco de código para se inserir o código Freemarker, este bloco estava sendo apresentado com um tamanho menor (width), inconsistente em relação ao que estava anteriormente no EAP 6.4. Também acrescentei uma verificação na página escolha.tag para não executar o javascript dessa página caso o parâmetro executarJavascript seja false, pois, no caso do cadastro de modelo, esse script não estava sendo executado e estava apresentando um erro na console do navegador devido ao código gerado por ele.