### PR TITLE
GOVSP1379 - Aviso e botão no painel administrativo para corrigir documentos sem descrição

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3344,22 +3344,7 @@ public class ExBL extends CpBL {
 			if (doc.getDtDocOriginal() != null && !Data.dataDentroSeculo21(doc.getDtDocOriginal())) {
 				throw new AplicacaoException("Data original inválida, deve estar entre o ano 2000 e ano 2100");
 			}
-			// Obtem a descricao pela macro @descricao
-			if (doc.getExModelo().isDescricaoAutomatica()) {
-				doc.setDescrDocumento(processarComandosEmTag(doc, "descricao"));
-
-				// Obter a descricao pela macro @entrevista
-			} else if (!Ex.getInstance().getComp().podeEditarDescricao(titular, lotaTitular, doc.getExModelo())) {
-				String s = processarModelo(doc, null, "entrevista", null, null);
-				String descr = extraiTag(s, "descricaoentrevista");
-				doc.setDescrDocumento(descr);
-			}
-			if (doc.getDescrDocumento() == null || doc.getDescrDocumento().isEmpty())
-				doc.setDescrDocumento(processarComandosEmTag(doc, "descricaodefault"));
-
-			if (doc.getDescrDocumento() == null || doc.getDescrDocumento().isEmpty())
-				doc.setDescrDocumento(doc.getExModelo().getNmMod()
-						+ (doc.getSubscritorString() != null ? " de " + doc.getSubscritorString() : ""));
+			gravaDescrDocumento(titular, lotaTitular, doc);
 
 			if (doc.getSubscritor() == null && !doc.getCosignatarios().isEmpty())
 				throw new AplicacaoException(
@@ -7414,6 +7399,38 @@ public class ExBL extends CpBL {
 		if (setVias == null || setVias.size() == 0)
 			criarVia(doc.getCadastrante(), doc.getLotaCadastrante(), doc, null);
 		return;
+	}
+	
+	public void corrigeDocSemDescricao(ExDocumento doc)
+			throws Exception {
+		if (doc.getDescrDocumento() != null)
+			throw new AplicacaoException("Documento já contém a descrição.");
+		gravaDescrDocumento(doc.getTitular(), doc.getLotaTitular(), doc);
+	
+		concluirAlteracaoDoc(doc);
+	
+		ContextoPersistencia.flushTransaction();
+	
+		return;
+	}
+
+	private void gravaDescrDocumento(DpPessoa titular, DpLotacao lotaTitular, ExDocumento doc) throws Exception {
+		// Obtem a descricao pela macro @descricao
+		if (doc.getExModelo().isDescricaoAutomatica()) {
+			doc.setDescrDocumento(processarComandosEmTag(doc, "descricao"));
+
+			// Obter a descricao pela macro @entrevista
+		} else if (!Ex.getInstance().getComp().podeEditarDescricao(titular, lotaTitular, doc.getExModelo())) {
+			String s = processarModelo(doc, null, "entrevista", null, null);
+			String descr = extraiTag(s, "descricaoentrevista");
+			doc.setDescrDocumento(descr);
+		}
+		if (doc.getDescrDocumento() == null || doc.getDescrDocumento().isEmpty())
+			doc.setDescrDocumento(processarComandosEmTag(doc, "descricaodefault"));
+
+		if (doc.getDescrDocumento() == null || doc.getDescrDocumento().isEmpty())
+			doc.setDescrDocumento(doc.getExModelo().getNmMod()
+					+ (doc.getSubscritorString() != null ? " de " + doc.getSubscritorString() : ""));
 	}
 	
 	public void gravarArquivoDocumento(ExDocumento doc) {

--- a/sigaex/src/main/webapp/WEB-INF/page/exPainel/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exPainel/exibe.jsp
@@ -75,6 +75,21 @@ function sbmtDoc() {
 			</div>
 		</div>
 	</c:if>
+	<c:if test="${erroSemDescricao}">
+		<div class="row mb-2">
+			<div class="col-12">
+				<div class="alert alert-warning" role="alert">
+					Atenção: O documento ${documentoRefSel.sigla} está sem a descri&ccedil;&atilde;o.
+					<c:if
+						test="${f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;DOC;FE;PAINEL;CORRIGEMOBIL:Corrige Documento sem Mobil de Via ou Volume')}">
+						<a class="btn btn-sm btn-primary float-right" title="Corrige falta de descricao"
+						  href="corrigeDocSemDescricao?documentoRefSel.sigla=${documentoRefSel.sigla}"
+						  ${popup?'target="_blank" ':''}><i class="fas fa-file-medical mr-2"></i>Corrige Falta de Descri&ccedil;&atilde;o</a>
+					</c:if>
+				</div>
+			</div>
+		</div>
+	</c:if>
 <c:if test="${not empty docVO}">
 	<div class="card bg-light mb-3">
 		<tags:collapse title="${docVO.nomeCompleto}" id="docDados" collapseMode="${collapse_Expanded}">


### PR DESCRIPTION
Os documentos sem descrição podem ser pesquisados no painel administrativo, que se identificar a situação de erro irá exibir a seguinte mensagem:

![image](https://user-images.githubusercontent.com/49542320/91894691-79a98f80-ec6c-11ea-9723-a7f6de1e8d20.png)


Ao clicar no botão "Corrige falta de descrição", o sistema irá inserir a descrição no documento, seguindo as regras atuais.