### PR TITLE
TRF2: Correção na query de busca de ExEmailNotificacao

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -875,7 +875,7 @@ public class ExDao extends CpDao {
 		} else {
 			query = em().createNamedQuery("consultarEmailporLotacao");
 
-			query.setParameter("idLotacaoIni", lot);
+			query.setParameter("idLotacaoIni", lot.getLotacaoInicial());
 		}
 
 		return query.getResultList();


### PR DESCRIPTION
 Alteração para getLotacaoIni na passagem de parâmetros da query consultarEmailporPessoa em ExDao ao buscar as ocorrências de ExEmailNotificacao. 