### PR TITLE
1245#Cadastro de Pessoa-limitação caracteres RG e validacao e-mail

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Texto.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Texto.java
@@ -253,4 +253,9 @@ public class Texto {
 		public static final String REGEX_CARACTERES_PERMITIDOS = "[a-zA-ZáâãéêíóôõúçÁÂÃÉÊÍÓÔÕÚÇ 0-9-/.]+";		
 	}
 	
+	public static class DpPessoa {
+		public static final String NOME_REGEX_CARACTERES_PERMITIDOS = "[a-zA-ZáâãäéêëíïóôõöúüçñÁÂÃÄÉÊËÍÏÓÔÕÖÚÜÇÑ'' ]+";
+		public static final String EMAIL_REGEX_PATTERN = "^[\\w-]+(\\.[\\w-]+)*@([\\w-]+\\.)+[a-zA-Z]{2,7}$";														 
+	}
+	
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/Excel.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/Excel.java
@@ -1049,7 +1049,7 @@ public class Excel {
 			return "Linha " + linha +": NOME com mais de 60 caracteres" + System.getProperty("line.separator");
 		}
 
-		if(nomePessoa != null && !nomePessoa.matches("[a-zA-ZáâãäéêëíïóôõöúüçñÁÂÃÄÉÊËÍÏÓÔÕÖÚÜÇÑ'' ]+")) {
+		if(nomePessoa != null && !nomePessoa.matches(Texto.DpPessoa.NOME_REGEX_CARACTERES_PERMITIDOS)) {
 			return "Linha " + linha +": NOME com caracteres não permitidos" + System.getProperty("line.separator");
 		}
 		return "";

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
@@ -81,7 +81,8 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ " and (pes.id <> :id or :id = 0)"
 				+ " and (:cargo = null or :cargo = 0L or pes.cargo.idCargo = :cargo) "
 		      	+ " and (:funcao = null or :funcao = 0L or pes.funcaoConfianca.idFuncao = :funcao) "
-		      	+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%')) ) " 
+		      	+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%')) ) "
+		      	+ " and (:identidade = null or (upper(pes.identidade) like upper('%' || :identidade || '%')) ) "
 				+ "	and (:situacaoFuncionalPessoa = null or pes.situacaoFuncionalPessoa = :situacaoFuncionalPessoa)"
 				+ "   	and pes.dataFimPessoa = null"
 				+ "   	order by pes.nomePessoa"),
@@ -121,6 +122,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ "  	and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or pes.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"
 				+ " and (:cpf = null or :cpf = 0L or pes.cpfPessoa = :cpf) "
 				+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%')) ) "
+				+ " and (:identidade = null or (upper(pes.identidade) like upper('%' || :identidade || '%')) ) "
 				+ "	and (:lotacao = null or :lotacao = 0L or pes.lotacao.idLotacao = :lotacao)"
 				+ " and (:cargo = null or :cargo = 0L or pes.cargo.idCargo = :cargo) "
 		      	+ " and (:funcao = null or :funcao = 0L or pes.funcaoConfianca.idFuncao = :funcao) "
@@ -138,6 +140,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ " and (:cargo = null or :cargo = 0L or pes.cargo.idCargo = :cargo) "
 				+ " and (:funcao = null or :funcao = 0L or pes.funcaoConfianca.idFuncao = :funcao) "
 				+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%')) ) " 
+				+ " and (:identidade = null or (upper(pes.identidade) like upper('%' || :identidade || '%')) ) "
 				+ "	group by pes.idPessoaIni"
 				+ ", pes.idPessoa having pes.idPessoa = (select max(a.idPessoa) from DpPessoa a where a.idPessoaIni = pes.idPessoaIni)"
 				+ ") order by pes.nomePessoaAI"),
@@ -155,6 +158,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ " and (:cargo = null or :cargo = 0L or pes.cargo.idCargo = :cargo) "
 				+ " and (:funcao = null or :funcao = 0L or pes.funcaoConfianca.idFuncao = :funcao) "
 				+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%'))) "
+				+ " and (:identidade = null or (upper(pes.identidade) like upper('%' || :identidade || '%'))) "
 				+ "	group by pes.idPessoaIni) order by pes.nomePessoaAI"),
 		@NamedQuery(name = "consultarQuantidadeDpPessoaInclusiveFechadas", query = "select count(distinct pes.idPessoaIni)"
 				+ "		from DpPessoa pes"
@@ -163,6 +167,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ " and (:cpf = null or :cpf = 0L or pes.cpfPessoa like '%' || :cpf || '%') "
 				+ "  			and (:lotacao = null or :lotacao = 0L or pes.lotacao.idLotacao = :lotacao)"
 				+ " and (:email = null or (upper(pes.emailPessoa) like upper('%' || :email || '%')) ) "
+				+ " and (:identidade = null or (upper(pes.identidade) like upper('%' || :identidade || '%')) ) "
 				+ " and (:cargo = null or :cargo = 0L or pes.cargo.idCargo = :cargo) "
 	      		+ " and (:funcao = null or :funcao = 0L or pes.funcaoConfianca.idFuncao = :funcao) "
 	      		+ " "

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1325,12 +1325,13 @@ public class CpDao extends ModeloDao {
 			}
 
 			query.setParameter("nome", flt.getNome().toUpperCase().replace(' ', '%'));
+			query.setParameter("identidade", flt.getIdentidade());
 
 			if(flt.getEmail() != null) {
 				query.setParameter("email", flt.getEmail().toUpperCase().replace(' ', '%'));
 			} else {
 				query.setParameter("email", null);
-			}
+			}						
 
 			if (!flt.isBuscarFechadas())
 				query.setParameter("situacaoFuncionalPessoa", flt.getSituacaoFuncionalPessoa());
@@ -1376,6 +1377,7 @@ public class CpDao extends ModeloDao {
 			query = em().createNamedQuery("consultarPessoaComOrgaoFuncaoCargo");
 
 			query.setParameter("nome", pes.getNomePessoa().toUpperCase().replace(' ', '%'));
+			query.setParameter("identidade", pes.getIdentidade());
 
 			if (pes.getEmailPessoa() != null) {
 				query.setParameter("email", pes.getEmailPessoa().toUpperCase().replace(' ', '%'));
@@ -1444,6 +1446,7 @@ public class CpDao extends ModeloDao {
 				query = em().createNamedQuery("consultarQuantidadeDpPessoaInclusiveFechadas");
 
 			query.setParameter("nome", flt.getNome().toUpperCase().replace(' ', '%'));
+			query.setParameter("identidade", flt.getIdentidade());
 
 			if (!flt.isBuscarFechadas())
 				query.setParameter("situacaoFuncionalPessoa", flt.getSituacaoFuncionalPessoa());

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/DpPessoaDaoFiltro.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/DpPessoaDaoFiltro.java
@@ -35,6 +35,7 @@ public class DpPessoaDaoFiltro extends DaoFiltroSelecionavel {
 	private Long cpf;
 	private Long id;
 	private String email;
+	private String identidade;
 	
 	
 	private boolean buscarFechadas;
@@ -78,6 +79,15 @@ public class DpPessoaDaoFiltro extends DaoFiltroSelecionavel {
 	public void setEmail(final String email) {
 		this.email = email;
 	}
+	
+	public String getIdentidade() {
+		return identidade;
+	}
+	
+	public void setIdentidade(String identidade) {
+		this.identidade = identidade;
+	}
+	
 	public DpLotacao getLotacao() {
 		return lotacao;
 	}	

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
@@ -102,9 +102,14 @@
 		if(campo.value != "") {
 			var RegExp = /\b[\w]+@[\w-]+\.[\w]+/;
 	
-			if (campo.value.search(RegExp) == -1) {
-					alert("E-mail inválido!");
+			if (campo.value.search(RegExp) == -1) {					
+					mensagemAlerta("E-mail inválido!");
+					document.getElementById('email').focus();
 					return false;
+			} else if (campo.value.search(',') > 0) {
+				mensagemAlerta("E-mail inválido! Não pode conter vírgula ( , )");
+				document.getElementById('email').focus();
+				return false;				
 			}
 			return true;
 		} else {
@@ -295,7 +300,7 @@
 						<div class="col-md-4">
 							<div class="form-group">
 								<label for="nmPessoa">RG (Incluindo dígito)</label>
-								<input type="text" id="identidade" name="identidade" value="${identidade}" maxlength="60" class="form-control"/>
+								<input type="text" id="identidade" name="identidade" value="${identidade}" maxlength="20" class="form-control"/>
 							</div>
 						</div>
 						<div class="col-md-2">

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/lista.jsp
@@ -149,7 +149,13 @@
 							<label for="nome">E-mail</label>
 							<input type="text" id="emailPesquisa" name="emailPesquisa" value="${emailPesquisa}" maxlength="100" class="form-control">
 						</div>					
-					</div>								
+					</div>	
+					<div class="col-md-2">
+						<div class="form-group">
+							<label for="nmPessoa">RG (Incluindo dígito)</label>
+							<input type="text" id="identidadePesquisa" name="identidadePesquisa" value="${identidadePesquisa}" maxlength="20" class="form-control"/>
+						</div>
+					</div>							
 				</div>
 				<div class="row">
 					<div class="col-sm-12">


### PR DESCRIPTION
Efetuados os seguintes ajustes para o cadastro de pessoa:

- RG limitado a 20 caracteres
- RG adicionado como filtro de pesquisa 
- E-mail com validação para não aceitar vírgula ( , ) e validação no servidor para não aceitar e-mail considerado inválido.