### PR TITLE
GOVSP1450 - Alterações visuais no cadastro de espécies, tipos de despacho e juntada

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6256,20 +6256,20 @@ public class ExBL extends CpBL {
 
 	public void gravarForma(ExFormaDocumento forma) throws AplicacaoException {
 		if (forma.getDescrFormaDoc() == null || forma.getDescrFormaDoc().isEmpty())
-			throw new AplicacaoException("não é possível salvar um tipo sem informar a descrição.");
+			throw new RegraNegocioException("Não é possível salvar um tipo sem informar a descrição.");
 		if (forma.getExTipoFormaDoc() == null)
-			throw new AplicacaoException("não é possível salvar um tipo sem informar se é processo ou expediente.");
+			throw new RegraNegocioException("Não é possível salvar um tipo sem informar se é processo ou expediente.");
 		if (!forma.isSiglaValida())
-			throw new AplicacaoException("Sigla inválida. A sigla deve ser formada por 3 letras.");
+			throw new RegraNegocioException("Sigla inválida. A sigla deve ser formada por 3 letras.");
 
 		if (Prop.isGovSP()
 				&& forma.getExTipoDocumentoSet().isEmpty())
-			throw new AplicacaoException("Selecione uma origem.");
+			throw new RegraNegocioException("Selecione uma origem.");
 
 		ExFormaDocumento formaConsulta = dao().consultarPorSigla(forma);
 		if ((forma.getIdFormaDoc() == null && formaConsulta != null) || (forma.getIdFormaDoc() != null
 				&& formaConsulta != null && !formaConsulta.getIdFormaDoc().equals(forma.getIdFormaDoc())))
-			throw new AplicacaoException("Esta sigla já está sendo utilizada.");
+			throw new RegraNegocioException("Esta sigla já está sendo utilizada.");
 
 		try {
 			ExDao.iniciarTransacao();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
@@ -14,6 +14,8 @@ import br.com.caelum.vraptor.Get;
 import br.com.caelum.vraptor.Post;
 import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.view.Results;
+import br.gov.jfrj.siga.base.RegraNegocioException;
+import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.ex.ExFormaDocumento;
 import br.gov.jfrj.siga.ex.ExTipoDocumento;
 import br.gov.jfrj.siga.ex.ExTipoFormaDoc;
@@ -51,26 +53,33 @@ public class ExFormaDocumentoController extends ExController {
 		}
 
 		result.include("itens", itens);
+		result.include("ordenadoPor", ordenar == null ? "descricao" : ordenar);
 	}
 
 	@Get("app/forma/editar")
-	public void editarForma(final Long id) {
+	public void editarForma(final Long id, String descricao, String sigla, Long idTipoFormaDoc, boolean origemExterno,
+			boolean origemInternoImportado, boolean origemInternoProduzido, boolean origemInternoCapturado, 
+			Integer isComposto, boolean origemExternoCapturado) {
+		
 		assertAcesso(ACESSO_SIGA_DOC_MOD);
 
 		final ExFormaDocumento forma = id != null ? recuperarForma(id) : new ExFormaDocumento();
+		
+		if (forma.getIdFormaDoc() != null) {
+			descricao = forma.getDescrFormaDoc();
+			sigla = forma.getSigla();
+			isComposto = forma.getIsComposto();
+			
+			if (forma.getExTipoFormaDoc() != null) {
+				idTipoFormaDoc = forma.getExTipoFormaDoc().getIdTipoFormaDoc();
+			}			
+		}
 
 		if (getPostback() == null) {
-			result.include("descricao", forma.getDescrFormaDoc());
-			result.include("sigla", forma.getSigla());
-			if (forma.getExTipoFormaDoc() != null) {
-				result.include("idTipoFormaDoc", forma.getExTipoFormaDoc().getIdTipoFormaDoc());
-			}
-
-			boolean origemExterno = false;
-			boolean origemInternoImportado = false;
-			boolean origemInternoProduzido = false;
-			boolean origemInternoCapturado = false;
-			boolean origemExternoCapturado = false;
+			result.include("descricao", descricao);
+			result.include("sigla", sigla);			
+			result.include("idTipoFormaDoc", idTipoFormaDoc);	
+			result.include("isComposto", isComposto);
 
 			if (forma.getExTipoDocumentoSet() != null) {
 				for (ExTipoDocumento origem : forma.getExTipoDocumentoSet()) {
@@ -91,13 +100,12 @@ public class ExFormaDocumentoController extends ExController {
 					}
 				}
 			}
-
-			result.include("isComposto", forma.getIsComposto());
+			
 			result.include("origemExterno", origemExterno);
 			result.include("origemInternoImportado", origemInternoImportado);
 			result.include("origemInternoProduzido", origemInternoProduzido);
 			result.include("origemInternoCapturado", origemInternoCapturado);
-			result.include("origemExternoCapturado", origemExternoCapturado);
+			result.include("origemExternoCapturado", origemExternoCapturado);			
 		}
 
 		result.include("id", id);
@@ -164,20 +172,27 @@ public class ExFormaDocumentoController extends ExController {
 			forma.getExTipoDocumentoSet().add(dao().consultar(ExTipoDocumento.TIPO_DOCUMENTO_EXTERNO_CAPTURADO, ExTipoDocumento.class, false));
 		}
 
-		Ex.getInstance().getBL().gravarForma(forma);
-
-		result.include("id", forma.getIdFormaDoc());
-		result.include("descricao", descricao);
-		result.include("sigla", sigla);
-		result.include("idTipoFormaDoc", idTipoFormaDoc);
-		result.include("isComposto", isComposto);
-		result.include("origemExterno", origemExterno);
-		result.include("origemInternoImportado", origemInternoImportado);
-		result.include("origemInternoProduzido", origemInternoProduzido);
-		result.include("origemInternoCapturado", origemInternoCapturado);
-		result.include("origemExternoCapturado", origemExternoCapturado);
-		
-		result.redirectTo("/app/forma/listar");
+		try {
+			Ex.getInstance().getBL().gravarForma(forma);
+			
+			result.include("id", forma.getIdFormaDoc());
+			result.include("descricao", descricao);
+			result.include("sigla", sigla);
+			result.include("idTipoFormaDoc", idTipoFormaDoc);
+			result.include("isComposto", isComposto);
+			result.include("origemExterno", origemExterno);
+			result.include("origemInternoImportado", origemInternoImportado);
+			result.include("origemInternoProduzido", origemInternoProduzido);
+			result.include("origemInternoCapturado", origemInternoCapturado);
+			result.include("origemExternoCapturado", origemExternoCapturado);
+			
+			result.redirectTo("/app/forma/listar");
+		} catch (RegraNegocioException e) {			
+			
+			result.include(SigaModal.ALERTA, SigaModal.mensagem(e.getMessage()));
+			result.forwardTo(this).editarForma(id, descricao, sigla, idTipoFormaDoc, origemExterno, origemInternoImportado,  origemInternoProduzido
+					, origemInternoCapturado, isComposto,  origemExternoCapturado);
+		}
 	}
 
 	private ExFormaDocumento recuperarForma(final Long id) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExTipoDespachoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExTipoDespachoController.java
@@ -31,6 +31,8 @@ import br.com.caelum.vraptor.Get;
 import br.com.caelum.vraptor.Post;
 import br.com.caelum.vraptor.Result;
 import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.base.RegraNegocioException;
+import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.dp.dao.CpDao;
 import br.gov.jfrj.siga.ex.ExTipoDespacho;
 import br.gov.jfrj.siga.vraptor.builder.ExTipoDespachoBuilder;
@@ -95,16 +97,24 @@ public class ExTipoDespachoController extends ExController {
 	@Post("app/despacho/tipodespacho/gravar")
 	public void gravar(final ExTipoDespacho exTipoDespacho) {
 		assertAcesso(CAMINHO_ACESSO);
+			
+		if (exTipoDespacho.getDescTpDespacho() == null) {
+			result.include(SigaModal.ALERTA, SigaModal.mensagem("Favor informar uma descrição."));
+			result.forwardTo(this).edita(exTipoDespacho.getIdTpDespacho());
+			return;
+		}
+		
 		final ExTipoDespachoBuilder builder = ExTipoDespachoBuilder.novaInstancia();
 		builder.setIdTpDespacho(exTipoDespacho.getIdTpDespacho());
 		builder.setDescTpDespacho(exTipoDespacho.getDescTpDespacho());
 		builder.setAtivo(exTipoDespacho.getFgAtivo());
-
+		
 		try {
 			dao().iniciarTransacao();
 			dao().gravar(builder.construir(dao()));
 			dao().commitTransacao();
 			result.redirectTo(this).lista();
+					
 		} catch (Exception e) {
 			dao().rollbackTransacao();
 			throw new AplicacaoException("Ocorreu um Erro durante a gravação", 0, e);

--- a/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/editarForma.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/editarForma.jsp
@@ -20,22 +20,20 @@
 					<div class="row">
 						<div class="col-md-4">
 							<div class="form-group">
-								<label for="descricao">Descrição</label> <input type="text"
-									value="${descricao}" name="descricao" class="form-control" />
-							</div>
-							
+								<label for="descricao">Descrição</label> 
+								<input type="text" id="descricao" value="${descricao}" name="descricao" class="form-control" />
+							</div>							
 						</div>
-						<div class="col-md-1">
+						<div class="col-lg-1 col-md-2">
 							<div class="form-group">
-								<label for="sigla">Sigla</label> <input type="text"
-									value="${sigla}" name="sigla" id="gravar_sigla"
-									class="form-control" /> <span id="mensagem"></span>
+								<label for="sigla">Sigla</label> 
+								<input type="text" id="sigla" value="${sigla}" name="sigla" id="gravar_sigla" class="form-control"/> <span id="mensagem"></span>
 							</div>
 						</div>
-						<div class="col-md-2">
+						<div class="col-md-3">
 							<div class="form-group">
-								<label for="idTipoFormaDoc">Tipo</label> <select
-									name="idTipoFormaDoc" value="${idTipoFormaDoc}"
+								<label for="tipoFormaDoc">Tipo</label> 
+								<select id="tipoFormaDoc" name="idTipoFormaDoc" value="${idTipoFormaDoc}"
 									class="form-control">
 									<c:forEach var="tipo" items="${listaTiposFormaDoc}">
 										<option value="${tipo.idTipoFormaDoc}"
@@ -54,37 +52,42 @@
 						</div>
 					</div>
 					<div class="row">
-						<div class="col-sm-6">
-							<div class="form-group">
-								<label for="idTipoFormaDoc">Origem</label><br />
-								<div class="form-check form-check-inline">
-									<input class="form-check-input ml-2" type="checkbox"
-										name="origemExterno" value="true"
-										${origemExterno ? 'checked' : ''} /> Externo &nbsp; <input
-										class="form-check-input ml-3" type="checkbox"
-										name="origemInternoProduzido" value="true"
-										${origemInternoProduzido ? 'checked' : ''} /> Interno
-									Produzido &nbsp; <input class="form-check-input ml-3"
-										type="checkbox" name="origemInternoImportado" value="true"
-										${origemInternoImportado ? 'checked' : ''} /> Interno
-									Importado <input class="form-check-input ml-3" type="checkbox"
-										name="origemInternoCapturado" value="true"
-										${origemInternoCapturado ? 'checked' : ''} /> Interno
-									Capturado <input class="form-check-input ml-3" type="checkbox"
-										name="origemExternoCapturado" value="true"
-										${origemExternoCapturado ? 'checked' : ''} /> Externo
-									Capturado
+						<div class="col-sm-12">
+							<h3 style="font-size: 1rem; margin-bottom: 3px; font-weight: normal;">Origem</h3>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-sm-12">
+							<div class="form-group">								
+								<div class="form-check  form-check-inline">
+									<input type="checkbox" id="origemExterno" class="form-check-input" name="origemExterno" value="true" ${origemExterno ? 'checked' : ''}/> 
+									<label for="origemExterno">Externo</label>
+								</div>								
+								<div class="form-check  form-check-inline">	
+									<input type="checkbox" id="origemInternoProduzido" class="form-check-input" name="origemInternoProduzido" value="true" ${origemInternoProduzido ? 'checked' : ''}/>
+									<label for="origemInternoProduzido">Interno Produzido</label>
+								</div>
+								<div class="form-check  form-check-inline">	
+									<input type="checkbox" id="origemInternoImportado" class="form-check-input" name="origemInternoImportado" value="true" ${origemInternoImportado ? 'checked' : ''}/>
+									<label for="origemInternoImportado">Interno Importado</label>
+								</div>
+								<div class="form-check  form-check-inline">	
+									<input type="checkbox" id="origemInternoCapturado" class="form-check-input" name="origemInternoCapturado" value="true" ${origemInternoCapturado ? 'checked' : ''}/> 
+									<label for="origemInternoCapturado">Interno Capturado</label>
+								</div>
+								<div class="form-check  form-check-inline">	 
+									<input type="checkbox" id="origemExternoCapturado" class="form-check-input" name="origemExternoCapturado" value="true" ${origemExternoCapturado ? 'checked' : ''} /> 
+									<label for="origemExternoCapturado">Externo Capturado</label>
 								</div>
 							</div>
 						</div>
 					</div>
 					<div class="row">
-						<div class="col-sm-3">
+						<div class="col-sm-8">
 							<div class="form-group">
 								<button type="submit" class="btn btn-primary">Ok</button>
-								<button type="submit" name="submit" class="btn btn-primary">Aplicar</button>
-								<button type="button" onclick="javascript:history.back();"
-									class="btn btn-primary">Cancela</button>
+								<button type="submit" name="submit" class="btn btn-primary">Aplicar</button>								
+								<a href="${linkTo[ExFormaDocumentoController].listarFormas()}?ordenar=descricao" class="btn btn-cancel">Cancela</a>
 							</div>
 						</div>
 					</div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/listarFormas.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/listarFormas.jsp
@@ -7,6 +7,13 @@
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
 
 <siga:pagina titulo="Lista de Espécies Documentais">
+
+<style>
+	#tableOrder tr td span.badge:nth-last-child(2) {
+		margin-bottom: 0!important;
+	}
+</style>
+		
 	<!-- main content -->
 	<div class="container-fluid">
 		<div class="card bg-light mb-3">
@@ -22,18 +29,17 @@
 					</div>
 				</div>
 				<div class="row">
-					<form id="listar" name="listar" method="GET" class="form100">
+					<form id="listar" name="listar" method="GET" class="form100">						
 						<div class="col-sm-4">
 							<div class="form-group">
 								<div class="form-check form-check-inline">
-									<input type="radio" id="order1" name="ordenar"
-										value="descricao" onclick="this.form.submit();"
-										class="form-check-input"><label
-										class="form-check-label" for="order1">Descri&ccedil;&atilde;o</label>
-										<input type="radio" id="order2" name="ordenar" value="sigla"
-										onclick="this.form.submit();" class="form-check-input ml-2"><label
-											class="form-check-label" for="order2">Sigla</label>
-								</div>
+									<input type="radio" id="ordenadoPorDescricao" name="ordenar" value="descricao" onclick="this.form.submit();"
+										class="form-check-input" ${ordenadoPor eq 'descricao' ? 'checked' : ''} />
+									<label class="form-check-label" for="ordenadoPorDescricao">Descri&ccedil;&atilde;o</label>
+									<input type="radio" id="ordenadoPorSigla" name="ordenar" value="sigla" onclick="this.form.submit();" 
+										class="form-check-input ml-2" ${ordenadoPor eq 'sigla' ? 'checked' : ''} />
+									<label class="form-check-label" for="ordenadoPorSigla">Sigla</label>
+								</div>								
 							</div>
 						</div>
 					</form>
@@ -46,7 +52,7 @@
 					</div>
 				</div>
 			</div>
-		</div>
+		</div>		
 		<div class="row">
 			<div class="col-sm">
 				<table id="tableOrder" class="table table-sm table-striped">
@@ -63,15 +69,57 @@
 						<c:set var="tamanho" value="0" />
 						<c:forEach var="forma" items="${itens}">
 							<tr class="${evenorodd}">
-								<td><a
-									href="${pageContext.request.contextPath}/app/forma/editar?id=${forma.idFormaDoc}">${forma.descrFormaDoc}</a>
+								<td>
+									<a href="${pageContext.request.contextPath}/app/forma/editar?id=${forma.idFormaDoc}">${forma.descrFormaDoc}</a>
 								</td>
 								<td>${forma.sigla}</td>
-								<td>${forma.exTipoFormaDoc.descricao}</td>
-								<td><c:forEach var="origem"
-										items="${forma.exTipoDocumentoSet}">
-											${origem.descricao}<br />
-									</c:forEach></td>
+								<td class="pt-2">
+									<span class="badge badge-${forma.exTipoFormaDoc.id eq 1 ? 'primary' : 'secondary'}">
+										${forma.exTipoFormaDoc.descricao}
+									</span>
+								</td>
+								<td class="pt-2">
+									<c:forEach var="origem" items="${forma.exTipoDocumentoSet}">
+										<c:choose>
+											<c:when test="${origem.id eq 1}">												
+												<span class="badge badge-primary  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:when>
+											<c:when test="${origem.id eq 2}">												
+												<span class="badge badge-info  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:when>
+											<c:when test="${origem.id eq 3}">												
+												<span class="badge badge-secondary  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:when>
+											<c:when test="${origem.id eq 4}">												
+												<span class="badge badge-dark  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:when>
+											<c:when test="${origem.id eq 5}">												
+												<span class="badge badge-light  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:when>
+											<c:otherwise>
+												<span class="badge badge-warning  mb-1">
+													${origem.descricao}
+												</span>
+												<br />
+											</c:otherwise>										
+										</c:choose>										
+									</c:forEach>
+								</td>
 							</tr>
 							<c:choose>
 								<c:when test='${evenorodd == "even"}'>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/juntar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/juntar.jsp
@@ -76,8 +76,8 @@
 				</div>
 				<div class="row">
 					<div class="form-group col-md-4">
-						<button type="submit" class="btn btn-primary mt-auto" >Ok</button>
-						<button type="button" onclick="javascript:history.back();" class="btn btn-cancel mt-auto" >Cancela</button>
+						<button type="submit" class="btn btn-primary mt-auto" >Ok</button>						
+						<a href="${linkTo[ExDocumentoController].exibe()}?sigla=${sigla}" class="btn btn-cancel ml-2">Cancela</a>
 					</div>
 				</div>
 			</form>

--- a/sigaex/src/main/webapp/WEB-INF/page/exTipoDespacho/edita.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exTipoDespacho/edita.jsp
@@ -17,10 +17,10 @@
 						<c:if test="${!empty exTipoDespacho.idTpDespacho}">
 							<input type="hidden" name="exTipoDespacho.idTpDespacho" value="${exTipoDespacho.idTpDespacho}"/>
 							<div class="row">
-								<div class="col-sm-1">
+								<div class="col-sm-12">
 									<div class="form-group">
 										<label>C&oacute;digo</label>
-										<label class="form-control"><fmt:formatNumber pattern="0000000" value="${exTipoDespacho.idTpDespacho}"/></label>
+										<label class="form-control" style="max-width: 90px"><fmt:formatNumber pattern="0000000" value="${exTipoDespacho.idTpDespacho}"/></label>
 									</div>
 								</div>
 							</div>
@@ -28,27 +28,34 @@
 						<div class="row">
 							<div class="col-sm-6">
 								<div class="form-group">
-									<label>Descri&ccedil;&atilde;o</label>
-									<textarea name="exTipoDespacho.descTpDespacho" cols="60" rows="5" class="form-control">${exTipoDespacho.descTpDespacho}</textarea>
+									<label for="descTpDespacho">Descri&ccedil;&atilde;o</label>
+									<textarea id="descTpDespacho" name="exTipoDespacho.descTpDespacho" cols="60" rows="5" maxlength="256" class="form-control">${exTipoDespacho.descTpDespacho}</textarea>
 								</div>
 							</div>
 						</div>
 						<div class="row">
 							<div class="col-sm-6">
 								<div class="form-check">
-									  <input class="form-check-input" type="checkbox" value="" id="defaultCheck1"  name="exTipoDespacho.fgAtivo" <c:if test="${exTipoDespacho.fgAtivo == 'S'}">checked</c:if> >
-									  <label class="form-check-label" for="defaultCheck1">Ativo</label>
+									  <input class="form-check-input" type="checkbox" value="S" id="ativo" name="exTipoDespacho.fgAtivo" ${exTipoDespacho.fgAtivo == 'S' ? 'checked' : ''} />
+									  <label class="form-check-label" for="ativo">Ativo</label>
 								</div>
 							</div>
 						</div>
-						<div class="row">
+						<div class="row  mt-3">
 							<div class="col-sm-6">
 								<div class="form-group">
-									<input type="submit" value="OK" class="btn btn-primary" />
+									<c:choose>
+										<c:when test="${empty exTipoDespacho.idTpDespacho}">
+											<input type="submit" value="OK" class="btn btn-primary" />
+											<a href="${linkTo[ExTipoDespachoController].lista()}" class="btn btn-cancel ml-2">Cancela</a>
+										</c:when>
+										<c:otherwise>
+											<a href="${linkTo[ExTipoDespachoController].lista()}" class="btn btn-secondary">Voltar</a>
+										</c:otherwise>
+									</c:choose>																	
 								</div>
 							</div>
 						</div>
-
 				</form>
 			</div>
 		</div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exTipoDespacho/lista.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exTipoDespacho/lista.jsp
@@ -5,36 +5,28 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 <%@ taglib uri="http://localhost/customtag" prefix="tags"%>
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
-<script type="text/javascript" language="Javascript1.1">
-	function excluir(id) {
-        var form  = document.getElementById("frm");
-		if (confirm("Deseja realmente excluir?")){
-			location.href = "apagar?id="+id;
-		}
-	}
-</script>
 <siga:pagina titulo="Lista Tipo de Despacho">
 	<div class="container-fluid">
 		<div class="card bg-light mb-3" >
 			<div class="card-header"><h5>Listagem dos tipos de despacho</h5></div>
-
 			<div class="card-body">
-				<table border="0" class="table table-sm table-striped">
+				<table border="0" class="table table-sm table-striped ">
 					<thead class="${thead_color}">
 						<th align="right">N&uacute;mero</th>
-						<th colspan="3">Descri&ccedil;&atilde;o</th>
+						<th colspan="3">Descri&ccedil;&atilde;o</th>						
 					</thead>
 					<tbody class="table-bordered">
 					<c:forEach var="tipoDespacho" items="${tiposDespacho}">
 						<tr>
 							<td>
-								<a href="editar?id=${tipoDespacho.idTpDespacho}">
-									<fmt:formatNumber pattern="0000000" value="${tipoDespacho.idTpDespacho}" />
+								<a id="tipoDespacho${tipoDespacho.idTpDespacho}" href="editar?id=${tipoDespacho.idTpDespacho}">
+									<fmt:formatNumber pattern="0000000" value="${tipoDespacho.idTpDespacho}" />									
 								</a>
 							</td>
 							<td>${tipoDespacho.descTpDespacho}</td>
-							<td>
-								<input type="button" value="Apagar" class="btn btn-primary" onclick="javascript:excluir(${tipoDespacho.idTpDespacho})" />
+							<td class="text-center">
+								<a href="#" onclick="confirmarExclusao('${tipoDespacho.idTpDespacho}');return false;"
+									data-toggle="tooltip" data-placement="left" title="Excluir" style="color:#040404cc;"><i class="fas fa-times"></i></a>
 							</td>
 						</tr>
 					</c:forEach>
@@ -43,10 +35,27 @@
 				<form name="frm" id="frm" action="editar" theme="simple" method="get">
 				<input type="submit" id="editar_0" value="Novo" class="btn btn-primary"/>
 			</form>
+			</div>					
+		</div>			
+		<siga:siga-modal id="confirmacaoModal" exibirRodape="false" tituloADireita="Confirma&ccedil;&atilde;o">
+			<div class="modal-body">
+	       		Deseja realmente excluir?
+	     	</div>
+	     	<div class="modal-footer">
+	       		<button type="button" class="btn btn-success" data-dismiss="modal">N&atilde;o</button>		        
+	       		<a href="#" class="btn btn-danger btn-confirmacao-exclusao" role="button" aria-pressed="true">Sim</a>
 			</div>
-			
-			
-		</div>
+		</siga:siga-modal>	
+	</div>	
+<script>	
+	function confirmarExclusao(idTipoDespacho){	
+		var descricao = $('a[id="tipoDespacho' + idTipoDespacho +  '"]').text().trim();		
 		
-	</div>
+		$('.btn-confirmacao-exclusao').attr('href', 'apagar?id='.concat(idTipoDespacho));		
+		sigaModal.enviarTextoEAbrir('confirmacaoModal', 'Deseja realmente excluir o tipo de despacho ' + descricao + '?');
+	}
+	$(function() {
+		$('[data-toggle="tooltip"]').tooltip();
+	});
+</script>	
 </siga:pagina>


### PR DESCRIPTION
Foram efetuadas algumas alterações e adequações nas funcionalidades listadas abaixo:

Juntada
- Botão "Cancela" alterado para não retornar com base no javascript:history.back(); e sim linkado para retornar para a página de exibição do documento.

Cadastro de Espécies Documentais
- Input radio "Ordenar Por" permanecendo marcado ao selecionar uma ordenação para que usuário saiba qual ordenação escolheu; 
- Na tabela que lista as espécies cadastradas, a coluna "Tipo" foi alterada para exibir os tipos em cores diferentes, a fim de facilitar a distinção entre os tipos distintos, o mesmo foi feito para coluna "Origem";
- No cadastro, foram ajustados inputs checkbox para que fiquem melhores dispostos na tela;
- Validações ao cadastrar foram ajustadas para serem retornadas na própria página e não na página de erro geral.

Tipos de Despacho
- Alterado botão de exclusão;
- Alterado mensagem de confirmação de exclusão, de alert javascript para modal;
- Não havia validação para o campo descrição, que se caso não fosse informado, retornava erro, foi criado validação;
- Aplicação não permite edição, então para quando estiver apenas visualizando um cadastro foi adicionado um botão "Voltar" no lugar do botão "Ok";
- Foi também adicionado um botão "Cancela" ao cadastrar para permitir retornar para a tela de listagem de tipos de despacho.