### PR TITLE
GOVSP1315* - Alteração nas validações para movimentação de anotar em doc…

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/RegraNegocioException.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/RegraNegocioException.java
@@ -1,0 +1,11 @@
+package br.gov.jfrj.siga.base;
+
+public class RegraNegocioException extends RuntimeException {
+	
+	private static final long serialVersionUID = 1L;
+
+	public RegraNegocioException(String mensagem) {
+		super(mensagem);
+	}
+
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -91,6 +91,7 @@ import br.gov.jfrj.siga.base.Data;
 import br.gov.jfrj.siga.base.GeraMessageDigest;
 import br.gov.jfrj.siga.base.HttpRequestUtils;
 import br.gov.jfrj.siga.base.Par;
+import br.gov.jfrj.siga.base.RegraNegocioException;
 import br.gov.jfrj.siga.base.SigaBaseProperties;
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.Texto;
@@ -4808,10 +4809,14 @@ public class ExBL extends CpBL {
 		if (descrMov == null) {
 			if (responsavel == null && lotaResponsavel == null)
 				if (dtMov == null)
-					throw new AplicacaoException("não foram informados dados para a anotação");
+					throw new RegraNegocioException("Não foram informados dados para a anotação");
+		}
+		
+		if (descrMov.length() > 500) {
+			throw new RegraNegocioException("Descrição com mais de 500 caracteres");
 		}
 
-		try {
+		try {						
 			// criarWorkflow(cadastrante, lotaCadastrante, doc, "Exoneracao");
 			iniciarAlteracao();
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -61,8 +61,11 @@ import br.gov.jfrj.siga.base.Contexto;
 import br.gov.jfrj.siga.base.Correio;
 import br.gov.jfrj.siga.base.Data;
 import br.gov.jfrj.siga.base.DateUtils;
+import br.gov.jfrj.siga.base.RegraNegocioException;
 import br.gov.jfrj.siga.base.SigaBaseProperties;
 import br.gov.jfrj.siga.base.SigaMessages;
+import br.gov.jfrj.siga.base.SigaModal;
+import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
 import br.gov.jfrj.siga.cp.CpToken;
 import br.gov.jfrj.siga.cp.model.CpOrgaoSelecao;
@@ -2067,7 +2070,7 @@ public class ExMovimentacaoController extends ExController {
 	}
 
 	@Get("/app/expediente/mov/anotar")
-	public void aAnotar(final String sigla) {
+	public void aAnotar(final String sigla, final String descrMov) {
 		final BuscaDocumentoBuilder documentoBuilder = BuscaDocumentoBuilder
 				.novaInstancia().setSigla(sigla);
 
@@ -2084,8 +2087,13 @@ public class ExMovimentacaoController extends ExController {
 				.podeFazerAnotacao(getTitular(), getLotaTitular(),
 						documentoBuilder.getMob())) {
 			throw new AplicacaoException("Não é possível fazer anotação");
+		}	
+		
+		String descricaoMov = movimentacaoBuilder.getDescrMov();
+		if (descricaoMov == null) {
+			descricaoMov = descrMov;
 		}
-
+				
 		result.include("sigla", sigla);
 		result.include("dtMovString", movimentacaoBuilder.getDtMovString());
 		result.include("mob", documentoBuilder.getMob());
@@ -2094,7 +2102,7 @@ public class ExMovimentacaoController extends ExController {
 		result.include("substituicao", movimentacaoBuilder.isSubstituicao());
 		result.include("nmFuncaoSubscritor",
 				movimentacaoBuilder.getNmFuncaoSubscritor());
-		result.include("descrMov", movimentacaoBuilder.getDescrMov());
+		result.include("descrMov", descricaoMov);
 		result.include("tipoResponsavel",
 				this.processarTipoResponsavel(documentoBuilder.getMob()));
 		result.include("obsOrgao", movimentacaoBuilder.getObsOrgao());
@@ -2109,6 +2117,11 @@ public class ExMovimentacaoController extends ExController {
 			final String nmFuncaoSubscritor, final String descrMov,
 			final String obsOrgao, final String[] campos) {
 		this.setPostback(postback);
+		
+		String descricaoMov = descrMov;
+		if (descricaoMov != null) {
+			descricaoMov = Texto.removerEspacosExtra(descricaoMov);
+		}
 
 		final ExMovimentacaoBuilder builder = ExMovimentacaoBuilder
 				.novaInstancia();
@@ -2116,7 +2129,7 @@ public class ExMovimentacaoController extends ExController {
 		builder.setDtMovString(dtMovString).setSubscritorSel(subscritorSel)
 				.setSubstituicao(substituicao).setTitularSel(titularSel)
 				.setNmFuncaoSubscritor(nmFuncaoSubscritor)
-				.setDescrMov(descrMov).setObsOrgao(obsOrgao);
+				.setDescrMov(descricaoMov).setObsOrgao(obsOrgao);
 
 		final ExMovimentacao mov = builder.construir(dao());
 
@@ -2131,16 +2144,21 @@ public class ExMovimentacaoController extends ExController {
 						documentoBuilder.getMob())) {
 			throw new AplicacaoException("Não é possível fazer anotação");
 		}
-
-		Ex.getInstance()
-				.getBL()
-				.anotar(getCadastrante(), getLotaTitular(),
-						documentoBuilder.getMob(), mov.getDtMov(),
-						mov.getLotaResp(), mov.getResp(), mov.getSubscritor(),
-						mov.getTitular(), mov.getDescrMov(),
-						mov.getNmFuncaoSubscritor());
-
-		result.redirectTo("/app/expediente/doc/exibir?sigla=" + sigla);
+		
+		try {
+			Ex.getInstance()
+			.getBL()
+			.anotar(getCadastrante(), getLotaTitular(),
+					documentoBuilder.getMob(), mov.getDtMov(),
+					mov.getLotaResp(), mov.getResp(), mov.getSubscritor(),
+					mov.getTitular(), mov.getDescrMov(),
+					mov.getNmFuncaoSubscritor());		
+			
+			result.redirectTo("/app/expediente/doc/exibir?sigla=" + sigla);			
+		} catch (RegraNegocioException e) {
+			result.include(SigaModal.ALERTA, SigaModal.mensagem(e.getMessage()));
+			result.forwardTo(this).aAnotar(sigla, descrMov);			
+		}					
 	}
 
 	@Get("/app/expediente/mov/anotar_lote")

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
@@ -82,7 +82,7 @@
 				</c:if>
 			</c:forEach>
 			<c:if test="${temmov}">
-					<table class="table table-sm table-hover table-striped mov mt-2">
+					<table class="table table-sm table-hover table-striped  table-responsive mov mt-2">
 						<thead class="${thead_color} align-middle text-center">
 							<tr>
 								<th style="width: 5%" class="text-left" rowspan="2">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAnotar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAnotar.jsp
@@ -38,7 +38,7 @@
 			}
 			function corrige() {
 				if (tamanho2() < 0) {
-					alert('Descrição com mais de 500 caracteres');
+					sigaModal.alerta('Descrição com mais de 500 caracteres');
 					nota = new String();
 					nota = document.getElementById("descrMov").value;
 					document.getElementById("descrMov").value = nota.substring(
@@ -145,9 +145,8 @@
 						<div class="col-sm">
 							<div class="form-group">
 								<label for="descrMov">Nota</label>
-								<textarea class="form-control" name="descrMov" value="${descrMov}" cols="60"
-									rows="5" onkeydown="corrige();tamanho();" maxlength="500"
-									onblur="tamanho();" onclick="tamanho();"></textarea>
+								<textarea class="form-control" name="descrMov" cols="60" rows="5" onkeydown="corrige();tamanho();" maxlength="500"
+									onblur="tamanho();" onclick="tamanho();">${descrMov}</textarea>
 								<small class="form-text text-muted" id="Qtd">Restam&nbsp;500&nbsp;caracteres</small>
 							</div>
 						</div>
@@ -174,3 +173,8 @@
 		</div>
 	</div>
 </siga:pagina>
+<script>
+	$(function() {
+		$('[name=descrMov]').focus();
+	});
+</script>


### PR DESCRIPTION
- Efetuado ajustes para que as validações sejam retornadas na própria tela ao invés de serem exibidas na página de erro geral
- Acrescentado validação no servidor para checar se texto não possui mais de 500 caracteres
- Adicionado a classe "table-responsive" do bootstrap na tabela da página de histórico do documento, para evitar de quebrar o layout caso a tabela tenha que ocupar um espaço muito grande em tela.