### PR TITLE
GOVSP1505-Espécie-bloqueando campos que não podem ser editados

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExFormaDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExFormaDocumento.java
@@ -43,10 +43,7 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Table(name = "EX_FORMA_DOCUMENTO", catalog = "SIGA")
 @Cache(region = ExDao.CACHE_EX, usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class ExFormaDocumento extends AbstractExFormaDocumento implements
-		Serializable, Selecionavel, Comparable<ExFormaDocumento> {
-	
-	@Transient
-	boolean tipoFormaAlterada;
+		Serializable, Selecionavel, Comparable<ExFormaDocumento> {	
 	
 	/**
 	 * Simple constructor of ExFormaDocumento instances.
@@ -137,14 +134,6 @@ public class ExFormaDocumento extends AbstractExFormaDocumento implements
 	
 	public boolean isEditando() {
 		return getIdFormaDoc() != null; 
-	}
-	
-	public void setTipoFormaAlterada(boolean tipoFormaAlterada) {
-		this.tipoFormaAlterada = tipoFormaAlterada;
-	}
-	
-	public boolean isTipoFormaAlterada() {						
-		return isEditando() && tipoFormaAlterada;
-	}
+	}	
 	
 }

--- a/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/editarForma.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exFormaDocumento/editarForma.jsp
@@ -27,30 +27,32 @@
 						<div class="col-lg-1 col-md-2">
 							<div class="form-group">
 								<label for="sigla">Sigla</label> 
-								<input type="text" id="sigla" value="${sigla}" name="sigla" id="gravar_sigla" class="form-control"/> <span id="mensagem"></span>
+								<input type="text" id="sigla" value="${sigla}" name="sigla" id="gravar_sigla" class="form-control"
+									${temDocumentoVinculado ? 'readonly' : ''} /> <span id="mensagem"></span>
 							</div>
 						</div>
 						<div class="col-md-3">
 							<div class="form-group">
 								<label for="tipoFormaDoc">Tipo</label> 
 								<select id="tipoFormaDoc" name="idTipoFormaDoc" value="${idTipoFormaDoc}"
-									class="form-control">
+									class="form-control" ${temDocumentoVinculado ? 'readonly' : ''}>
 									<c:forEach var="tipo" items="${listaTiposFormaDoc}">
 										<option value="${tipo.idTipoFormaDoc}"
 											${tipo.idTipoFormaDoc == idTipoFormaDoc ? 'selected' : ''}>${tipo.descTipoFormaDoc}</option>
 									</c:forEach>
 								</select>
 							</div>
-						</div>						
+						</div>														
 						<div class="col-md-2">
 							<div class="form-group">
 								<div class="form-check form-check-inline mt-4">
-								  <input class="form-check-input" type="checkbox" name="isComposto" id="isComposto" value="1" <c:if test="${isComposto == 1}">checked</c:if>/>
-								  <label class="form-check-label" for="isComposto">Documento Composto</label>
+								  <input class="form-check-input" type="checkbox" name="isComposto" id="isComposto" value="1" <c:if test="${isComposto == 1}">checked</c:if>
+								  	${temDocumentoVinculado ? 'disabled' : ''}/>
+								  <label class="form-check-label${temDocumentoVinculado ? '  label-disabled' : ''}" for="isComposto">Documento Composto</label>
 								</div>
 							</div>
-						</div>
-					</div>
+						</div>						
+					</div>			
 					<div class="row">
 						<div class="col-sm-12">
 							<h3 style="font-size: 1rem; margin-bottom: 3px; font-weight: normal;">Origem</h3>
@@ -60,24 +62,29 @@
 						<div class="col-sm-12">
 							<div class="form-group">								
 								<div class="form-check  form-check-inline">
-									<input type="checkbox" id="origemExterno" class="form-check-input" name="origemExterno" value="true" ${origemExterno ? 'checked' : ''}/> 
-									<label for="origemExterno">Externo</label>
+									<input type="checkbox" id="origemExterno" class="form-check-input" name="origemExterno" value="true" ${origemExterno ? 'checked' : ''}
+										${temDocumentoVinculado ?  (origemExterno ?  'disabled' : '') : ''}/> 
+									<label for="origemExterno" ${temDocumentoVinculado ?  (origemExterno ?  'class="label-disabled"' : '') : ''}>Externo</label>
 								</div>								
 								<div class="form-check  form-check-inline">	
-									<input type="checkbox" id="origemInternoProduzido" class="form-check-input" name="origemInternoProduzido" value="true" ${origemInternoProduzido ? 'checked' : ''}/>
-									<label for="origemInternoProduzido">Interno Produzido</label>
+									<input type="checkbox" id="origemInternoProduzido" class="form-check-input" name="origemInternoProduzido" value="true" ${origemInternoProduzido ? 'checked' : ''}
+										${temDocumentoVinculado ?  (origemInternoProduzido ?  'disabled' : '') : ''}/>
+									<label for="origemInternoProduzido" ${temDocumentoVinculado ?  (origemInternoProduzido ?  'class="label-disabled"' : '') : ''}>Interno Produzido</label>
 								</div>
 								<div class="form-check  form-check-inline">	
-									<input type="checkbox" id="origemInternoImportado" class="form-check-input" name="origemInternoImportado" value="true" ${origemInternoImportado ? 'checked' : ''}/>
-									<label for="origemInternoImportado">Interno Importado</label>
+									<input type="checkbox" id="origemInternoImportado" class="form-check-input" name="origemInternoImportado" value="true" ${origemInternoImportado ? 'checked' : ''}
+										${temDocumentoVinculado ?  (origemInternoImportado ?  'disabled' : '') : ''}/>
+									<label for="origemInternoImportado" ${temDocumentoVinculado ?  (origemInternoImportado ?  'class="label-disabled"' : '') : ''}>Interno Importado</label>
 								</div>
 								<div class="form-check  form-check-inline">	
-									<input type="checkbox" id="origemInternoCapturado" class="form-check-input" name="origemInternoCapturado" value="true" ${origemInternoCapturado ? 'checked' : ''}/> 
-									<label for="origemInternoCapturado">Interno Capturado</label>
+									<input type="checkbox" id="origemInternoCapturado" class="form-check-input" name="origemInternoCapturado" value="true" ${origemInternoCapturado ? 'checked' : ''}
+										${temDocumentoVinculado ?  (origemInternoCapturado ?  'disabled' : '') : ''}/>
+									<label for="origemInternoCapturado" ${temDocumentoVinculado ?  (origemInternoCapturado ?  'class="label-disabled"' : '') : ''}>Interno Capturado</label>
 								</div>
 								<div class="form-check  form-check-inline">	 
-									<input type="checkbox" id="origemExternoCapturado" class="form-check-input" name="origemExternoCapturado" value="true" ${origemExternoCapturado ? 'checked' : ''} /> 
-									<label for="origemExternoCapturado">Externo Capturado</label>
+									<input type="checkbox" id="origemExternoCapturado" class="form-check-input" name="origemExternoCapturado" value="true" ${origemExternoCapturado ? 'checked' : ''} 
+										${temDocumentoVinculado ?  (origemExternoCapturado ?  'disabled' : '') : ''}/>
+									<label for="origemExternoCapturado" ${temDocumentoVinculado ?  (origemExternoCapturado ?  'class="label-disabled"' : '') : ''}>Externo Capturado</label>
 								</div>
 							</div>
 						</div>
@@ -85,8 +92,8 @@
 					<div class="row">
 						<div class="col-sm-8">
 							<div class="form-group">
-								<button type="submit" class="btn btn-primary">Ok</button>
-								<button type="submit" name="submit" class="btn btn-primary">Aplicar</button>								
+								<button type="button" class="btn btn-primary  btn-salvar" onclick="onBtnSalvarClicado()">Ok</button>
+								<button type="button" class="btn btn-primary  btn-salvar" onclick="onBtnSalvarClicado()">Aplicar</button>								
 								<a href="${linkTo[ExFormaDocumentoController].listarFormas()}?ordenar=descricao" class="btn btn-cancel">Cancela</a>
 							</div>
 						</div>
@@ -156,7 +163,7 @@
 		</div>
 		</form>
 	</div>
-	<script> 
+<script> 
 $("#gravar_sigla").change(function () {
     var sigla = $("#gravar_sigla").val().toUpperCase();
 	$("#gravar_sigla").attr("value", sigla);
@@ -168,7 +175,7 @@ $("#gravar_sigla").change(function () {
 	$.ajax({				     				  
 		  url:'${pageContext.request.contextPath}/app/forma/verificar_sigla',
 		  type: "GET",
-		  data: {sigla : sigla, id : ${id} },
+		  data: {sigla : sigla, id : '${id}' },
 		  success: function(data) {
 	    	$('#mensagem').html(data);				    
 	 	 }
@@ -195,5 +202,39 @@ $("#gravar_sigla").change(function () {
 	montaTableCadastradas('tableCadastradasNivelAcessoMaximo', 18, 0 ,${id});
 	montaTableCadastradas('tableCadastradasNivelAcessoMinimo', 19, 0 ,${id});			
 </c:if>
+
+<c:if test="${temDocumentoVinculado}">
+		
+	function onTipoAlterado() {
+		this.value = '${idTipoFormaDoc}';
+	}
+
+	function aplicarTooltipsEmCamposNaoEditaveis() {
+		$('form[name=frm]').find('[readonly], .label-disabled').each(function(){						
+			$(this).tooltip({title : 'Edição não permitida, pois existem documentos que dependem desta informação'});								
+		});				
+	}
+
+	$('#tipoFormaDoc').on('change', onTipoAlterado);
+	
+	$(function() {		
+		aplicarTooltipsEmCamposNaoEditaveis();		
+	});
+</c:if>
+
+function onBtnSalvarClicado() {
+	$('.btn-salvar').attr('disabled', 'disabled');
+	habilitarCheckboxes();				
+	frm.submit();
+}
+
+function habilitarCheckboxes() {
+	frm.elements["isComposto"].disabled = false;
+	frm.elements["origemInternoProduzido"].disabled = false;
+	frm.elements["origemInternoImportado"].disabled = false;
+	frm.elements["origemExterno"].disabled = false;
+	frm.elements["origemInternoCapturado"].disabled = false;
+	frm.elements["origemExternoCapturado"].disabled = false;	
+}		
 </script>
 </siga:pagina>


### PR DESCRIPTION
- Implementado validação para não permitir editar Sigla e indicativo de Documento Composto quando Espécie estiver vinculada a documento(s)
- Implementado bloqueio de campos que não podem ser editados diretamente na tela.