### PR TITLE
Ordenação das opções de Marcadores de documento.

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
@@ -70,6 +70,8 @@ import br.gov.jfrj.siga.model.Objeto;
 		+ "	and id_marcador not in (9,8,10,11,12 ,13,16, 18, 20 , 21, 22, 24 ,26, 32, 62, 63, 64, 7, 50, 51)")})
 public abstract class AbstractCpMarcador extends Objeto implements Serializable {
 
+	private static final long serialVersionUID = 6436403895150961831L;
+
 	@Id
 	@Column(name = "ID_MARCADOR", nullable = false)
 	private Long idMarcador;
@@ -83,6 +85,9 @@ public abstract class AbstractCpMarcador extends Objeto implements Serializable 
 
 	@Column(name = "GRUPO_MARCADOR")
 	private Integer grupoMarcador;
+	
+	@Column(name = "ORD_MARCADOR")
+	private Integer ordem;
 
 	public Long getIdMarcador() {
 		return idMarcador;
@@ -114,6 +119,14 @@ public abstract class AbstractCpMarcador extends Objeto implements Serializable 
 
 	public void setGrupoMarcador(Integer grupoMarcador) {
 		this.grupoMarcador = grupoMarcador;
+	}
+
+	public Integer getOrdem() {
+		return ordem;
+	}
+
+	public void setOrdem(Integer ordem) {
+		this.ordem = ordem;
 	}
 
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/CpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/CpMarcador.java
@@ -23,6 +23,7 @@
 package br.gov.jfrj.siga.dp;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.persistence.Cacheable;
@@ -42,6 +43,8 @@ import br.gov.jfrj.siga.model.ActiveRecord;
 @Cache(region = CpDao.CACHE_HOURS, usage = CacheConcurrencyStrategy.READ_ONLY)
 @Table(name = "CP_MARCADOR", schema = "CORPORATIVO")
 public class CpMarcador extends AbstractCpMarcador {
+
+	private static final long serialVersionUID = -909421649258750797L;
 
 	final static public long MARCADOR_EM_ELABORACAO = 1;
 
@@ -209,6 +212,12 @@ public class CpMarcador extends AbstractCpMarcador {
 
 	public static final List<Long> MARCADORES_DEMANDA_JUDICIAL = Arrays.asList(MARCADOR_DEMANDA_JUDICIAL_BAIXA,
 			MARCADOR_DEMANDA_JUDICIAL_MEDIA, MARCADOR_DEMANDA_JUDICIAL_ALTA);
+
+	/**
+	 * Ordena de acordo com a {@link #getOrdem() Ordem}.
+	 */
+	public static final Comparator<CpMarcador> ORDEM_COMPARATOR = Comparator
+			.nullsFirst(Comparator.comparing(CpMarcador::getOrdem));
 
 	public CpMarcador() {
 		super();

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V83_0__Marcadores_ordem.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V83_0__Marcadores_ordem.sql
@@ -1,0 +1,16 @@
+-------------------------------------------
+--	SCRIPT: DEFINE A ORDEM DOS MARCADORES A SEREM ATRIBUÍDOS AOS DOCUMENTOS
+--	ORDENAÇÃO DEFINIDA NO TRELLO 1446
+-------------------------------------------
+ALTER SESSION SET CURRENT_SCHEMA=corporativo;
+
+update corporativo.cp_marcador set ORD_MARCADOR = 1100 where ID_MARCADOR = 1006; -- COVID-19
+update corporativo.cp_marcador set ORD_MARCADOR = 1200 where ID_MARCADOR = 1005; -- Documento Analisado
+update corporativo.cp_marcador set ORD_MARCADOR = 1300 where ID_MARCADOR = 1001; -- Idoso
+update corporativo.cp_marcador set ORD_MARCADOR = 1400 where ID_MARCADOR = 1007; -- Nota de Empenho
+update corporativo.cp_marcador set ORD_MARCADOR = 1500 where ID_MARCADOR = 1010; -- Demanda Judicial Prioridade Alta
+update corporativo.cp_marcador set ORD_MARCADOR = 1600 where ID_MARCADOR = 1009; -- Demanda Judicial Prioridade Média
+update corporativo.cp_marcador set ORD_MARCADOR = 1700 where ID_MARCADOR = 1008; -- Demanda Judicial Prioridade Baixa
+update corporativo.cp_marcador set ORD_MARCADOR = 1800 where ID_MARCADOR = 1003; -- Prioritário
+update corporativo.cp_marcador set ORD_MARCADOR = 1900 where ID_MARCADOR = 1004; -- Restrição de Acesso
+update corporativo.cp_marcador set ORD_MARCADOR = 2000 where ID_MARCADOR = 1000; -- Urgente

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -594,7 +594,7 @@ public class Mesa2 {
 							.filter(mov -> mov.getExTipoMovimentacao().getId()
 									.equals(ExTipoMovimentacao.TIPO_MOVIMENTACAO_MARCACAO))
 							.filter(mov -> !mov.isCancelada()) //
-							.filter(mov -> mov.getMarcador().equals(tag.marca.getCpMarcador())) //
+							.filter(mov -> tag.marca.getCpMarcador().equals(mov.getMarcador())) //
 							.map(ExMovimentacao::getDtFimMovDDMMYY) //
 							.findFirst().orElse("[indeterminado]");
 				}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -2401,8 +2401,23 @@ public class ExMovimentacaoController extends ExController {
 		return dataLimite ;
 	}
 
-	private Object getListaMarcadoresGeraisTaxonomiaAdministrada() {
-		return dao().listarCpMarcadoresGeraisTaxonomiaAdministrada();
+	/**
+	 * Retorna a relação das opções de {@link CpMarcador Marcadores} que podem ser
+	 * atribuídos a um {@link ExDocumento Documento}. A ordenação é feita aqui ao
+	 * invés do método de origem pois
+	 * {@link ExDao#listarCpMarcadoresGeraisTaxonomiaAdministrada()} é chamado em
+	 * mais de um lugar e além disso nele é retornado a união de 2 queries
+	 * diferentes.
+	 * 
+	 * @return opções de {@link CpMarcador Marcadores} que podem ser atribuídos a um
+	 *         {@link ExDocumento Documento} devidamente ordenados de acordo com
+	 *         {@link CpMarcador#getOrdem()}
+	 */
+	private List<CpMarcador> getListaMarcadoresGeraisTaxonomiaAdministrada() {
+		List<CpMarcador> marcadores = dao().listarCpMarcadoresGeraisTaxonomiaAdministrada();
+		marcadores.sort(CpMarcador.ORDEM_COMPARATOR);
+
+		return marcadores;
 	}
 
 	/**


### PR DESCRIPTION
Ajustado de acordo com trello 1446. Teve que ser adicionado o mapeamento
da coluna de ordem de cp_marcador. Foi adicionado um Comparator
específico.