### PR TITLE
GOVSP1471-Alteração tipo de espécie bloqueado quando espécie vinculada a documentos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExFormaDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExFormaDocumento.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -43,6 +44,9 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Cache(region = ExDao.CACHE_EX, usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class ExFormaDocumento extends AbstractExFormaDocumento implements
 		Serializable, Selecionavel, Comparable<ExFormaDocumento> {
+	
+	@Transient
+	boolean tipoFormaAlterada;
 	
 	/**
 	 * Simple constructor of ExFormaDocumento instances.
@@ -129,6 +133,18 @@ public class ExFormaDocumento extends AbstractExFormaDocumento implements
 			return true;
 
 		return false;
+	}
+	
+	public boolean isEditando() {
+		return getIdFormaDoc() != null; 
+	}
+	
+	public void setTipoFormaAlterada(boolean tipoFormaAlterada) {
+		this.tipoFormaAlterada = tipoFormaAlterada;
+	}
+	
+	public boolean isTipoFormaAlterada() {						
+		return isEditando() && tipoFormaAlterada;
 	}
 	
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1327,7 +1327,7 @@ public class ExDao extends CpDao {
 		if (l.size() != 1)
 			return null;
 		return l.get(0);
-	}
+	}	
 
 	public int obterProximoNumeroVolume(ExDocumento doc) {
 		return doc.getNumUltimoVolume() + 1;
@@ -1435,7 +1435,7 @@ public class ExDao extends CpDao {
 		
 		q.where(cb().equal(c.get("idFormaDoc"), idFormaDoc));
 		return (ExFormaDocumento) em().createQuery(q).getSingleResult();
-	}
+	}	
 	
 	public ExFormaDocumento consultarExForma(String sForma) {
 		CriteriaQuery<ExFormaDocumento> q = cb().createQuery(ExFormaDocumento.class);
@@ -1443,6 +1443,15 @@ public class ExDao extends CpDao {
 		q.select(c);
 		q.where(cb().equal(c.get("descrFormaDoc"), sForma));
 		return em().createQuery(q).getSingleResult();
+	}
+	
+	public boolean isExFormaComDocumentoVinculado(Long idFormaDoc) {	   
+        Query query = em().createQuery("SELECT DISTINCT forma.idFormaDoc FROM ExFormaDocumento forma JOIN ExDocumento doc ON forma.idFormaDoc = doc.exFormaDocumento.idFormaDoc WHERE forma.idFormaDoc = :idFormaDoc")
+        		.setParameter("idFormaDoc", idFormaDoc);
+        
+        Long idFormaDocEncontrado = (Long) query.getResultStream().findFirst().orElse(0L);
+        
+        return idFormaDocEncontrado > 0L;	    
 	}
 
 	public ExTipoDocumento consultarExTipoDocumento(String descricao) {
@@ -1566,7 +1575,7 @@ public class ExDao extends CpDao {
 		q.setParameter("mascara", mascara);
 		q.setParameter("idOrgaoUsuario", orgaoUsu.getIdOrgaoUsu());
 		return q.getResultList();
-	}
+	}	
 
 	public List<ExPapel> listarExPapeis() {
 		return findByCriteria(ExPapel.class);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
@@ -141,7 +141,11 @@ public class ExFormaDocumentoController extends ExController {
 		setPostback(postback);
 
 		final ExFormaDocumento forma = id != null ? recuperarForma(id) : new ExFormaDocumento();
-
+				
+		if (forma.isEditando()) {
+			forma.setTipoFormaAlterada(forma.getExTipoFormaDoc().getId() != idTipoFormaDoc);
+		}
+		
 		forma.setDescrFormaDoc(descricao);
 		forma.setSigla(sigla);
 		forma.setExTipoFormaDoc(dao().consultar(idTipoFormaDoc, ExTipoFormaDoc.class, false));


### PR DESCRIPTION
Implementado checagem para não permitir alterar o Tipo da Espécie no cadastro de Espécie Documental, caso a Espécie já esteja vinculada a um ou mais documentos.