### PR TITLE
GOVSP1367 - Documento completo: exibindo barra de rolagem na lista lateral de documentos

### DIFF
--- a/siga/src/main/webapp/javascript/documento.reordenar-doc.js
+++ b/siga/src/main/webapp/javascript/documento.reordenar-doc.js
@@ -27,7 +27,7 @@ Documento.ReordenarDoc = (function() {
 	function onInicializar() {		
 		this.btnOrdenar.css({'display': 'none'});		
 		this.tituloTabelaDocumentos.css({'display': 'none'});
-		this.divMenuOrdenacao.css({'max-height':'111px', 'opacity':'1', 'left':'0'});			
+		this.divMenuOrdenacao.css({'max-height':'152px', 'opacity':'1', 'left':'0'});			
 		idDocsInicial = montarIdDocs(this.tabelaDosDocumentos);	
 		tabelaOriginal = this.tabelaDosDocumentos.html();		
 		this.tabelaDosDocumentos.addClass('tabela-ordenavel');						
@@ -46,7 +46,7 @@ Documento.ReordenarDoc = (function() {
 	
 	function onCancelar() {
 		this.btnOrdenar.css({'display': 'inline-block'});
-		this.tituloTabelaDocumentos.css({'display': 'flex'});
+		this.tituloTabelaDocumentos.css({'display': 'block'});
 		this.divMenuOrdenacao.css({'max-height':'0', 'opacity':'0','left':'-999px'});		
 		this.tabelaDosDocumentos.removeClass('tabela-ordenavel');
 		this.tabelaDosDocumentos.html(tabelaOriginal);

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
@@ -68,6 +68,17 @@
 		#btnSalvarOrdenacao:disabled {
 			cursor: not-allowed;
 		}
+		
+		.container-tabela-lista-documentos {
+			overflow: hidden;							
+		}
+		
+		@media screen and (max-width: 575px) {
+  			.container-tabela-lista-documentos {
+    			overflow: auto;
+    			max-height: 112px;
+  			}
+		}
 	</style>
 </c:if>
 
@@ -221,7 +232,7 @@
 	<div class="row mt-3">
 		<c:set var="arqsNum" value="${mob.arquivosNumerados}" />
 		<c:set var="paginacao" value="${not empty arqsNum[0].paginaInicial}" />
-		<div class="wrapper col-sm-3" >
+		<div class="wrapper col-sm-4 col-lg-3">
 			<div id="sidebar" class="w-100">
 				<div class="card-sidebar card bg-light mb-3" id="documentosDossie">
 					<div class="text-size-6 card-header">
@@ -252,7 +263,7 @@
 							</div>	
 						</c:if>							
 					</div>
-					<div class="card-body pl-1 pr-1 pt-0 pb-0">
+					<div class="card-body pl-1 pr-1 pt-0 pb-0  container-tabela-lista-documentos">
 						<table class="text-size-6 table table-hover table-sm table-striped m-0 mov tabela-documentos">
 							<tbody id="${mob.doc.podeReordenar() ? 'sortable' : ''}">
 								<c:forEach var="arqNumerado" items="${arqsNum}">
@@ -365,7 +376,7 @@
 				</div>
 			</div>
 		</div>
-		<div id="right-col" class="col-sm-9">
+		<div id="right-col" class="col-sm-8 col-lg-9">
 			<c:if test="${siga_cliente == 'GOVSP'}">
 				<div id="linhaBtn" class="mb-2">						
 					<div class="input-group d-inline mb-2">						
@@ -410,13 +421,38 @@
 		$(document).ready(function() {
 			//se exibindo documentos reordenados, não permite visualização PDF						
 			$('#radioPDF').attr('data-toggle', 'tooltip').attr('data-placement', 'top').attr('title', 'Indisponível enquanto documento estiver reordenado').removeAttr('onclick').css({'cursor':'not-allowed', 'color':'rgba(0, 0, 0, 0.3)', 'border':'1px solid rgba(0, 0, 0, 0.3)'});		
+			$('#radioPDFSemMarcas').attr('data-toggle', 'tooltip').attr('data-placement', 'top').attr('title', 'Indisponível enquanto documento estiver reordenado').removeAttr('onclick').css({'cursor':'not-allowed', 'color':'rgba(0, 0, 0, 0.3)', 'border':'1px solid rgba(0, 0, 0, 0.3)'});
 		});
 	</script>
 </c:if>
 <script>
-	$(function () {
-	  $('[data-toggle="tooltip"]').tooltip()
-	})
+	$(function () {	
+		analisarAlturaListaDocumentos();
+		
+		$('[data-toggle="tooltip"]').tooltip();
+	});
+	
+	function analisarAlturaListaDocumentos() {
+		var containerListaDeDocumentos = $('#documentosDossie');
+		var alturaContainerListaDeDocumentos = containerListaDeDocumentos.height();
+		var distanciaTopo = containerListaDeDocumentos.offset().top;
+		var alturaJanela = window.screen.availHeight;
+		var diferencaNecessaria = 102;		
+		var alturaLimite = alturaJanela - distanciaTopo - diferencaNecessaria;
+				
+		if (alturaContainerListaDeDocumentos > alturaLimite) {					
+			aplicarMaxHeight(containerListaDeDocumentos, alturaLimite);
+			aplicarScroll(containerListaDeDocumentos.find('.container-tabela-lista-documentos'));
+		}		
+	}
+	
+	function aplicarMaxHeight(elemento, altura) {
+		elemento.css('max-height', altura + 'px');
+	}
+	
+	function aplicarScroll (elemento) {
+		elemento.css('overflow', 'auto');
+	}	
 </script>
 <c:if test="${siga_cliente == 'GOVSP' && paginacao}">
 	<script>


### PR DESCRIPTION
Ajustado para que a lista lateral que exibe a relação de documentos apresente uma barra de rolagem, caso a mesma fique muito grande.