### PR TITLE
GOVSP - 973 Tramitação de documento com data anterior a data do dia

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -1882,8 +1882,14 @@ public class ExMovimentacaoController extends ExController {
 			
 	        if (SigaMessages.isSigaSP()) {
 	        	if (!DateUtils.isSameDay(new Date(), dtDevolucao) && dtDevolucao.before(new Date())) {
-					throw new AplicacaoException(
-							"Data de devolução não pode ser anterior à data de hoje.");
+	        		result.include("msgCabecClass", "alert-danger");
+	        		result.include("mensagemCabec", "Data de devolução não pode ser anterior à data de hoje.");
+	        		result.forwardTo(this).aTransferir(
+	        				sigla, idTpDespacho, tipoResponsavel, postback, dtMovString, subscritorSel, 
+	        				substituicao, titularSel, nmFuncaoSubscritor, idResp, tiposDespacho, descrMov, 
+	        				lotaResponsavelSel, responsavelSel, cpOrgaoSel, dtDevolucaoMovString, obsOrgao, protocolo);
+	        		
+	        			return;
 	        	}
 	        }
 		}

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -176,8 +176,8 @@ $(function(){
 				<div class="row">
 					<div class="col-sm-2">
 						<div class="form-group">
-							<a accesskey="o" id="button_ok" onclick="javascript:submeter();" class="btn btn-primary"><u>O</u>k</a>
-							<button type="button"  onclick="javascript:history.back();" class="btn btn-primary">Cancela</button>
+							<a accesskey="o" id="button_ok" onclick="javascript:submeter();" class="btn btn-primary"><u>O</u>k</a>																			
+							<a href="${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${sigla}" class="btn btn-primary">Cancela</a>
 						</div>
 					</div>
 				</div>				


### PR DESCRIPTION
Na Tramitação para usuário, ao definirmos erroneamente a data de devolução, apresenta a mensagem “Data de devolução não pode ser anterior à data de hoje”. Até então ok, porém ao clicar no botão voltar, apresenta a tela de erro, não retornando para a tela de tramitação.

Observação: "Ambiente de Produção e Homologação"