### PR TITLE
Bloquear definição de perfil REVISOR após documento assinado 

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -2185,6 +2185,15 @@ public class ExMovimentacaoController extends ExController {
 
 		final List<ExPapel> papeis = this.getListaExPapel();
 		
+		if (builder.getMob().getDoc().isAssinadoPorTodosOsSignatariosComTokenOuSenha()) {			
+			for (Iterator<ExPapel> iter = papeis.listIterator(); iter.hasNext(); ) {
+			    ExPapel p = iter.next();
+			    if (p.getIdPapel() == ExPapel.PAPEL_REVISOR) {
+			        iter.remove();
+			    }
+			}			
+		}
+		
 		if (SigaMessages.isSigaSP()) {
 			for (Iterator<ExPapel> iter = papeis.listIterator(); iter.hasNext(); ) {
 			    ExPapel p = iter.next();


### PR DESCRIPTION
DOC: Alteração para bloquear definição de perfil REVISOR após o documento estar assinado.