### PR TITLE
GOVSP1323* - Consulta a unidade pai retornando null caso consulta não retorne nada

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/Excel.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/Excel.java
@@ -312,7 +312,8 @@ public class Excel {
 					if(lo!=null) {
 						lot.setLotacaoPai(lo);
 					} else {
-						problemas += "Linha " + linha +": SIGLA de LOTAÇÃO PAI inválida" + System.getProperty("line.separator");
+						problemas += "Linha " + linha +": SIGLA de LOTAÇÃO PAI não encontrada, se você deseja informar " 
+								+ lotacaopaisigla + " como unidade pai, é necessário cadastrá-lo antes de importar essa planilha" + System.getProperty("line.separator");
 					}
 				}
 				

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -2154,8 +2154,10 @@ public class CpDao extends ModeloDao {
 		whereList.add(cb().equal(c.get("orgaoUsuario"), orgaoUsuario));
 		whereList.add(cb().equal(c.get("siglaLotacao"), siglaLotacao));
 		q.where(whereList.toArray(new Predicate[2]));
-		q.select(c);
-		return em().createQuery(q).getSingleResult();
+		q.select(c);		
+		return em().createQuery(q).getResultList().stream()
+				.findFirst()
+				.orElse(null);
 	}
 	
 	public CpOrgaoUsuario consultarOrgaoUsuarioPorId(Long idOrgaoUsu) {


### PR DESCRIPTION
A função CpDao.consultarLotacaoPorOrgaoEId(orgao, siglaLotacao) é utilizada na carga de unidade (via importação de planilha Excel) para checar se a unidade informada como unidade pai já está cadastrada no banco de dados, porém, é utilizado como retorno a função getSingleResult() e a mesma lança uma exception quando a consulta não retorna nada, foi ajustado para retornar null nesses casos.