### PR TITLE
Resolve issue #1335 - Melhorar performance do Criar Novo (combo de modelos)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,21 +97,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-           	<plugin>
-               <groupId>org.hibernate.orm.tooling</groupId>
-               <artifactId>hibernate-enhance-maven-plugin</artifactId>
-               <version>${hibernate.version}</version>
-               <executions>
-                   <execution>
-                    <configuration>
-                        <enableLazyInitialization>true</enableLazyInitialization>
-                    </configuration>
-                       <goals>
-                           <goal>enhance</goal>
-                       </goals>
-                   </execution>
-               </executions>
-           </plugin>
 		</plugins>
 	</build>
 

--- a/siga-ex/pom.xml
+++ b/siga-ex/pom.xml
@@ -84,6 +84,24 @@
 				</plugin>
 	 		</plugins>
 	 	</pluginManagement>
+	 	<plugins>
+	 		<plugin>
+               <groupId>org.hibernate.orm.tooling</groupId>
+               <artifactId>hibernate-enhance-maven-plugin</artifactId>
+               <version>${hibernate.version}</version>
+               <executions>
+                   <execution>
+                    <configuration>
+                        <enableLazyInitialization>true</enableLazyInitialization>
+                    </configuration>
+                       <goals>
+                           <goal>enhance</goal>
+                       </goals>
+                   </execution>
+               </executions>
+           </plugin>
+		</plugins>
+	 	
 	</build>
 
 	<dependencies>


### PR DESCRIPTION
Mover plugin hibernate-enhance-maven-plugin do siga-doc para siga-ex, para que o hibernate enhancement atue somente no siga-ex. Em produção, o editar levava 3 a 4 segundos para carregar.