### PR TITLE
GOVSP1489 - Retorno da identificação se pessoa externa ou interna no WS

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/gi/service/impl/GiServiceImpl.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/gi/service/impl/GiServiceImpl.java
@@ -183,6 +183,7 @@ public class GiServiceImpl implements GiService {
 					DpPessoa p = identidade.getPessoaAtual();
 					pessoa.put("siglaPessoa", p.getSiglaCompleta());
 					pessoa.put("nomePessoa", p.getNomePessoa());
+					pessoa.put("isExternaPessoa", p.isUsuarioExterno());
 					
 					// Orgao Pessoa
 					CpOrgaoUsuario o = p.getOrgaoUsuario();
@@ -241,6 +242,7 @@ public class GiServiceImpl implements GiService {
 			DpPessoa p = id.getPessoaAtual();
 			pessoa.put("idPessoa", p.getId());
 			pessoa.put("idExternaPessoa", p.getIdExterna());
+			pessoa.put("isExternaPessoa", p.isUsuarioExterno());
 			pessoa.put("matriculaPessoa", p.getMatricula());
 			pessoa.put("cpf", p.getCpfPessoa());
 			pessoa.put("siglaPessoa", p.getSiglaCompleta());


### PR DESCRIPTION
Adicionar o conceito de usuário interno e externo no retorno dos WSs de perfilAcessoPorCpf e Login.

Adicionado ao Json:

"isExternaPessoa": **false/true** (Conforme método DpPessoa/isUsuarioExterno())