### PR TITLE
Develop govsp versao arquivo

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
@@ -38,18 +38,15 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
-import org.hibernate.annotations.Immutable;
+import javax.persistence.Version;
 
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
-import br.gov.jfrj.siga.model.ContextoPersistencia;
 
 /**
  * A class that represents a row in the CP_ARQUIVO table. You can customize the
  * behavior of this class by editing the class, {@link CpArquivo()}.
  */
 @Entity
-@Immutable
 @Table(name = "CP_ARQUIVO", schema = "CORPORATIVO")
 public class CpArquivo implements Serializable {
 
@@ -87,6 +84,9 @@ public class CpArquivo implements Serializable {
 	
 	@Transient
 	private String hashMD5Original;
+	
+	@Version
+	private Long versao;
 
 	/**
 	 * Simple constructor of AbstractExDocumento instances.
@@ -141,36 +141,6 @@ public class CpArquivo implements Serializable {
 			this.arquivoBlob.setArquivo(this);
 		}
 		this.arquivoBlob.setConteudoBlobArq(createBlob);
-	}
-
-	public static CpArquivo forUpdate(CpArquivo old) {
-		if (old != null) {
-			if (old.getIdArq() != null) {
-				CpArquivo arq = new CpArquivo();
-				arq.setConteudoTpArq(old.getConteudoTpArq());
-				arq.setOrgaoUsuario(old.getOrgaoUsuario());
-				if (old.getArquivoBlob() != null) {
-					arq.setArquivoBlob(new CpArquivoBlob());
-					arq.getArquivoBlob().setArquivo(arq);
-					arq.getArquivoBlob().setConteudoBlobArq(old.getArquivoBlob().getConteudoBlobArq());
-				}
-				ContextoPersistencia.em().remove(old);
-				return arq;
-			} else
-				return old;
-		} else
-			return new CpArquivo();
-	}
-
-	public static CpArquivo updateConteudoTp(CpArquivo old, String conteudoTp) {
-		//TODO: Verificar essa linha
-		//if (old == null || !Texto.equals(old.getConteudoTpArq(), conteudoTp)) {
-		if (old == null) {
-			CpArquivo arq = CpArquivo.forUpdate(old);
-			arq.setConteudoTpArq(conteudoTp);
-			return arq;
-		}
-		return old;
 	}
 
 	public CpArquivoTipoArmazenamentoEnum getTipoArmazenamento() {
@@ -228,6 +198,14 @@ public class CpArquivo implements Serializable {
 
 	public String getHashMD5Original() {
 		return hashMD5Original;
+	}
+
+	public Long getVersao() {
+		return versao;
+	}
+
+	public void setVersao(Long versao) {
+		this.versao = versao;
 	}
 	
 	

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivoExcluir.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivoExcluir.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.siga.cp;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * A class that represents a row in the CP_ARQUIVO_EXCLUIR table. You can customize the
+ * behavior of this class by editing the class, {@link CpArquivoExcluir()}.
+ */
+@Entity
+@Table(name = "CP_ARQUIVO_EXCLUIR", schema = "CORPORATIVO")
+public class CpArquivoExcluir implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "CAMINHO")
+	private String caminho;
+
+	public String getCaminho() {
+		return caminho;
+	}
+
+	public void setCaminho(String caminho) {
+		this.caminho = caminho;
+	}
+	
+}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/arquivo/ArmazenamentoHCP.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/arquivo/ArmazenamentoHCP.java
@@ -24,6 +24,8 @@ import org.jboss.logging.Logger;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.cp.CpArquivo;
+import br.gov.jfrj.siga.cp.CpArquivoExcluir;
+import br.gov.jfrj.siga.model.ContextoPersistencia;
 
 public class ArmazenamentoHCP implements ArmazenamentoBCInterface {
 
@@ -49,19 +51,22 @@ public class ArmazenamentoHCP implements ArmazenamentoBCInterface {
 	    SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
 	    SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
 	    client = HttpClients.custom().setSSLSocketFactory(csf).build();
-
-//		client = HttpClients.createDefault();
 	}
 
 	@Override
 	public void salvar(CpArquivo cpArquivo, byte[] conteudo) {
 		try {
 			configurar();
-			cpArquivo.setTamanho(conteudo.length);
-			if(cpArquivo.getCaminho()==null)
-				cpArquivo.gerarCaminho(null);
 			
-			apagarArquivo(cpArquivo);
+			if(cpArquivo.getCaminho()!=null) {
+				CpArquivoExcluir excluir = new CpArquivoExcluir();
+				excluir.setCaminho(cpArquivo.getCaminho());
+				ContextoPersistencia.em().persist(excluir);
+			}
+			
+			cpArquivo.setTamanho(conteudo.length);
+			cpArquivo.gerarCaminho(null);
+			
 			
 			HttpPut request = new HttpPut(uri+cpArquivo.getCaminho());
 			request.addHeader(AUTHORIZATION, token);

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V87_0__Inclusao_versao_CpArquivo_e _Controle_de_transacional.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V87_0__Inclusao_versao_CpArquivo_e _Controle_de_transacional.sql
@@ -1,0 +1,8 @@
+/* Inclusão de coluna versão para controlar gravação concorrente e criação de tabela para controle transacional dos documentos */
+
+alter table corporativo.cp_arquivo add versao number default 1 not null;
+COMMENT ON COLUMN "CORPORATIVO"."CP_ARQUIVO"."VERSAO" IS 'Coluna de versão para uso do Lock Otimista do JPA';
+
+create table corporativo.CP_ARQUIVO_EXCLUIR (
+  CAMINHO VARCHAR2(255) NOT NULL PRIMARY KEY
+);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -1136,8 +1136,6 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 		if(cpArquivo == null) {
 			cpArquivo = new CpArquivo();
 			cpArquivo.setTipoArmazenamento(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")));
-			if(CpArquivoTipoArmazenamentoEnum.HCP.equals(cpArquivo.getTipoArmazenamento()))
-				cpArquivo.gerarCaminho(getDtRegDoc()!=null?getDtRegDoc():new Date());
 		}
 	}
 	

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
@@ -882,8 +882,6 @@ public abstract class AbstractExMovimentacao extends ExArquivo implements Serial
 		if(cpArquivo == null) {
 			cpArquivo = new CpArquivo();
 			cpArquivo.setTipoArmazenamento(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")));
-			if(CpArquivoTipoArmazenamentoEnum.HCP.equals(cpArquivo.getTipoArmazenamento()))
-				cpArquivo.gerarCaminho(getDtMov()!=null?getDtMov():new Date());
 		}
 	}
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
@@ -211,8 +211,6 @@ public abstract class AbstractExPreenchimento extends Objeto implements
 			cpArquivo = new CpArquivo();
 			cpArquivo.setTipoArmazenamento(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")));
 			cpArquivo.setConteudoTpArq(TipoConteudo.TXT.getMimeType());
-			if(CpArquivoTipoArmazenamentoEnum.HCP.equals(cpArquivo.getTipoArmazenamento()))
-				cpArquivo.gerarCaminho(new Date());
 		}
 	}
 }

--- a/siga-ex/src/main/resources/META-INF/persistence.xml
+++ b/siga-ex/src/main/resources/META-INF/persistence.xml
@@ -78,6 +78,7 @@
 		<class>br.gov.jfrj.siga.ex.ExProtocolo</class>
 		<class>br.gov.jfrj.siga.cp.CpArquivo</class>
 		<class>br.gov.jfrj.siga.cp.CpArquivoBlob</class>
+		<class>br.gov.jfrj.siga.cp.CpArquivoExcluir</class>
 
 		<properties>
 		<property name="hibernate.jpa.compliance.global_id_generators" value="false"/>


### PR DESCRIPTION
Controle de concorrência na gravação do documento através do uso de lock otimista na tabela CpArquivo
Controle transacional com o HCP para evitar a sobrescrita de documento caso haja rollback