### PR TITLE
Resolve issue #1311 - Null pointer na mesa 2 em capturado cancelado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -437,8 +437,6 @@ public class Mesa2 {
 		List<MeM> listMeM;
 		Date movUltimaDtIniMov;
 		Date movUltimaDtFimMov;
-		String movUltimaSiglaOrgao;
-		String movUltimaSiglaLotacao;
 		String movTramiteSiglaOrgao;
 		String movTramiteSiglaLotacao;
 		String movAnotacaoDescrMov;
@@ -715,8 +713,6 @@ public class Mesa2 {
 			if (movUltima != null) {
 				docDados.movUltimaDtIniMov = movUltima.getDtIniMov();
 				docDados.movUltimaDtFimMov = movUltima.getDtFimMov();
-				docDados.movUltimaSiglaLotacao = movUltima.getLotacao().getSigla();
-				docDados.movUltimaSiglaOrgao = movUltima.getLotacao().getOrgaoUsuario().getSigla();
 			}
 			if (movTramite != null) {
 				docDados.movTramiteSiglaLotacao = movTramite.getLotacao().getSigla();


### PR DESCRIPTION
Removidos dois campos não utilizados na mesa 2 que eram a origem do null pointer.