### PR TITLE
GOVSP - Estabiliza obtenção do DpPessoa

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
@@ -54,9 +54,9 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 		@NamedQuery(name = "consultarPorIdInicialDpPessoa", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoaIni and pes.dataFimPessoa = null"),
 		@NamedQuery(name = "consultarPorSiglaDpPessoa", query = "select pes from DpPessoa pes where pes.matricula = :matricula and pes.sesbPessoa = :sesb and pes.dataFimPessoa = null"),
 		@NamedQuery(name = "consultarPessoaAtualPelaInicial", query = "from DpPessoa pes "
-				+ "		where pes.dataInicioPessoa = "
-				+ "		(select max(p.dataInicioPessoa) from DpPessoa p where p.idPessoaIni = :idPessoaIni)"
-				+ "		 and pes.idPessoaIni = :idPessoaIni"),
+				+ "		where pes.idPessoaIni = :idPessoaIni "
+				+ "		and pes.dataInicioPessoa = (select max(p.dataInicioPessoa) from DpPessoa p where p.idPessoaIni = :idPessoaIni)"
+				+ "		order by idPessoa desc"),
 		@NamedQuery(name = "consultarPorIdInicialDpPessoaInclusiveFechadas", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoaIni"),
 		@NamedQuery(name = "consultarPorCpf", query = "from DpPessoa pes where pes.cpfPessoa = :cpfPessoa and pes.dataFimPessoa = null"),	
 		@NamedQuery(name = "consultarPorCpfAtivoInativo", query = "from DpPessoa pes where pes.cpfPessoa = :cpfPessoa and pes.idPessoa in"

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -2406,6 +2406,7 @@ public class CpDao extends ModeloDao {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public DpPessoa obterPessoaAtual(final DpPessoa pessoa) {
 		try {
 
@@ -2413,8 +2414,18 @@ public class CpDao extends ModeloDao {
 			qry.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
 			qry.setHint("org.hibernate.cacheable", true); 
 			qry.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CONFIGURACAO);
-			final DpPessoa pes = (DpPessoa) qry.getSingleResult();
-			return pes;
+			
+			
+			//final DpPessoa pes = (DpPessoa) qry.getSingleResult();
+			//return pes;
+			
+			List<DpPessoa> result = qry.getResultList();			
+			if (result == null || result.size() == 0)
+				return null;
+			return result.get(0);
+			
+			
+			
 		} catch (final IllegalArgumentException e) {
 			throw e;
 


### PR DESCRIPTION
Hoje, por falha sistêmica pode ocorrer a inclusão de mais de um registro no mesmo segundo, ocasionando erro no hibernate pois query está single result. 
Ordenado resultado pelo o maior ID e retorna o primeiro da lista, que é exceção. Regra é ter apenas um registo com mesmo ID inicial no mesmo segundo.

Access Plan antes:
![image](https://user-images.githubusercontent.com/20362170/90167099-99d2e680-dd71-11ea-9213-17e331afbe76.png)

Access Plan depois:
![image](https://user-images.githubusercontent.com/20362170/90167150-abb48980-dd71-11ea-8197-ca034a07f4a8.png)
