### PR TITLE
GOVSP1496 - Remoção de Origem bloqueada quando espécie vinculada a documentos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExTipoDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExTipoDocumento.java
@@ -56,8 +56,8 @@ public class ExTipoDocumento extends AbstractExTipoDocumento implements
 	final static public long TIPO_DOCUMENTO_INTERNO_FOLHA_DE_ROSTO = 2;
 	final static public long TIPO_DOCUMENTO_EXTERNO_FOLHA_DE_ROSTO = 3;
 	final static public long TIPO_DOCUMENTO_EXTERNO_CAPTURADO = 4;
-	final static public long TIPO_DOCUMENTO_INTERNO_CAPTURADO = 5;
-
+	final static public long TIPO_DOCUMENTO_INTERNO_CAPTURADO = 5;	
+	
 	/**
 	 * 
 	 */
@@ -93,8 +93,29 @@ public class ExTipoDocumento extends AbstractExTipoDocumento implements
 	public String getDescricao() {
 		return getDescrTipoDocumento();
 	}
-
-
-	/* Add customized code below */
+	
+	public String getDescricaoSimples() {
+		String descricao = "";
+		
+		switch (getIdTpDoc().intValue()) {
+		case 1:		
+			descricao = "Interno Produzido";
+			break;
+		case 2:
+			descricao = "Interno Importado";
+			break;
+		case 3:
+			descricao = "Externo";
+			break;
+		case 4:
+			descricao =  "Externo Capturado";
+			break;
+		case 5:
+			descricao = "Interno Capturado";
+			break;
+		}
+		
+		return descricao;
+	}
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6262,17 +6262,32 @@ public class ExBL extends CpBL {
 		}
 	}
 
-	public void gravarForma(ExFormaDocumento forma) throws AplicacaoException {
-		try {		
-			if (forma.isTipoFormaAlterada()) {
+	public void gravarForma(ExFormaDocumento forma, List<ExTipoDocumento> origensCadastradas) throws AplicacaoException {
+		try {	
+			
+			if (forma.isEditando()) {
 				boolean isExFormaComDocumentoVinculado = dao().isExFormaComDocumentoVinculado(forma.getId());
 				
-				if (isExFormaComDocumentoVinculado) {
-					throw new RegraNegocioException("Não é possível alterar o Tipo para <b>" + forma.getExTipoFormaDoc().getDescTipoFormaDoc() + "</b>"
-							+ ", existem documentos que dependem desta informação.");
-				}					
-			}
+				if (isExFormaComDocumentoVinculado) {				
+					if (forma.isTipoFormaAlterada()) {													
+						throw new RegraNegocioException("Não é possível alterar o Tipo para <b>" + forma.getExTipoFormaDoc().getDescTipoFormaDoc() + "</b>"
+								+ ", existem documentos que dependem desta informação.");									
+					}
 					
+					for (ExTipoDocumento origemCadastrada : origensCadastradas) {
+						ExTipoDocumento origemEncontrada = forma.getExTipoDocumentoSet().stream()
+								.filter(o -> o.getIdTpDoc() == origemCadastrada.getIdTpDoc())
+								.findAny()
+								.orElse(null);
+						
+						if (origemEncontrada == null) {
+							throw new RegraNegocioException("Não é possível retirar a Origem <b>" + origemCadastrada.getDescricaoSimples() + "</b>"
+									+ ", existem documentos que dependem desta informação.");
+						}
+					}
+				}			
+			}				
+							
 			if (forma.getDescrFormaDoc() == null || forma.getDescrFormaDoc().isEmpty())
 				throw new RegraNegocioException("Não é possível salvar um tipo sem informar a descrição.");
 			if (forma.getExTipoFormaDoc() == null)

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExFormaDocumentoController.java
@@ -1,5 +1,6 @@
 package br.gov.jfrj.siga.vraptor;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -140,6 +141,7 @@ public class ExFormaDocumentoController extends ExController {
 		assertAcesso(ACESSO_SIGA_DOC_MOD);
 		setPostback(postback);
 
+		List<ExTipoDocumento> origensCadastradas = new ArrayList<>();		
 		final ExFormaDocumento forma = id != null ? recuperarForma(id) : new ExFormaDocumento();
 				
 		if (forma.isEditando()) {
@@ -152,8 +154,14 @@ public class ExFormaDocumentoController extends ExController {
 
 		if (forma.getExTipoDocumentoSet() == null) {
 			forma.setExTipoDocumentoSet(new HashSet<ExTipoDocumento>());
-		} else {
-			forma.getExTipoDocumentoSet().clear();
+		} else {			
+			if (forma.isEditando()) {				
+				for (ExTipoDocumento origem : forma.getExTipoDocumentoSet()) {
+					origensCadastradas.add(origem);
+				}																	
+			}
+			
+			forma.getExTipoDocumentoSet().clear();					
 		}
 
 		forma.setIsComposto(isComposto);
@@ -177,7 +185,7 @@ public class ExFormaDocumentoController extends ExController {
 		}
 
 		try {
-			Ex.getInstance().getBL().gravarForma(forma);
+			Ex.getInstance().getBL().gravarForma(forma, origensCadastradas);
 			
 			result.include("id", forma.getIdFormaDoc());
 			result.include("descricao", descricao);

--- a/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/listarFormas.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/listarFormas.jsp
@@ -83,31 +83,31 @@
 										<c:choose>
 											<c:when test="${origem.id eq 1}">												
 												<span class="badge badge-primary  mb-1">
-													${origem.descricao}
+													${origem.descricaoSimples}
 												</span>
 												<br />
 											</c:when>
 											<c:when test="${origem.id eq 2}">												
 												<span class="badge badge-info  mb-1">
-													${origem.descricao}
+													${origem.descricaoSimples}
 												</span>
 												<br />
 											</c:when>
 											<c:when test="${origem.id eq 3}">												
 												<span class="badge badge-secondary  mb-1">
-													${origem.descricao}
+													${origem.descricaoSimples}
 												</span>
 												<br />
 											</c:when>
 											<c:when test="${origem.id eq 4}">												
 												<span class="badge badge-dark  mb-1">
-													${origem.descricao}
+													${origem.descricaoSimples}
 												</span>
 												<br />
 											</c:when>
 											<c:when test="${origem.id eq 5}">												
 												<span class="badge badge-light  mb-1">
-													${origem.descricao}
+													${origem.descricaoSimples}
 												</span>
 												<br />
 											</c:when>


### PR DESCRIPTION
Implementado para consistir a Origem, não permitindo desmarcar uma Origem se a espécie estiver vinculada a documento(s).