### PR TITLE
Removendo a lotação da ação "Atividades da lotação"

### DIFF
--- a/sigasr/src/main/webapp/WEB-INF/page/solicitacao/editar.jsp
+++ b/sigasr/src/main/webapp/WEB-INF/page/solicitacao/editar.jsp
@@ -150,7 +150,7 @@
 					
 					<div id="divLocalRamalEMeioContato" depende="solicitacao.solicitante">
 						<script>
-							//Edson: talvez fosse possível fazer de um modo melhor, mas assim é mais prático
+							//Edson: talvez fosse possivel fazer de um modo melhor, mas assim é mais prático
 							$("#solicitacaosolicitanteSpan").html("${solicitacao.solicitante.descricaoCompleta}");
 							$("#horarioComunicacao").mask("99:99");
 						</script>
@@ -179,7 +179,7 @@
 						</div>
 						
 						<div class="gt-form-row-inline-block gt-width-33">
-							<label>Endereço de atendimento</label> 
+							<label>Endere&ccedil;o de atendimento</label> 
 								<input type="text" name="solicitacao.endereco" id="endereco" value="${solicitacao.endereco}" size="65" maxlength="255" />
 								<siga:error name="solicitacao.endereco"/>
 						</div>

--- a/sigasr/src/main/webapp/WEB-INF/tags/classificacao.tag
+++ b/sigasr/src/main/webapp/WEB-INF/tags/classificacao.tag
@@ -63,11 +63,14 @@
 					<c:forEach items="${acoesEAtendentes.keySet()}" var="cat">
 						<optgroup  label="${cat.tituloAcao}">
 							<c:forEach items="${acoesEAtendentes.get(cat)}" var="tarefa">
+								<c:set var="atividadeLotacao" value="${fn:startsWith(fn:toLowerCase(tarefa.acao.tituloAcao), 'atividades da lotação')}" />
+								
 								<option value="${tarefa.acao.idAcao}" ${solicitacao.acao.idAcao.equals(tarefa.acao.idAcao) ? 'selected' : ''}> 
 									${tarefa.acao.tituloAcao}
-									<c:if test="${exibeLotacaoNaAcao}">(${tarefa.conf.atendente.lotacaoAtual.siglaCompleta})</c:if>
+									<c:if test="${exibeLotacaoNaAcao && !atividadeLotacao}">(${tarefa.conf.atendente.lotacaoAtual.siglaCompleta})</c:if>
+									<c:if test="${atividadeLotacao}"><!-- (${tarefa.conf.atendente.lotacaoAtual.siglaCompleta}) --></c:if>
 								</option>
-							</c:forEach>					 
+							</c:forEach>
 						</optgroup>
 					</c:forEach>
 				</select>


### PR DESCRIPTION
Removendo da visão do usuário a sigla da lotação que aparece entre parênteses na frente do título da ação, na combo de Ação do formulário de inclusão de solicitação, a fim de não confundir os usuários.

Removendo acentos do arquivo JSP para que não haja problema com codepage.