### PR TITLE
TRF2 - Permitir que cosignatário externo assine primeiro que o subscritor.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,21 +97,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-           	<plugin>
-               <groupId>org.hibernate.orm.tooling</groupId>
-               <artifactId>hibernate-enhance-maven-plugin</artifactId>
-               <version>${hibernate.version}</version>
-               <executions>
-                   <execution>
-                    <configuration>
-                        <enableLazyInitialization>true</enableLazyInitialization>
-                    </configuration>
-                       <goals>
-                           <goal>enhance</goal>
-                       </goals>
-                   </execution>
-               </executions>
-           </plugin>
 		</plugins>
 	</build>
 

--- a/siga-ex/pom.xml
+++ b/siga-ex/pom.xml
@@ -84,6 +84,24 @@
 				</plugin>
 	 		</plugins>
 	 	</pluginManagement>
+	 	<plugins>
+	 		<plugin>
+               <groupId>org.hibernate.orm.tooling</groupId>
+               <artifactId>hibernate-enhance-maven-plugin</artifactId>
+               <version>${hibernate.version}</version>
+               <executions>
+                   <execution>
+                    <configuration>
+                        <enableLazyInitialization>true</enableLazyInitialization>
+                    </configuration>
+                       <goals>
+                           <goal>enhance</goal>
+                       </goals>
+                   </execution>
+               </executions>
+           </plugin>
+		</plugins>
+	 	
 	</build>
 
 	<dependencies>

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -1247,7 +1247,7 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 		
 		return (mob.doc().getSubscritor().equivale(titular)
 				|| (mob.doc().isExterno() && mob.doc().getCadastrante().equivale(titular))
-				|| (mob.doc().isCossignatario(titular) && mob.doc().isPendenteDeAssinatura() && mob.doc().isAssinadoPeloSubscritorComTokenOuSenha())
+				|| (mob.doc().isCossignatario(titular) && mob.doc().isPendenteDeAssinatura() && (mob.doc().isAssinadoPeloSubscritorComTokenOuSenha() || titular.isUsuarioExterno()))
 				|| podeMovimentar(titular, lotaTitular, mob))
 				&& (mob.doc().isFinalizado() || podeFinalizar(titular, lotaTitular, mob))
 				&& !mob.doc().isCancelado()

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -446,11 +446,13 @@ public class ExMarcadorBL {
 					continue;
 				else if (mob.getDoc().isAssinadoPeloSubscritorComTokenOuSenha())
 					acrescentarMarca(CpMarcador.MARCADOR_COMO_SUBSCRITOR, mov.getDtIniMov(), mov.getSubscritor(), null);
-				else
+				else {
 					if (!(Boolean.valueOf(SigaBaseProperties.getString("siga.mesa.naoRevisarTemporarios")) 
 								&& !mob.getDoc().isFinalizado())) 
 						acrescentarMarca(CpMarcador.MARCADOR_REVISAR, mov.getDtIniMov(), mov.getSubscritor(), null);
-
+					if (mov.getSubscritor().isUsuarioExterno())
+						acrescentarMarca(CpMarcador.MARCADOR_COMO_SUBSCRITOR, mov.getDtIniMov(), mov.getSubscritor(), null);						
+				}	
 			}
 		}
 	}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -450,7 +450,8 @@ public class ExMarcadorBL {
 					if (!(Boolean.valueOf(SigaBaseProperties.getString("siga.mesa.naoRevisarTemporarios")) 
 								&& !mob.getDoc().isFinalizado())) 
 						acrescentarMarca(CpMarcador.MARCADOR_REVISAR, mov.getDtIniMov(), mov.getSubscritor(), null);
-					if (mov.getSubscritor().isUsuarioExterno())
+					if (!(Boolean.valueOf(SigaBaseProperties.getString("siga.mesa.naoRevisarTemporarios")) 
+							&& !mob.getDoc().isFinalizado()) && mov.getSubscritor().isUsuarioExterno())
 						acrescentarMarca(CpMarcador.MARCADOR_COMO_SUBSCRITOR, mov.getDtIniMov(), mov.getSubscritor(), null);						
 				}	
 			}


### PR DESCRIPTION
Permitir que cosignatário externo assine primeiro que o subscritor :

Problema : Hoje o sigaDoc exige que o subscritor assine primeiro um documento para depois os cosignatários poderem assinar.

Necessidade do Negócio : No caso de empresas que tem vinculo com a administração e precisarão assinar documentos essas precisam assinar primeiro que o subscritor.

A solução de contorno sugerida apresenta 3 problemas que foi incluir o usuario externo como subscritor e o Presidente como cosignatário:

a) O nome do órgão no documento fica o nome do órgão externo.
b) Se esse documento for assinado pelo usuário externo que está como subscritor e o presidente não quiser assinar , o presidente não consegue torná-lo sem efeito.
c) A ordem da exibição dos assinantes no documento. O Presidente geralmente aparece primeiro. Nessa solução de contorno, isso não ocorre.

Discussão completa :  https://forumh.trf2.jus.br/viewtopic.php?f=2&t=7

Evidências de testes realizados : https://1drv.ms/w/s!AjeNIsMqze0XgoBre7dBu5rVbdRIkw?e=EfXnKz

