### PR TITLE
GOVSP1214 - Removendo relacionamento do documento anterior

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -407,9 +407,8 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "exDocumento")
 	private java.util.Set<ExBoletimDoc> exBoletimDocSet;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "ID_DOC_ANTERIOR")
-	private ExDocumento exDocAnterior;
+	@Column(name = "ID_DOC_ANTERIOR")
+	private java.lang.Long idDocAnterior;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ID_MOB_AUTUADO")
@@ -553,8 +552,8 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 	 * 
 	 * @return
 	 */
-	public ExDocumento getExDocAnterior() {
-		return exDocAnterior;
+	public java.lang.Long getIdDocAnterior() {
+		return idDocAnterior;
 	}
 
 	/**
@@ -887,8 +886,8 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 		this.exClassificacao = exClassificacao;
 	}
 
-	public void setExDocAnterior(ExDocumento exDocAnterior) {
-		this.exDocAnterior = exDocAnterior;
+	public void setIdDocAnterior(java.lang.Long idDocAnterior) {
+		this.idDocAnterior = idDocAnterior;
 	}
 
 	public void setExFormaDocumento(final ExFormaDocumento exFormaDocumento) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4244,7 +4244,7 @@ public class ExBL extends CpBL {
 			novoDoc.setLotaTitular(doc.getLotaTitular().getLotacaoAtual());
 
 		novoDoc.setNumAntigoDoc(doc.getNumAntigoDoc());
-		novoDoc.setExDocAnterior(doc);
+		novoDoc.setIdDocAnterior(doc.getIdDoc());
 		// novoDoc.setNumPaginas(novoDoc.getContarNumeroDePaginas());
 
 		ExMobil mob = new ExMobil();
@@ -6841,7 +6841,7 @@ public class ExBL extends CpBL {
 		// doc.setDestinatario(null);
 		doc.setExBoletimDocSet(null);
 		doc.setExClassificacao(null);
-		doc.setExDocAnterior(null);
+		doc.setIdDocAnterior(null);
 		doc.setExFormaDocumento(null);
 		doc.setExMobilAutuado(null);
 		doc.setExMobilPai(null);


### PR DESCRIPTION
Na tabela EX_DOCUMENTO tem um campo ID_DOC_ANTERIOR. Esse campo faz referência ao documento original quando é duplicado ou refeito. Acontece que quando esse processo ocorre para documentos temporários, o sistema permite excluir fisicamente o documento que originou a cópia quebrando esse relacionamento. Até então na EAP 6 o hibernate respeitava o LAZY dessa coluna e não trazia os documentos que originou o documento atual. Agora na EAP 7 ele tenta trazer em modo EAGER esse documento anterior que tem essa falha no autorrelacionamento. Percebemos que aparentemente esse ID não é usado no sistema, mas para manter a escrita desse ID nos moldes atuais e resolver esse problema.. 
Tentamos usar outras anotações, mas também não foram respeitadas.

Retirado o Mapeamento do Relacionamento e mantido o ID para persistência