### PR TITLE
GOVSP1104* - juntada-gerando termo de desentranhamento e numeracao das p…

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
@@ -1533,8 +1533,7 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 		}				
 					
 		// Numerar as paginas
-		if (isNumeracaoUnicaAutomatica()) {
-
+		if (isNumeracaoUnicaAutomatica() || (SigaMessages.isSigaSP() && mobilPrincipalPossuiJuntadaOuDesentranhamento(mob, listaFinal))) {				
 			if (mob.getDnmNumPrimeiraPagina() == null) {
 				if (mob.isVolume() && mob.getNumSequencia() > 1) {
 					List<ExArquivoNumerado> listVolumeAnterior = mob.doc()
@@ -1607,6 +1606,32 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 	
 	private void limparOrdenacaoDosDocumentos() {
 		this.setOrdenacaoDoc(null);
+	}
+	
+	public boolean mobilPrincipalPossuiJuntadaOuDesentranhamento(ExMobil mobilPrincipal, List<ExArquivoNumerado> arquivosNumerados) {
+		if (arquivosNumerados != null) {
+			ExMovimentacao movimentacao;
+			long[] tpIdMovs = { ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA,
+					ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA_EXTERNO,
+					ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA };			
+			
+			for (ExArquivoNumerado arquivoNumerado : arquivosNumerados) {				
+				if (arquivoNumerado.getMobil().getId() != mobilPrincipal.getId()) {
+					
+					movimentacao = arquivoNumerado.getMobil().getMovsNaoCanceladas(tpIdMovs)
+							.stream()
+							.filter(m -> m.getExMobilRef().getId() == mobilPrincipal.getId())
+							.findAny()
+							.orElse(null);
+												
+					if (movimentacao != null) {
+						return true;
+					}
+				}										
+			}			
+		}		
+		
+		return false;
 	}
 	
 	public void removerDesentranhamentosQueNaoFazemParteDoDossie(

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -2206,6 +2206,26 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return set;
 	}
 	
+	public Set<ExMovimentacao> getMovsNaoCanceladas(long[] idTpMovs) {
+		Set<ExMovimentacao> set = new TreeSet<ExMovimentacao>();
+
+		if (getExMovimentacaoSet() == null)
+			return set;
+				
+		for (ExMovimentacao m : getExMovimentacaoSet()) {
+			for (long idTpMov : idTpMovs) {
+				if (m.getExMovimentacaoCanceladora() != null)
+					continue;
+				if (m.getExTipoMovimentacao().getIdTpMov() != idTpMov)
+					continue;
+			
+				set.add(m);
+			}
+		}			
+		
+		return set;
+	}
+	
 	public static void adicionarIndicativoDeMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso() {
 		isMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso = true;
 	}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -2355,8 +2355,7 @@ public class ExBL extends CpBL {
 				final ExMobil mobPai = mov.getExMovimentacaoRef().getExMobilRef();
 
 				if (mobPai.isArquivado())
-					throw new AplicacaoException(
-							"não é possível fazer o desentranhamento porque o documento ao qual este está juntado encontra-se arquivado.");
+					throw new RegraNegocioException("Não é possível fazer o desentranhamento porque o documento ao qual este está juntado encontra-se arquivado.");
 
 				ExMovimentacao ultMovDoc = null;
 				if (mobPai.isApensado()) {
@@ -2370,7 +2369,7 @@ public class ExBL extends CpBL {
 				mov.setLotaResp(ultMovDoc.getLotaResp());
 				mov.setResp(ultMovDoc.getResp());
 
-				if (mobPai.getMobilPrincipal().isNumeracaoUnicaAutomatica()) {
+				if (mobPai.getMobilPrincipal().isNumeracaoUnicaAutomatica() || SigaMessages.isSigaSP()) {
 					List<ExArquivoNumerado> ans = mov.getExMobil().filtrarArquivosNumerados(null, true);
 					armazenarCertidaoDeDesentranhamento(mov, mobPai.getMobilPrincipal(), ans, mov.obterDescrMovComPontoFinal());
 				}
@@ -2383,6 +2382,9 @@ public class ExBL extends CpBL {
 
 			gravarMovimentacao(mov);
 			concluirAlteracaoComRecalculoAcesso(mov.getExMobil());
+		} catch (RegraNegocioException e) {
+			cancelarAlteracao();
+			throw new RegraNegocioException(e.getMessage());
 		} catch (final Exception e) {
 			cancelarAlteracao();
 			throw new AplicacaoException("Erro ao cancelar juntada.", 0, e);
@@ -4032,7 +4034,6 @@ public class ExBL extends CpBL {
 					null, null);
 
 			mov.setExMobilRef(mobPai);
-			mov.getExDocumento().setExMobilPai(mobPai);
 
 			if (idDocEscolha.equals("1")) {
 				mov.setDescrMov("Juntado ao documento " + mov.getExMobilRef().getCodigo().toString());

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/cancelarJuntada.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/cancelarJuntada.jsp
@@ -74,8 +74,8 @@
 					</div>
 					<div class="row">
 						<div class="col-sm">
-							<input type="submit" value="Ok" class="btn btn-primary" />
-							<input type="button" value=<fmt:message key="botao.cancela"/> onclick="javascript:history.back();" class="btn btn-cancel ml-2" />
+							<input type="submit" value="Ok" class="btn btn-primary" />							
+							<a href="${linkTo[ExDocumentoController].exibe()}?sigla=${sigla}" class="btn btn-cancel ml-2"><fmt:message key="botao.cancela"/></a>														 												
 						</div>
 					</div>
 				</form>


### PR DESCRIPTION
Em SP, temos por regra que todo desentranhamento tem que gerar a certidão de desentranhamento, porém, quando o documento tem sua espécie documental do tipo expediente, a certidão não é gerada e a numeração das páginas não é exibida ao visualizar o documento completo. Anteriormente, por entender equivocadamente que a nível de regra de negócio a ação de "Incluir Documento" e "Juntar" eram iguais, eu havia vinculado o idMobilPai no documento, porém acarretou em outro problema. 
Nessa nova implementação, foi removido  a gravação do vínculo com idMobilPai  e foi levado em consideração para calcular a numeração das páginas o fato de o mobil filho ter movimentações de juntada ou desentranhamento.