### PR TITLE
GOVSP1523 - Conversão da API de documentos do SIGA-LE para o SIGA-EX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,9 +157,9 @@
 			</dependency>
 			
 			<dependency>
-				<groupId>com.crivano</groupId>
-				<artifactId>swaggerservlet</artifactId>
-				<version>1.33.0</version>
+			    <groupId>com.crivano</groupId>
+			    <artifactId>swaggerservlet</artifactId>
+			    <version>1.36.0</version>
 			</dependency>
 			
 			<dependency>

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/AbstractCpIdentidade.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/AbstractCpIdentidade.java
@@ -88,6 +88,11 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ "or pes.situacaoFuncionalPessoa = :sfp36)")})
 
 public abstract class AbstractCpIdentidade extends HistoricoAuditavelSuporte {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 6096621825604901831L;
+
 	@Id
 	@SequenceGenerator(name = "CP_IDENTIDADE_SEQ", sequenceName = "CORPORATIVO.CP_IDENTIDADE_SEQ")
 	@GeneratedValue(generator = "CP_IDENTIDADE_SEQ")

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpIdentidade.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpIdentidade.java
@@ -48,6 +48,11 @@ import br.gov.jfrj.siga.sinc.lib.SincronizavelSuporte;
 @Table(name = "CP_IDENTIDADE", schema = "CORPORATIVO")
 public class CpIdentidade extends AbstractCpIdentidade {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 5911884614189757579L;
+
 	public DpPessoa getPessoaAtual() {
 		return CpDao.getInstance().consultarPorIdInicial(
 				getDpPessoa().getIdInicial());

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpTipoIdentidade.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpTipoIdentidade.java
@@ -28,7 +28,6 @@ import org.hibernate.annotations.Immutable;
 
 import br.gov.jfrj.siga.dp.dao.CpDao;
 
-import br.gov.jfrj.siga.dp.dao.CpDao;
 
 @Entity
 @Immutable

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoSigaLeVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoSigaLeVO.java
@@ -1,0 +1,657 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.siga.ex.vo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+
+import com.google.gson.annotations.Expose;
+
+import br.gov.jfrj.siga.base.Texto;
+import br.gov.jfrj.siga.dp.CpMarcador;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMarca;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExCompetenciaBL;
+import br.gov.jfrj.siga.ex.util.ExGraphColaboracao;
+import br.gov.jfrj.siga.ex.util.ExGraphRelacaoDocs;
+import br.gov.jfrj.siga.ex.util.ExGraphTramitacao;
+
+public class ExDocumentoSigaLeVO extends ExVO {
+	@Expose String classe;
+	@Expose List<ExMobilVO> mobs = new ArrayList<ExMobilVO>();
+	@Expose List<ExDocumentoVO> documentosPublicados = new ArrayList<ExDocumentoVO>();
+	@Expose ExDocumentoVO boletim;
+	@Expose Map<ExMobil, Set<ExMarca>> marcasPorMobil = new LinkedHashMap<ExMobil, Set<ExMarca>>();
+	@Expose String outrosMobsLabel;
+	@Expose String nomeCompleto;
+	@Expose String dtDocDDMMYY;
+	@Expose String subscritorString;
+	@Expose String originalNumero;
+	@Expose String originalData;
+	@Expose String originalOrgao;
+	@Expose String classificacaoDescricaoCompleta;
+	@Expose List<String> tags;
+	@Expose String destinatarioString;
+	@Expose String descrDocumento;
+	@Expose String nmNivelAcesso;
+	@Expose String paiSigla;
+	@Expose String tipoDocumento;
+
+	@Expose String dtFinalizacao;
+	@Expose String nmArqMod;
+	@Expose String conteudoBlobHtmlString;
+	@Expose String sigla;
+	@Expose String fisicoOuEletronico;
+	@Expose boolean fDigital;
+	//@Expose Map<ExMovimentacao, Boolean> cossignatarios = new HashMap<ExMovimentacao, Boolean>();
+	@Expose String dadosComplementares;
+	@Expose String forma;
+	@Expose String modelo;
+	@Expose String tipoFormaDocumento;
+	@Expose String cadastranteString;
+	@Expose String lotaCadastranteString;
+	@Expose String dotTramitacao;
+	@Expose String dotRelacaoDocs;
+	@Expose String dotColaboracao;
+	@Expose boolean podeAssinar;
+	@Expose String exTipoDocumentoDescricao;
+
+	// Desabilitado temporariamente
+	// private List<Object> listaDeAcessos;
+
+	public ExDocumentoSigaLeVO(ExDocumento doc, ExMobil mob, DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular,
+			boolean completo, boolean exibirAntigo) {
+		this.sigla = doc.getSigla();
+		this.descrDocumento = doc.getDescrDocumento();
+
+		this.exTipoDocumentoDescricao = doc.getExTipoDocumento().getDescricao();
+
+		if (!completo)
+			return;
+
+		this.nomeCompleto = doc.getNomeCompleto();
+		this.dtDocDDMMYY = doc.getDtDocDDMMYY();
+		this.subscritorString = doc.getSubscritorString();
+		this.cadastranteString = doc.getCadastranteString();
+		if (doc.getLotaCadastrante() != null)
+			this.lotaCadastranteString = "(" + doc.getLotaCadastrante().getSigla() + ")";
+		else
+			this.lotaCadastranteString = "";
+
+		if (doc.getExClassificacaoAtual() != null)
+			this.classificacaoDescricaoCompleta = doc.getExClassificacaoAtual().getAtual().getDescricaoCompleta();
+		this.destinatarioString = doc.getDestinatarioString();
+		if (doc.getExNivelAcessoAtual() != null)
+			this.nmNivelAcesso = doc.getExNivelAcessoAtual().getNmNivelAcesso();
+		// Desabilitado temporariamente
+		// this.listaDeAcessos = doc.getListaDeAcessos();
+		if (doc.getExMobilPai() != null)
+			this.paiSigla = doc.getExMobilPai().getSigla();
+		if (doc.getExTipoDocumento() != null)
+			switch (doc.getExTipoDocumento().getId().intValue()) {
+			case 1:
+				this.tipoDocumento = "interno";
+				break;
+			case 2:
+				this.tipoDocumento = "interno_importado";
+				break;
+			case 3:
+				this.tipoDocumento = "externo";
+				break;
+			}
+		if (doc.getExFormaDocumento().getExTipoFormaDoc() != null)
+			switch (doc.getExFormaDocumento().getExTipoFormaDoc().getId().intValue()) {
+			case 1:
+				this.tipoFormaDocumento = "expediente";
+				break;
+			case 2:
+				this.tipoFormaDocumento = "processo_administrativo";
+				break;
+			}
+
+		this.dtFinalizacao = doc.getDtFinalizacaoDDMMYY();
+		if (doc.getExModelo() != null)
+			this.nmArqMod = doc.getExModelo().getNmArqMod();
+
+		this.conteudoBlobHtmlString = doc.getConteudoBlobHtmlStringComReferencias();
+
+		if (doc.isEletronico()) {
+			this.classe = "header_eletronico";
+			this.fisicoOuEletronico = "Documento Eletrônico";
+			this.fDigital = true;
+		} else {
+			this.classe = "header";
+			this.fisicoOuEletronico = "Documento Físico";
+			this.fDigital = false;
+		}
+
+		ExCompetenciaBL comp = Ex.getInstance().getComp();
+		/*for (ExMovimentacao movCossig : doc.getMovsCosignatario())
+			cossignatarios.put(movCossig, comp.podeExcluirCosignatario(titular, lotaTitular,
+					doc.getMobilGeral(), movCossig));
+*/
+		this.forma = doc.getExFormaDocumento() != null ? doc.getExFormaDocumento().getDescricao() : "";
+		this.modelo = doc.getExModelo() != null ? doc.getExModelo().getNmMod() : "";
+
+		if (mob != null) {
+			SortedSet<ExMobil> mobsDoc;
+			if (doc.isProcesso())
+				mobsDoc = doc.getExMobilSetInvertido();
+			else
+				mobsDoc = doc.getExMobilSet();
+
+			for (ExMobil m : mobsDoc) {
+				if (mob.isGeral() || m.isGeral() || mob.getId().equals(m.getId()))
+					mobs.add(new ExMobilVO(m, cadastrante, titular, lotaTitular, completo));
+			}
+
+			addAcoes(doc, titular, lotaTitular, exibirAntigo);
+
+			this.podeAssinar = comp.podeAssinar(titular, lotaTitular, mob) 
+					&& comp.podeAssinarComSenha(titular, lotaTitular, mob);
+			
+			ExGraphTramitacao exGraphTramitacao = new ExGraphTramitacao(mob);
+			if (exGraphTramitacao.getNumNodos() > 1)
+				this.dotTramitacao = exGraphTramitacao.toString();
+			this.dotRelacaoDocs = new ExGraphRelacaoDocs(mob, titular).toString();
+			this.dotColaboracao = new ExGraphColaboracao(doc).toString();
+		}
+
+		// Desabilitado temporariamente
+		// addDadosComplementares();
+
+		tags = new ArrayList<String>();
+		if (doc.getExClassificacao() != null) {
+			String classificacao = doc.getExClassificacao().getDescricao();
+			if (classificacao != null && classificacao.length() != 0) {
+				String a[] = classificacao.split(": ");
+				for (String s : a) {
+					String ss = "@" + Texto.slugify(s, true, true);
+					if (!tags.contains(ss)) {
+						tags.add(ss);
+					}
+				}
+			}
+		}
+		if (doc.getExModelo() != null) {
+			String ss = "@" + Texto.slugify(doc.getExModelo().getNmMod(), true, true);
+			if (!tags.contains(ss)) {
+				tags.add(ss);
+			}
+		}
+
+		// Desabilitado temporariamente
+		// if (doc.getDocumentosPublicadosNoBoletim() != null) {
+		// for (ExDocumento documentoPublicado : doc
+		// .getDocumentosPublicadosNoBoletim()) {
+		// documentosPublicados.add(new ExDocumentoVO(documentoPublicado));
+		// }
+		// }
+		//
+		// ExDocumento bol = doc.getBoletimEmQueDocFoiPublicado();
+		// if (bol != null)
+		// boletim = new ExDocumentoVO(bol);
+
+		this.originalNumero = doc.getNumExtDoc();
+		this.originalData = doc.getDtDocOriginalDDMMYYYY();
+		this.originalOrgao = doc.getOrgaoExterno() != null ? doc.getOrgaoExterno().getDescricao() : null;
+
+		// Aqui começa o exibe()
+		List<Long> movimentacoesPermitidas = new ArrayList<Long>();
+
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA_A_DOCUMENTO_EXTERNO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA_EXTERNO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANEXACAO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANEXACAO_DE_ARQUIVO_AUXILIAR);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANOTACAO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_INTERNO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_INTERNO_TRANSFERENCIA);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA_EXTERNA);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_DISPONIBILIZACAO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_AGENDAMENTO_DE_PUBLICACAO_BOLETIM);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_PUBLICACAO_BOLETIM);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_PEDIDO_PUBLICACAO);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_ENCERRAMENTO_DE_VOLUME);
+		movimentacoesPermitidas.add(ExTipoMovimentacao.TIPO_MOVIMENTACAO_COPIA);
+
+		List<Long> marcasGeralPermitidas = new ArrayList<Long>();
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_A_ELIMINAR);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_ARQUIVADO_CORRENTE);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_ARQUIVADO_INTERMEDIARIO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_ARQUIVADO_PERMANENTE);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_EM_EDITAL_DE_ELIMINACAO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_PUBLICACAO_SOLICITADA);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_PUBLICADO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_RECOLHER_PARA_ARQUIVO_PERMANENTE);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_REMETIDO_PARA_PUBLICACAO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_PENDENTE_DE_ASSINATURA);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_COMO_SUBSCRITOR);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_REVISAR);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_ANEXO_PENDENTE_DE_ASSINATURA);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO);
+		marcasGeralPermitidas.add(CpMarcador.MARCADOR_PENDENTE_DE_ANEXACAO);
+
+		for (ExMobilVO mobVO : mobs) {
+
+			// Limpa as Movimentações
+			List<ExMovimentacaoVO> movimentacoesFinais = new ArrayList<ExMovimentacaoVO>();
+			List<ExMovimentacaoVO> juntadasRevertidas = new ArrayList<ExMovimentacaoVO>();
+
+			for (ExMovimentacaoVO exMovVO : mobVO.getMovs()) {
+				if (!exMovVO.isCancelada() && movimentacoesPermitidas.contains(exMovVO.getIdTpMov())) {
+
+					// Desabilitado temporariamente
+					// if (exMovVO.getIdTpMov() ==
+					// ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA)
+					// {
+					// juntadasRevertidas.add(exMovVO.getMov()
+					// .getExMovimentacaoRef());
+					// // Edson: se não gerou peça, nem mostra o
+					// // desentranhamento
+					// if (exMovVO.getMov().getConteudoBlobMov() == null)
+					// continue;
+					// }
+					if (!juntadasRevertidas.contains(exMovVO))
+						movimentacoesFinais.add(exMovVO);
+				}
+
+			}
+
+			mobVO.setMovs(movimentacoesFinais);
+		}
+
+		ExMobilVO mobilGeral = null;
+		ExMobilVO mobilEspecifico = null;
+
+		for (ExMobilVO mobilVO : mobs) {
+			if (mobilVO.isGeral)
+				mobilGeral = mobilVO;
+			else
+				mobilEspecifico = mobilVO;
+		}
+
+		// MarcasPorMobil
+		for (ExMobil cadaMobil : doc.getExMobilSet()) {
+			// if (!cadaMobil.isGeral())
+				marcasPorMobil.put(cadaMobil, cadaMobil.getExMarcaSet());
+		}
+
+		if (mobilEspecifico != null && mobilGeral != null) {
+			mobilEspecifico.getAcoes().addAll(mobilGeral.getAcoes());
+			mobilEspecifico.getMovs().addAll(mobilGeral.getMovs());
+			mobilEspecifico.anexosNaoAssinados
+					.addAll(mobilGeral.anexosNaoAssinados);
+			for (ExMarca m : mobilGeral.getMarcasAtivas())
+				if (marcasGeralPermitidas.contains(m.getCpMarcador()
+						.getIdMarcador()))
+					mobilEspecifico.getMarcasAtivas().add(m);
+//			for (ExMarca m : mobilGeral.getMob().getExMarcaSet())
+//				if (marcasGeralPermitidas.contains(m.getCpMarcador()
+//						.getIdMarcador()))
+//					for (ExMobil cadaMobil : marcasPorMobil.keySet())
+//						marcasPorMobil.get(cadaMobil).add(m);
+			mobs.remove(mobilGeral);
+		}
+//
+//		// Edson: mostra lista de vias/volumes só se número de
+//		// vias/volumes além do geral for > que 1 ou se o móbil
+//		// tiver informações que não aparecem no topo da tela
+//		if (doc.getExMobilSet().size() > 2 || mob.temMarcaNaoAtiva())
+//			outrosMobsLabel = doc.isProcesso() ? "Volumes" : "Vias";
+	}
+
+	/**
+	 * @param doc
+	 * @param titular
+	 * @param lotaTitular
+	 * @throws Exception
+	 */
+	private void addAcoes(ExDocumento doc, DpPessoa titular, DpLotacao lotaTitular, boolean exibirAntigo) {
+		ExVO vo = this;
+		for (ExMobilVO mobvo : mobs) {
+			if (mobvo.isGeral)
+				vo = mobvo;
+		}
+
+		ExMobil mob = doc.getMobilGeral();
+
+		vo.addAcao("folder_magnify", "_Ver Dossiê", "/app/expediente/doc", "exibirProcesso",
+				Ex.getInstance().getComp().podeVisualizarImpressao(titular, lotaTitular, mob));
+
+		vo.addAcao("printer", "Ver _Impressão", "/app/arquivo", "exibir",
+				Ex.getInstance().getComp().podeVisualizarImpressao(titular, lotaTitular, mob), null,
+				"&popup=true&arquivo=" + doc.getReferenciaPDF(), null, null, null);
+
+		vo.addAcao("lock", "Fina_lizar", "/app/expediente/doc",
+
+				"finalizar", Ex.getInstance().getComp().podeFinalizar(titular, lotaTitular, mob), null, null, null,
+				null, "once");
+
+		// addAcao("Finalizar e Assinar", "/expediente/mov",
+		// "finalizar_assinar",
+		// podeFinalizarAssinar(titular, lotaTitular, mob),
+		// "Confirma a finalização do documento?", null, null, null);
+
+		vo.addAcao("pencil", "Edita_r", "/app/expediente/doc", "editar",
+				Ex.getInstance().getComp().podeEditar(titular, lotaTitular, mob));
+
+		vo.addAcao("delete", "Excluir", "/app/expediente/doc", "excluir",
+				Ex.getInstance().getComp().podeExcluir(titular, lotaTitular, mob), "Confirma a exclusão do documento?",
+				null, null, null, "once");
+
+		vo.addAcao("user_add", "Incluir Cossignatário", "/app/expediente/mov", "incluir_cosignatario",
+				Ex.getInstance().getComp().podeIncluirCosignatario(titular, lotaTitular, mob), null,
+				"sigla=" + doc.getSigla(), null, null, null);
+
+		vo.addAcao("attach", "Ane_xar", "/app/expediente/mov", "anexar",
+				Ex.getInstance().getComp().podeAnexarArquivo(titular, lotaTitular, mob));
+		vo.addAcao("note_add", "_Anotar", "/app/expediente/mov", "anotar",
+				Ex.getInstance().getComp().podeFazerAnotacao(titular, lotaTitular, mob));
+
+		vo.addAcao("folder_user", "Definir Perfil", "/app/expediente/mov", "vincularPapel",
+				Ex.getInstance().getComp().podeFazerVinculacaoPapel(titular, lotaTitular, mob));
+
+		vo.addAcao("folder_star", "Definir Marcador", "/app/expediente/mov", "marcar",
+				Ex.getInstance().getComp().podeMarcar(titular, lotaTitular, mob));
+
+		vo.addAcao("cd", "Download do Conteúdo", "/expediente/doc", "anexo",
+				Ex.getInstance().getComp().podeDownloadConteudo(titular, lotaTitular, mob));
+
+		vo.addAcao("add", "Criar Via", "/app/expediente/doc", "criar_via",
+				Ex.getInstance().getComp().podeCriarVia(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		vo.addAcao("add", "Abrir Novo Volume", "/app/expediente/doc", "criar_volume",
+				Ex.getInstance().getComp().podeCriarVolume(titular, lotaTitular, mob),
+				"Confirma a abertura de um novo volume?", null, null, null, "once");
+
+		vo.addAcao("link_add", "Criar Subprocesso", "/app/expediente/doc", "editar",
+				Ex.getInstance().getComp().podeCriarSubprocesso(titular, lotaTitular, mob), null,
+				"mobilPaiSel.sigla=" + getSigla() + "&idForma=" + mob.doc().getExFormaDocumento().getIdFormaDoc()
+						+ "&criandoSubprocesso=true",
+				null, null, null);
+
+		vo.addAcao("script_edit", "Registrar A_ssinatura Manual", "/app/expediente/mov", "registrar_assinatura",
+				Ex.getInstance().getComp().podeRegistrarAssinatura(titular, lotaTitular, mob));
+
+		vo.addAcao("script_key", "A_ssinar", "/app/expediente/mov", "assinar",
+				Ex.getInstance().getComp().podeAssinar(titular, lotaTitular, mob));
+
+		vo.addAcao("script_key", "A_utenticar", "/app/expediente/mov", "autenticar_documento",
+				Ex.getInstance().getComp().podeAutenticarDocumento(titular, lotaTitular, mob.doc()));
+
+		if (doc.isFinalizado() && doc.getNumExpediente() != null) {
+			// documentos finalizados
+			if (mob.temAnexos()) {
+				vo.addAcao("script_key", "Assinar Anexos Gerais", "/app/expediente/mov", "assinarAnexos", true, null,
+						"assinandoAnexosGeral=true&sigla=" + getSigla(), null, null, null);
+			}
+		}
+
+		vo.addAcao("shield", "Redefinir Acesso", "/app/expediente/mov", "redefinir_nivel_acesso",
+				Ex.getInstance().getComp().podeRedefinirNivelAcesso(titular, lotaTitular, mob));
+
+		vo.addAcao("book_add", "Solicitar Publicação no Boletim", "/app/expediente/mov", "boletim_agendar",
+				Ex.getInstance().getComp().podeBotaoAgendarPublicacaoBoletim(titular, lotaTitular, mob));
+
+		vo.addAcao("book_link", "Registrar Publicação do Boletim", "/app/expediente/mov", "boletim_publicar",
+				Ex.getInstance().getComp().podePublicar(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		vo.addAcao("error_go", "Refazer", "/app/expediente/doc", "refazer",
+				Ex.getInstance().getComp().podeRefazer(titular, lotaTitular, mob),
+				"Esse documento será cancelado e seus dados serão copiados para um novo expediente em elaboração. Prosseguir?",
+				null, null, null, "once");
+
+		vo.addAcao("arrow_divide", "Duplicar", "/app/expediente/doc", "duplicar",
+				Ex.getInstance().getComp().podeDuplicar(titular, lotaTitular, mob),
+				"Esta operação criará um expediente com os mesmos dados do atual. Prosseguir?", null, null, null,
+				"once");
+
+		// test="${exibirCompleto != true}" />
+		int numUltMobil = doc.getNumUltimoMobil();
+		vo.addAcao("eye", "Ver _Mais", "/app/expediente/doc", "exibirAntigo",
+				Ex.getInstance().getComp().podeExibirInformacoesCompletas(titular, lotaTitular, mob) && !exibirAntigo,
+				numUltMobil < 20 ? ""
+						: "Exibir todos os " + numUltMobil
+								+ " volumes do processo simultaneamente pode exigir um tempo maior de processamento. Deseja exibi-los?",
+				null, null, null, null);
+
+		vo.addAcao("magnifier", "Auditar", "/app/expediente/doc", "exibirAntigo",
+				Ex.getInstance().getComp().podeExibirInformacoesCompletas(titular, lotaTitular, mob) && exibirAntigo,
+				null, "&exibirCompleto=true", null, null, null);
+
+		vo.addAcao("report_link", "Agendar Publicação no Diário", "/app/expediente/mov", "agendar_publicacao",
+				Ex.getInstance().getComp().podeAgendarPublicacao(titular, lotaTitular, mob));
+
+		vo.addAcao("report_add", "Solicitar Publicação no Diário", "/app/expediente/mov", "pedirPublicacao",
+				Ex.getInstance().getComp().podePedirPublicacao(titular, lotaTitular, mob));
+
+		// <ww:param name="idFormaDoc">60</ww:param>
+		vo.addAcao("arrow_undo", "Desfazer Cancelamento", "/app/expediente/doc", "desfazerCancelamentoDocumento",
+				Ex.getInstance().getComp().podeDesfazerCancelamentoDocumento(titular, lotaTitular, mob),
+				"Esta operação anulará o cancelamento do documento e tornará o documento novamente editável. Prosseguir?",
+				null, null, null, "once");
+
+		vo.addAcao("delete", "Cancelar", "/app/expediente/doc", "tornarDocumentoSemEfeito",
+				Ex.getInstance().getComp().podeTornarDocumentoSemEfeito(titular, lotaTitular, mob),
+				"Esta operação tornará esse documento sem efeito. Prosseguir?", null, null, null, "once");
+	}
+
+	// Desabilitado temporariamente
+	// public void addDadosComplementares() {
+	// ProcessadorModeloFreemarker p = new ProcessadorModeloFreemarker();
+	// Map attrs = new HashMap();
+	// attrs.put("nmMod", "macro dadosComplementares");
+	// attrs.put("template", "[@dadosComplementares/]");
+	// attrs.put("doc", this.getDoc());
+	//
+	// Desabilitado temporariamente
+	// dadosComplementares = p.processarModelo(doc.getOrgaoUsuario(), attrs,
+	// null);
+	// }
+
+	public String getClasse() {
+		return classe;
+	}
+
+	public String getClassificacaoDescricaoCompleta() {
+		return classificacaoDescricaoCompleta;
+	}
+
+	public String getConteudoBlobHtmlString() {
+		return conteudoBlobHtmlString;
+	}
+
+	public String getDescrDocumento() {
+		return descrDocumento;
+	}
+
+	public String getDestinatarioString() {
+		return destinatarioString;
+	}
+
+	public String getDtDocDDMMYY() {
+		return dtDocDDMMYY;
+	}
+
+	public String getDtFinalizacao() {
+
+		return dtFinalizacao;
+	}
+
+	public List<ExMobilVO> getMobs() {
+		return mobs;
+	}
+
+	public String getNmArqMod() {
+		return nmArqMod;
+	}
+
+	public String getNmNivelAcesso() {
+		return nmNivelAcesso;
+	}
+
+	public String getNomeCompleto() {
+		return nomeCompleto;
+	}
+
+	public String getPaiSigla() {
+		return paiSigla;
+	}
+
+	public String getSigla() {
+		return sigla;
+	}
+
+	// Desabilitado temporariamente
+	// public String getSiglaCurtaSubProcesso() {
+	// if (doc.isProcesso() && doc.getExMobilPai() != null) {
+	// try {
+	// return sigla.substring(sigla.length() - 3, sigla.length());
+	// } catch (Exception e) {
+	// return sigla;
+	// }
+	// }
+	//
+	// return "";
+	//
+	// }
+
+	public String getSubscritorString() {
+		return subscritorString;
+	}
+
+	public String getTipoDocumento() {
+		return tipoDocumento;
+	}
+
+	public String getFisicoOuEletronico() {
+		return fisicoOuEletronico;
+	}
+
+	public boolean isDigital() {
+		return fDigital;
+	}
+
+	@Override
+	public String toString() {
+		String s = getSigla() + "[" + getAcoes() + "]";
+		for (ExMobilVO m : getMobs()) {
+			s += "\n" + m.toString();
+		}
+		return s;
+	}
+
+	public String getDadosComplementares() {
+		return dadosComplementares;
+	}
+
+	public String getForma() {
+		return forma;
+	}
+
+	public void setForma(String forma) {
+		this.forma = forma;
+	}
+
+	public String getModelo() {
+		return modelo;
+	}
+
+	public void setModelo(String modelo) {
+		this.modelo = modelo;
+	}
+
+	public List<String> getTags() {
+		return tags;
+	}
+
+	public void setTags(List<String> tags) {
+		this.tags = tags;
+	}
+
+	public String getTipoFormaDocumento() {
+		return tipoFormaDocumento;
+	}
+
+	public String getCadastranteString() {
+		return cadastranteString;
+	}
+
+	public String getLotaCadastranteString() {
+		return lotaCadastranteString;
+	}
+
+	public String getOutrosMobsLabel() {
+		return outrosMobsLabel;
+	}
+
+	public List<ExDocumentoVO> getDocumentosPublicados() {
+		return documentosPublicados;
+	}
+
+	public ExDocumentoVO getBoletim() {
+		return boletim;
+	}
+
+	// Desabilitado temporariamente
+	 public Map<ExMobil, Set<ExMarca>> getMarcasPorMobil() {
+		 return marcasPorMobil;
+	 }
+	
+	 public void setMarcasPorMobil(Map<ExMobil, Set<ExMarca>> marcasPorMobil) {
+		 this.marcasPorMobil = marcasPorMobil;
+	 }
+
+	/*public Map<ExMovimentacao, Boolean> getCossignatarios() {
+		return cossignatarios;
+	}
+
+	public void setCossignatarios(Map<ExMovimentacao, Boolean> cossignatarios) {
+		this.cossignatarios = cossignatarios;
+	}*/
+
+	public String getOriginalNumero() {
+		return originalNumero;
+	}
+
+	public String getOriginalData() {
+		return originalData;
+	}
+
+	public String getOriginalOrgao() {
+		return originalOrgao;
+	}
+
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -44,6 +44,7 @@ public class ExMobilVO extends ExVO {
 	Logger log = Logger.getLogger(ExMobilVO.class.getCanonicalName());
 	ExMobil mob;
 	String sigla;
+	boolean isGeral;
 	List<ExMobilVO> apensos = new ArrayList<ExMobilVO>();
 	// List<ExDocumentoVO> filhos = new ArrayList<ExDocumentoVO>();
 	List<ExDocumentoVO> expedientesFilhosNaoCancelados = new ArrayList<ExDocumentoVO>();
@@ -99,6 +100,7 @@ public class ExMobilVO extends ExVO {
 			boolean completo, Long tpMov, boolean movAssinada) {
 		this.mob = mob;
 		this.sigla = mob.getSigla();
+		this.isGeral = mob.isGeral();
 
 		if (!completo || mob.isEliminado())
 			return;

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/DuracaoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/DuracaoApiVO.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+public class DuracaoApiVO {
+	private String duracao;
+	private int span;
+	private int spanExibirCompleto;
+
+	public String getDuracao() {
+		return duracao;
+	}
+
+	public void setDuracao(String duracao) {
+		this.duracao = duracao;
+	}
+
+	public int getSpan() {
+		return span;
+	}
+
+	public void setSpan(int span) {
+		this.span = span;
+	}
+
+	public int getSpanExibirCompleto() {
+		return spanExibirCompleto;
+	}
+
+	public void setSpanExibirCompleto(int spanExibirCompleto) {
+		this.spanExibirCompleto = spanExibirCompleto;
+	}
+
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExAcaoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExAcaoApiVO.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+public class ExAcaoApiVO {
+	String icone;
+	String nome;
+	String nameSpace;
+	String acao;
+	boolean pode;
+	String msgConfirmacao;
+	String pre;
+	String pos;
+	String classe;
+	Map<String, String> params;
+	
+	public Map<String, String> getParams() {
+		return params;
+	}
+	
+	public String getPre() {
+		return pre;
+	}
+	
+	public String getPos() {
+		return pos;
+	}
+	
+	public String getIcone() {
+		return icone;
+	}
+	
+	public String getNome() {
+		return nome;
+	}
+	
+	public String getNomeNbsp() {
+		return getNome().replace(" ", "&nbsp;");
+	}
+	
+	public String getNameSpace() {
+		return nameSpace;
+	}
+	
+	public String getAcao() {
+		return acao;
+	}
+	
+	public boolean isPode() {
+		return pode;
+	}
+	
+	public boolean isPopup() {
+		return params.containsKey("popup");
+	}
+	
+	public boolean isAjax() {
+		return params.containsKey("ajax");
+	}
+	
+	public String getMsgConfirmacao() {
+		return msgConfirmacao;
+	}
+	
+	public String getClasse() {
+		return classe;
+	}
+	
+	public void setClasse(String classe) {
+		this.classe = classe;
+	}
+	
+	public ExAcaoApiVO(String icone, String nome, String nameSpace, String acao, boolean pode, String msgConfirmacao,
+			TreeMap<String, String> params, String pre, String pos, String classe) {
+		super();
+		this.icone = icone;
+		this.nome = nome;
+		this.nameSpace = nameSpace;
+		this.acao = acao;
+		this.pode = pode;
+		this.msgConfirmacao = msgConfirmacao;
+		this.params = params;
+		this.pre = pre;
+		this.pos = pos;
+		this.classe = classe;
+	}
+	
+	@Override
+	public String toString() {
+		return getPre() + " " + getNome() + " " + getPos() + " <" + getNameSpace() + " - " + getAcao() + "?"
+				+ getParams() + ">";
+	}
+	
+	public static List<ExAcaoApiVO> ordena(List<ExAcaoApiVO> acoes, Comparator<ExAcaoApiVO> comparator) {
+		if (comparator != null)
+			Collections.sort(acoes, comparator);
+		return acoes;
+	}
+	
+	public String getUrl() {
+		String resultUrl = "";
+		String valueOfParameterToAdd;
+		Map<String, String> parameters = this.params;
+		Set<String> parametersNames = this.params.keySet();
+		for (String nameOfParameterToAdd : parametersNames) {
+			valueOfParameterToAdd = parameters.get(nameOfParameterToAdd);
+			resultUrl = (nameOfParameterToAdd + "=" + valueOfParameterToAdd + "&").concat(resultUrl);
+		}
+		if (!parametersNames.isEmpty())
+			resultUrl = ("?").concat(resultUrl);
+		resultUrl = (this.nameSpace + "/" + this.acao).concat(resultUrl);
+		return resultUrl;
+	}
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExApiVO.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeMap;
+
+import br.gov.jfrj.siga.ex.bl.Ex;
+
+public class ExApiVO {
+	List<ExAcaoApiVO> acoes = new ArrayList<ExAcaoApiVO>();
+
+	private class NomeExAcaoApiVOComparator implements Comparator<ExAcaoApiVO> {
+
+		public int compare(ExAcaoApiVO o1, ExAcaoApiVO o2) {
+			return o1.getNome().replace("_", "")
+					.compareTo(o2.getNome().replace("_", ""));
+		}
+	}
+
+	public List<ExAcaoApiVO> getAcoes() {
+		return acoes;
+	}
+
+	public List<ExAcaoApiVO> getAcoesOrdenadasPorNome() {
+		return ExAcaoApiVO.ordena(getAcoes(), new NomeExAcaoApiVOComparator());
+	}
+
+	public void setAcoes(List<ExAcaoApiVO> acoes) {
+		this.acoes = acoes;
+	}
+
+	protected void addAcao(String icone, String nome, String nameSpace,
+			String action, boolean pode) {
+		addAcao(icone, nome, nameSpace, action, pode, null, null, null, null,
+				null);
+	}
+
+	protected void addAcao(String icone, String nome, String nameSpace,
+			String action, boolean pode, String msgConfirmacao,
+			String parametros, String pre, String pos, String classe) {
+		TreeMap<String, String> params = new TreeMap<String, String>();
+
+		if (this instanceof ExMovimentacaoApiVO) {
+			params.put("id",
+					Long.toString(((ExMovimentacaoApiVO) this).getIdMov()));
+			// params.put("sigla", ((ExMovimentacaoVO)
+			// this).getMobilVO().getSigla());
+		} else if (this instanceof ExMobilApiVO) {
+			params.put("sigla", ((ExMobilApiVO) this).getSigla());
+		} else if (this instanceof ExDocumentoApiVO) {
+			params.put("sigla", ((ExDocumentoApiVO) this).getSigla());
+		}
+
+		if (parametros != null) {
+			if (parametros.startsWith("&"))
+				parametros = parametros.substring(1);
+			else
+				params.clear();
+			try {
+				Ex.getInstance()
+						.getBL()
+						.mapFromUrlEncodedForm(params,
+								parametros.getBytes("iso-8859-1"));
+			} catch (UnsupportedEncodingException e) {
+			}
+		}
+
+		if (pode) {
+			ExAcaoApiVO acao = new ExAcaoApiVO(icone, nome, nameSpace, action, pode,
+					msgConfirmacao, params, pre, pos, classe);
+			acoes.add(acao);
+		}
+	}
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExDocumentoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExDocumentoApiVO.java
@@ -16,24 +16,19 @@
  *     You should have received a copy of the GNU General Public License
  *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************/
-package br.gov.jfrj.siga.ex.vo;
+package br.gov.jfrj.sigale.ex.vo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
-
-import com.google.gson.annotations.Expose;
 
 import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.dp.CpMarcador;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExDocumento;
-import br.gov.jfrj.siga.ex.ExMarca;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
 import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
@@ -43,50 +38,51 @@ import br.gov.jfrj.siga.ex.util.ExGraphColaboracao;
 import br.gov.jfrj.siga.ex.util.ExGraphRelacaoDocs;
 import br.gov.jfrj.siga.ex.util.ExGraphTramitacao;
 
-public class ExDocumentoSigaLeVO extends ExVO {
-	@Expose String classe;
-	@Expose List<ExMobilVO> mobs = new ArrayList<ExMobilVO>();
-	@Expose List<ExDocumentoVO> documentosPublicados = new ArrayList<ExDocumentoVO>();
-	@Expose ExDocumentoVO boletim;
-	@Expose Map<ExMobil, Set<ExMarca>> marcasPorMobil = new LinkedHashMap<ExMobil, Set<ExMarca>>();
-	@Expose String outrosMobsLabel;
-	@Expose String nomeCompleto;
-	@Expose String dtDocDDMMYY;
-	@Expose String subscritorString;
-	@Expose String originalNumero;
-	@Expose String originalData;
-	@Expose String originalOrgao;
-	@Expose String classificacaoDescricaoCompleta;
-	@Expose List<String> tags;
-	@Expose String destinatarioString;
-	@Expose String descrDocumento;
-	@Expose String nmNivelAcesso;
-	@Expose String paiSigla;
-	@Expose String tipoDocumento;
+public class ExDocumentoApiVO extends ExApiVO {
+	String classe;
+	List<ExMobilApiVO> mobs = new ArrayList<ExMobilApiVO>();
+	List<ExDocumentoApiVO> documentosPublicados = new ArrayList<ExDocumentoApiVO>();
+	ExDocumentoApiVO boletim;
+	// Map<ExMobil, Set<ExMarca>> marcasPorMobil = new LinkedHashMap<ExMobil,
+	// Set<ExMarca>>();
+	String outrosMobsLabel;
+	String nomeCompleto;
+	String dtDocDDMMYY;
+	String subscritorString;
+	String originalNumero;
+	String originalData;
+	String originalOrgao;
+	String classificacaoDescricaoCompleta;
+	List<String> tags;
+	String destinatarioString;
+	String descrDocumento;
+	String nmNivelAcesso;
+	String paiSigla;
+	String tipoDocumento;
 
-	@Expose String dtFinalizacao;
-	@Expose String nmArqMod;
-	@Expose String conteudoBlobHtmlString;
-	@Expose String sigla;
-	@Expose String fisicoOuEletronico;
-	@Expose boolean fDigital;
-	//@Expose Map<ExMovimentacao, Boolean> cossignatarios = new HashMap<ExMovimentacao, Boolean>();
-	@Expose String dadosComplementares;
-	@Expose String forma;
-	@Expose String modelo;
-	@Expose String tipoFormaDocumento;
-	@Expose String cadastranteString;
-	@Expose String lotaCadastranteString;
-	@Expose String dotTramitacao;
-	@Expose String dotRelacaoDocs;
-	@Expose String dotColaboracao;
-	@Expose boolean podeAssinar;
-	@Expose String exTipoDocumentoDescricao;
+	String dtFinalizacao;
+	String nmArqMod;
+	String conteudoBlobHtmlString;
+	String sigla;
+	String fisicoOuEletronico;
+	boolean fDigital;
+	Map<ExMovimentacaoApiVO, Boolean> cossignatarios = new HashMap<ExMovimentacaoApiVO, Boolean>();
+	String dadosComplementares;
+	String forma;
+	String modelo;
+	String tipoFormaDocumento;
+	String cadastranteString;
+	String lotaCadastranteString;
+	String dotTramitacao;
+	String dotRelacaoDocs;
+	String dotColaboracao;
+	boolean podeAssinar;
+	String exTipoDocumentoDescricao;
 
 	// Desabilitado temporariamente
 	// private List<Object> listaDeAcessos;
 
-	public ExDocumentoSigaLeVO(ExDocumento doc, ExMobil mob, DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular,
+	public ExDocumentoApiVO(ExDocumento doc, ExMobil mob, DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular,
 			boolean completo, boolean exibirAntigo) {
 		this.sigla = doc.getSigla();
 		this.descrDocumento = doc.getDescrDocumento();
@@ -153,10 +149,11 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		}
 
 		ExCompetenciaBL comp = Ex.getInstance().getComp();
-		/*for (ExMovimentacao movCossig : doc.getMovsCosignatario())
-			cossignatarios.put(movCossig, comp.podeExcluirCosignatario(titular, lotaTitular,
-					doc.getMobilGeral(), movCossig));
-*/
+		for (ExMovimentacao movCossig : doc.getMovsCosignatario()) {
+			ExMobilApiVO mobilApiVO = new ExMobilApiVO(doc.getMobilGeral(), titular, titular, lotaTitular, exibirAntigo);
+			ExMovimentacaoApiVO movApiVO =  new ExMovimentacaoApiVO(mobilApiVO, movCossig, cadastrante, titular, lotaTitular);
+			cossignatarios.put(movApiVO, comp.podeExcluirCosignatario(titular, lotaTitular,	doc.getMobilGeral(), movCossig));
+		}
 		this.forma = doc.getExFormaDocumento() != null ? doc.getExFormaDocumento().getDescricao() : "";
 		this.modelo = doc.getExModelo() != null ? doc.getExModelo().getNmMod() : "";
 
@@ -169,7 +166,7 @@ public class ExDocumentoSigaLeVO extends ExVO {
 
 			for (ExMobil m : mobsDoc) {
 				if (mob.isGeral() || m.isGeral() || mob.getId().equals(m.getId()))
-					mobs.add(new ExMobilVO(m, cadastrante, titular, lotaTitular, completo));
+					mobs.add(new ExMobilApiVO(m, cadastrante, titular, lotaTitular, completo));
 			}
 
 			addAcoes(doc, titular, lotaTitular, exibirAntigo);
@@ -211,13 +208,13 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		// if (doc.getDocumentosPublicadosNoBoletim() != null) {
 		// for (ExDocumento documentoPublicado : doc
 		// .getDocumentosPublicadosNoBoletim()) {
-		// documentosPublicados.add(new ExDocumentoVO(documentoPublicado));
+		// documentosPublicados.add(new ExDocumentoApiVO(documentoPublicado));
 		// }
 		// }
 		//
 		// ExDocumento bol = doc.getBoletimEmQueDocFoiPublicado();
 		// if (bol != null)
-		// boletim = new ExDocumentoVO(bol);
+		// boletim = new ExDocumentoApiVO(bol);
 
 		this.originalNumero = doc.getNumExtDoc();
 		this.originalData = doc.getDtDocOriginalDDMMYYYY();
@@ -263,13 +260,13 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		marcasGeralPermitidas.add(CpMarcador.MARCADOR_TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO);
 		marcasGeralPermitidas.add(CpMarcador.MARCADOR_PENDENTE_DE_ANEXACAO);
 
-		for (ExMobilVO mobVO : mobs) {
+		for (ExMobilApiVO mobVO : mobs) {
 
 			// Limpa as Movimentações
-			List<ExMovimentacaoVO> movimentacoesFinais = new ArrayList<ExMovimentacaoVO>();
-			List<ExMovimentacaoVO> juntadasRevertidas = new ArrayList<ExMovimentacaoVO>();
+			List<ExMovimentacaoApiVO> movimentacoesFinais = new ArrayList<ExMovimentacaoApiVO>();
+			List<ExMovimentacaoApiVO> juntadasRevertidas = new ArrayList<ExMovimentacaoApiVO>();
 
-			for (ExMovimentacaoVO exMovVO : mobVO.getMovs()) {
+			for (ExMovimentacaoApiVO exMovVO : mobVO.getMovs()) {
 				if (!exMovVO.isCancelada() && movimentacoesPermitidas.contains(exMovVO.getIdTpMov())) {
 
 					// Desabilitado temporariamente
@@ -292,10 +289,10 @@ public class ExDocumentoSigaLeVO extends ExVO {
 			mobVO.setMovs(movimentacoesFinais);
 		}
 
-		ExMobilVO mobilGeral = null;
-		ExMobilVO mobilEspecifico = null;
+		ExMobilApiVO mobilGeral = null;
+		ExMobilApiVO mobilEspecifico = null;
 
-		for (ExMobilVO mobilVO : mobs) {
+		for (ExMobilApiVO mobilVO : mobs) {
 			if (mobilVO.isGeral)
 				mobilGeral = mobilVO;
 			else
@@ -303,27 +300,24 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		}
 
 		// MarcasPorMobil
-		for (ExMobil cadaMobil : doc.getExMobilSet()) {
-			// if (!cadaMobil.isGeral())
-				marcasPorMobil.put(cadaMobil, cadaMobil.getExMarcaSet());
-		}
-
-		if (mobilEspecifico != null && mobilGeral != null) {
-			mobilEspecifico.getAcoes().addAll(mobilGeral.getAcoes());
-			mobilEspecifico.getMovs().addAll(mobilGeral.getMovs());
-			mobilEspecifico.anexosNaoAssinados
-					.addAll(mobilGeral.anexosNaoAssinados);
-			for (ExMarca m : mobilGeral.getMarcasAtivas())
-				if (marcasGeralPermitidas.contains(m.getCpMarcador()
-						.getIdMarcador()))
-					mobilEspecifico.getMarcasAtivas().add(m);
+//		for (ExMobil cadaMobil : doc.getExMobilSet()) {
+//			if (!cadaMobil.isGeral())
+//				marcasPorMobil.put(cadaMobil, cadaMobil.getExMarcaSet());
+//		}
+//
+//		if (mobilEspecifico != null && mobilGeral != null) {
+//			mobilEspecifico.getAcoes().addAll(mobilGeral.getAcoes());
+//			mobilEspecifico.getMovs().addAll(mobilGeral.getMovs());
+//			mobilEspecifico.anexosNaoAssinados.addAll(mobilGeral.anexosNaoAssinados);
+//			for (ExMarca m : mobilGeral.getMarcasAtivas())
+//				if (marcasGeralPermitidas.contains(m.getCpMarcador().getIdMarcador()))
+//					mobilEspecifico.getMarcasAtivas().add(m);
 //			for (ExMarca m : mobilGeral.getMob().getExMarcaSet())
-//				if (marcasGeralPermitidas.contains(m.getCpMarcador()
-//						.getIdMarcador()))
+//				if (marcasGeralPermitidas.contains(m.getCpMarcador().getIdMarcador()))
 //					for (ExMobil cadaMobil : marcasPorMobil.keySet())
 //						marcasPorMobil.get(cadaMobil).add(m);
-			mobs.remove(mobilGeral);
-		}
+//			mobs.remove(mobilGeral);
+//		}
 //
 //		// Edson: mostra lista de vias/volumes só se número de
 //		// vias/volumes além do geral for > que 1 ou se o móbil
@@ -339,8 +333,8 @@ public class ExDocumentoSigaLeVO extends ExVO {
 	 * @throws Exception
 	 */
 	private void addAcoes(ExDocumento doc, DpPessoa titular, DpLotacao lotaTitular, boolean exibirAntigo) {
-		ExVO vo = this;
-		for (ExMobilVO mobvo : mobs) {
+		ExApiVO vo = this;
+		for (ExMobilApiVO mobvo : mobs) {
 			if (mobvo.isGeral)
 				vo = mobvo;
 		}
@@ -510,7 +504,7 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		return dtFinalizacao;
 	}
 
-	public List<ExMobilVO> getMobs() {
+	public List<ExMobilApiVO> getMobs() {
 		return mobs;
 	}
 
@@ -567,7 +561,7 @@ public class ExDocumentoSigaLeVO extends ExVO {
 	@Override
 	public String toString() {
 		String s = getSigla() + "[" + getAcoes() + "]";
-		for (ExMobilVO m : getMobs()) {
+		for (ExMobilApiVO m : getMobs()) {
 			s += "\n" + m.toString();
 		}
 		return s;
@@ -617,30 +611,31 @@ public class ExDocumentoSigaLeVO extends ExVO {
 		return outrosMobsLabel;
 	}
 
-	public List<ExDocumentoVO> getDocumentosPublicados() {
+	public List<ExDocumentoApiVO> getDocumentosPublicados() {
 		return documentosPublicados;
 	}
 
-	public ExDocumentoVO getBoletim() {
+	public ExDocumentoApiVO getBoletim() {
 		return boletim;
 	}
 
 	// Desabilitado temporariamente
-	 public Map<ExMobil, Set<ExMarca>> getMarcasPorMobil() {
-		 return marcasPorMobil;
-	 }
-	
-	 public void setMarcasPorMobil(Map<ExMobil, Set<ExMarca>> marcasPorMobil) {
-		 this.marcasPorMobil = marcasPorMobil;
-	 }
+	// public Map<ExMobil, Set<ExMarca>> getMarcasPorMobil() {
+	// return marcasPorMobil;
+	// }
+	//
+	// public void setMarcasPorMobil(Map<ExMobil, Set<ExMarca>> marcasPorMobil)
+	// {
+	// this.marcasPorMobil = marcasPorMobil;
+	// }
 
-	/*public Map<ExMovimentacao, Boolean> getCossignatarios() {
+	public Map<ExMovimentacaoApiVO, Boolean> getCossignatarios() {
 		return cossignatarios;
 	}
 
-	public void setCossignatarios(Map<ExMovimentacao, Boolean> cossignatarios) {
+	public void setCossignatarios(Map<ExMovimentacaoApiVO, Boolean> cossignatarios) {
 		this.cossignatarios = cossignatarios;
-	}*/
+	}
 
 	public String getOriginalNumero() {
 		return originalNumero;

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMobilApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMobilApiVO.java
@@ -1,0 +1,607 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.jboss.logging.Logger;
+
+import br.gov.jfrj.siga.base.SigaCalendar;
+import br.gov.jfrj.siga.dp.CpMarcador;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMarca;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExParte;
+
+public class ExMobilApiVO extends ExApiVO {
+	String sigla;
+	boolean isGeral;
+	List<ExMobilApiVO> apensos = new ArrayList<ExMobilApiVO>();
+	// List<ExDocumentoApiVO> filhos = new ArrayList<ExDocumentoApiVO>();
+	List<ExDocumentoApiVO> expedientesFilhosNaoCancelados = new ArrayList<ExDocumentoApiVO>();
+	List<ExDocumentoApiVO> processosFilhosNaoCancelados = new ArrayList<ExDocumentoApiVO>();
+
+	List<ExMovimentacaoApiVO> anexosNaoAssinados = new ArrayList<ExMovimentacaoApiVO>();
+	List<ExMovimentacaoApiVO> despachosNaoAssinados = new ArrayList<ExMovimentacaoApiVO>();
+	List<ExDocumentoApiVO> expedientesFilhosNaoJuntados = new ArrayList<ExDocumentoApiVO>();
+	List<ExMobilApiVO> expedientesJuntadosNaoAssinados = new ArrayList<ExMobilApiVO>();
+	List<ExMovimentacaoApiVO> pendenciasDeAnexacao = new ArrayList<ExMovimentacaoApiVO>();
+	List<ExMovimentacaoApiVO> pendenciasDeColaboracao = new ArrayList<ExMovimentacaoApiVO>();
+	Long pendenciaProximoModelo = null;
+
+	List<ExMovimentacaoApiVO> movs = new ArrayList<ExMovimentacaoApiVO>();
+	// Desabilitado temporariamente
+	// List<ExMarca> marcasAtivas = new ArrayList<ExMarca>();
+	List<DuracaoApiVO> duracoes = new ArrayList<DuracaoApiVO>();
+	Long byteCount;
+	Integer pagInicial;
+	Integer pagFinal;
+	String tamanhoDeArquivo;
+	boolean ocultar;
+	Long id;
+	boolean podeTramitar;
+	boolean podeAnotar;
+	String marcadoresEmHtml;
+	String descricaoCompleta;
+
+
+	public List<ExMovimentacaoApiVO> getMovs() {
+		return movs;
+	}
+
+	public void setMovs(List<ExMovimentacaoApiVO> movs) {
+		this.movs = movs;
+	}
+
+	// Desabilitado temporariamente
+	// public List<ExMarca> getMarcasAtivas() {
+	// return marcasAtivas;
+	// }
+	//
+	// public void setMarcasAtivas(List<ExMarca> marcasAtivas) {
+	// this.marcasAtivas = marcasAtivas;
+	// }
+
+	public ExMobilApiVO(ExMobil mob, DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular, boolean completo) {
+		this(mob, cadastrante, titular, lotaTitular, completo, null, false);
+	}
+
+	public ExMobilApiVO(ExMobil mob, DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular, boolean completo,
+			Long tpMov, boolean movAssinada) {
+		this.sigla = mob.getSigla();
+		this.isGeral = mob.isGeral();
+		this.id = mob.getId();
+
+		this.podeTramitar = Ex.getInstance().getComp().podeTransferir(titular, lotaTitular, mob);
+		this.podeAnotar = Ex.getInstance().getComp().podeFazerAnotacao(titular, lotaTitular, mob);
+
+		if (!completo || mob.isEliminado())
+			return;
+
+		long tempoIni = System.currentTimeMillis();
+
+		Set<ExMarca> marcasAtivas = new TreeSet<>();
+		marcasAtivas.addAll(mob.getExMarcaSetAtivas());
+
+		marcadoresEmHtml = getMarcadoresEmHtml(marcasAtivas, titular, lotaTitular);
+		descricaoCompleta = mob.getDescricaoCompleta();
+
+		/*
+		 * Markenson: O código abaixo foi comentado por questões de desempenho.
+		 * Deve ser estudada uma maneira mais eficiente de calcular o tamanho
+		 * dos PDFs
+		 */
+
+		// byteCount, pagIni e pagFim
+		// if (mob.getExDocumento().isEletronico()){
+
+		// byteCount = mob.getByteCount();
+		// if (byteCount != null && byteCount > 0)
+		// tamanhoDeArquivo = FormataTamanhoDeArquivo
+		// .converterEmTexto(byteCount);
+		// }
+
+		for (ExMobil m : mob.getApensosExcetoVolumeApensadoAoProximo()) {
+			if (m.isEliminado())
+				continue;
+			apensos.add(new ExMobilApiVO(m, cadastrante, titular, lotaTitular, false));
+		}
+
+		tempoIni = System.currentTimeMillis();
+		for (ExDocumento d : mob.getExDocumentoFilhoSet()) {
+			if (d.isExpediente())
+				expedientesFilhosNaoCancelados
+						.add(new ExDocumentoApiVO(d, null, cadastrante, titular, lotaTitular, false, false));
+			else
+				processosFilhosNaoCancelados
+						.add(new ExDocumentoApiVO(d, null, cadastrante, titular, lotaTitular, false, false));
+		}
+
+		for (ExDocumento doc : mob.getDocsFilhosNaoJuntados())
+			expedientesFilhosNaoJuntados
+					.add(new ExDocumentoApiVO(doc, null, cadastrante, titular, lotaTitular, false, false));
+
+
+
+		tempoIni = System.currentTimeMillis();
+		addAcoes(mob, titular, lotaTitular);
+
+		tempoIni = System.currentTimeMillis();
+
+		if (tpMov == null)
+			for (ExMovimentacao mov : mob.getCronologiaSet()) {
+				if (mov.getExMobil() != mob
+						&& mov.getExTipoMovimentacao().getId().equals(ExTipoMovimentacao.TIPO_MOVIMENTACAO_COPIA))
+					continue;
+				movs.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+			}
+		else
+			for (ExMovimentacao mov : mob.getMovimentacoesPorTipo(tpMov)) {
+				if (!movAssinada) {
+					if (!mov.isAssinada() && !mov.isCancelada())
+						movs.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+				} else {
+					if (mov.isAssinada())
+						movs.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+				}
+			}
+
+		// Edson: infelizmente, aí embaixo estamos varrendo de novo as movs.
+		// Melhorar?
+
+		if (mob.doc().isEletronico()) {
+			for (ExMovimentacao mov : mob.getAnexosNaoAssinados())
+				anexosNaoAssinados.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+
+			for (ExMobil juntado : mob.getJuntados())
+				if (juntado.doc().isPendenteDeAssinatura())
+					expedientesJuntadosNaoAssinados
+							.add(new ExMobilApiVO(juntado, cadastrante, titular, lotaTitular, false));
+
+			for (ExMovimentacao mov : mob.getDespachosNaoAssinados())
+				despachosNaoAssinados.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+		}
+
+		if (mob.getPendenciasDeAnexacao() != null) {
+			for (ExMovimentacao mov : mob.getPendenciasDeAnexacao())
+				pendenciasDeAnexacao.add(new ExMovimentacaoApiVO(this, mov, cadastrante, titular, lotaTitular));
+		}
+
+		if (mob.getPendenciasDeColaboracao() != null) {
+			for (ExMovimentacao mov : mob.getPendenciasDeColaboracao()) {
+				ExMovimentacaoApiVO m = new ExMovimentacaoApiVO(this, mov, cadastrante, mov.getSubscritor(),
+						mov.getLotaSubscritor());
+				m.descricao = ExParte.create(mov.getDescrMov()).getString();
+				pendenciasDeColaboracao.add(m);
+			}
+		}
+
+		if (!mob.getExDocumento().isPendenteDeAssinatura()) {
+			if (mob.getExDocumento().getExFormaDocumento().getId() == 107L)
+				pendenciaProximoModelo = 110L;
+			else if (mob.getExDocumento().getExFormaDocumento().getId() == 110L)
+				pendenciaProximoModelo = 111L;
+			else if (mob.getExDocumento().getExFormaDocumento().getId() == 111L)
+				pendenciaProximoModelo = 112L;
+		}
+
+		// Desabilitado temporariamente
+		// marcasAtivas.addAll(mob.getExMarcaSetAtivas());
+
+		// Calcula o tempo que o documento ficou em cada uma das lotações por
+		// onde ele passou.
+		ExMovimentacaoApiVO movVOIni = null;
+		ExMovimentacaoApiVO movVOUlt = null;
+		int i = 1;
+		int duracaoSpan = 0;
+		Collections.reverse(movs);
+		for (ExMovimentacaoApiVO movVO : movs) {
+			if (movVOIni == null) {
+				movVOIni = movVO;
+			}
+			// if (movVO.idTpMov != 14 && !movVO.isCancelada())
+			duracaoSpan++;
+
+			if (i == movs.size()
+					|| (movVO.idTpMov == ExTipoMovimentacao.TIPO_MOVIMENTACAO_RECEBIMENTO && (!movVO.isCancelada()))) {
+				if (i == movs.size()) {
+					duracaoSpan++;
+				}
+				if (i == movs.size() || movVOUlt == null)
+					movVOUlt = movVO;
+				SigaCalendar lIni = new SigaCalendar(movVOIni.dtIniMov.getTime());
+				SigaCalendar lFim = new SigaCalendar(movVOUlt.dtIniMov.getTime());
+
+				DuracaoApiVO d = new DuracaoApiVO();
+				long l = lFim.getUnixDay() - lIni.getUnixDay();
+				if (l == 0) {
+					d.setDuracao(lIni.diffCompact(lFim));
+					if (d.getDuracao().endsWith("m"))
+						d.setDuracao(d.getDuracao() + "in");
+				} else {
+					d.setDuracao(Long.toString(l) + " dia" + (l == 1L ? "" : "s"));
+				}
+				// movVOUlt.duracaoSpan = duracaoSpan;
+				d.setSpan(duracaoSpan);
+				d.setSpanExibirCompleto(duracaoSpan);
+				duracoes.add(d);
+				movVOIni = movVOUlt;
+				duracaoSpan = 0;
+			}
+			i++;
+			movVOUlt = movVO;
+		}
+		Collections.reverse(movs);
+		Collections.reverse(duracoes);
+
+		int j = 0;
+		int span = 0;
+		for (ExMovimentacaoApiVO movVO : movs) {
+			span++;
+			if (movVO.idTpMov == 14 || movVO.isCancelada()) {
+				duracoes.get(j).setSpan(duracoes.get(j).getSpan() - 1);
+			}
+			if (span == duracoes.get(j).getSpanExibirCompleto()) {
+				j++;
+				span = 0;
+			}
+		}
+
+		// Ocultar movimentações de cancelamento
+		j = 0;
+		span = 0;
+		for (ExMovimentacaoApiVO movVO : movs) {
+			if (movVO.idTpMov != 14 && !movVO.isCancelada()) {
+				if (span == 0) {
+					movVO.duracao = duracoes.get(j).getDuracao();
+					movVO.duracaoSpan = duracoes.get(j).getSpan();
+					span = duracoes.get(j).getSpan();
+					j++;
+				}
+				span--;
+			}
+		}
+
+		// Exibir completo
+		j = 0;
+		span = 0;
+		for (ExMovimentacaoApiVO movVO : movs) {
+			if (span == 0) {
+				movVO.duracao = duracoes.get(j).getDuracao();
+				movVO.duracaoSpanExibirCompleto = duracoes.get(j).getSpanExibirCompleto();
+				span = duracoes.get(j).getSpanExibirCompleto();
+				j++;
+			}
+			span--;
+		}
+
+
+	}
+
+	/**
+	 * @param mob
+	 * @param titular
+	 * @param lotaTitular
+	 * @throws Exception
+	 */
+	private void addAcoes(ExMobil mob, DpPessoa titular, DpLotacao lotaTitular) {
+		if (!mob.isGeral()) {
+			addAcao("folder", "_Ver Dossiê", "/app/expediente/doc", "exibirProcesso",
+					Ex.getInstance().getComp().podeVisualizarImpressao(titular, lotaTitular, mob), null, null, null,
+					null, "once");
+
+			addAcao("printer", "Ver _Impressão", "/app/arquivo", "exibir",
+					Ex.getInstance().getComp().podeVisualizarImpressao(titular, lotaTitular, mob), null,
+					"&popup=true&arquivo=" + mob.getReferenciaPDF(), null, null, null);
+
+			addAcao("page_white_add", "Incluir _Documento", "/app/expediente/doc", "editar",
+					Ex.getInstance().getComp().podeIncluirDocumento(titular, lotaTitular, mob), null,
+					"criandoAnexo=true&mobilPaiSel.sigla=" + getSigla(), null, null, null);
+
+			if (mob.temAnexos()) {
+				addAcao("script_key", "Assinar Anexos " + (mob.isVia() ? "da Via" : "do Volume"), "/app/expediente/mov",
+						"assinarAnexos", true, null, "assinandoAnexosGeral=true&sigla=" + getSigla(), null, null, null);
+			}
+		}
+		addAcao("page_white_error", "Desentranhar", "/app/expediente/mov", "cancelar_juntada",
+				Ex.getInstance().getComp().podeCancelarJuntada(titular, lotaTitular, mob), null, null, null, null,
+				"once");
+
+		addAcao("link_delete", "Desapensar", "/app/expediente/mov", "desapensar",
+				Ex.getInstance().getComp().podeDesapensar(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		addAcao("email_open", "Receber", "/app/expediente/mov", "receber",
+				Ex.getInstance().getComp().podeReceber(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		addAcao("email_go", "_Tramitar", "/app/expediente/mov", "transferir",
+				Ex.getInstance().getComp().podeTransferir(titular, lotaTitular, mob));
+
+		if (mob.isVia() || mob.isVolume()) {
+			addAcao("attach", "Ane_xar", "/app/expediente/mov", "anexar",
+					Ex.getInstance().getComp().podeAnexarArquivo(titular, lotaTitular, mob));
+			addAcao("note_add", "_Anotar", "/app/expediente/mov", "anotar",
+					Ex.getInstance().getComp().podeFazerAnotacao(titular, lotaTitular, mob));
+			addAcao("page_white_copy", "Incluir _Cópia", "/app/expediente/mov", "copiar",
+					Ex.getInstance().getComp().podeCopiar(titular, lotaTitular, mob));
+		}
+
+		addAcao("box_add", "Ar_q. Corrente", "/app/expediente/mov", "arquivar_corrente_gravar",
+				Ex.getInstance().getComp().podeArquivarCorrente(titular, lotaTitular, mob), null, null, null, null,
+				"once");
+
+		addAcao("building_go", "Indicar para Guarda Permanente", "/app/expediente/mov", "indicar_permanente",
+				Ex.getInstance().getComp().podeIndicarPermanente(titular, lotaTitular, mob));
+
+		addAcao("buildinge_delete", "Reverter Ind. Guarda Permanente", "/app/expediente/mov",
+				"reverter_indicacao_permanente",
+				Ex.getInstance().getComp().podeReverterIndicacaoPermanente(titular, lotaTitular, mob));
+
+		addAcao("page_red", "Retirar de Edital de Eliminação", "/app/expediente/mov", "retirar_de_edital_eliminacao",
+				Ex.getInstance().getComp().podeRetirarDeEditalEliminacao(titular, lotaTitular, mob));
+
+		addAcao("table_edit", "Reclassificar", "/app/expediente/mov", "reclassificar",
+				Ex.getInstance().getComp().podeReclassificar(titular, lotaTitular, mob));
+
+		addAcao("table", "Avaliar", "/app/expediente/mov", "avaliar",
+				Ex.getInstance().getComp().podeAvaliar(titular, lotaTitular, mob));
+
+		addAcao("hourglass_add", "So_brestar", "/app/expediente/mov", "sobrestar_gravar",
+				Ex.getInstance().getComp().podeSobrestar(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		addAcao("building_add", "Recolher ao Arq. Permanente", "/app/expediente/mov", "arquivar_permanente_gravar",
+				Ex.getInstance().getComp().podeBotaoArquivarPermanente(titular, lotaTitular, mob), null, null, null,
+				null, "once");
+
+		addAcao("package_add", "Arq. Intermediário", "/app/expediente/mov", "arquivar_intermediario",
+				Ex.getInstance().getComp().podeBotaoArquivarIntermediario(titular, lotaTitular, mob), null, null, null,
+				null, "once");
+
+		addAcao("box_delete", "Desar_q. Corrente", "/app/expediente/mov", "reabrir_gravar",
+				Ex.getInstance().getComp().podeDesarquivarCorrente(titular, lotaTitular, mob), null, null, null, null,
+				"once");
+
+		addAcao("package_delete", "Desarq. Intermediário", "/app/expediente/mov", "desarquivar_intermediario_gravar",
+				Ex.getInstance().getComp().podeBotaoDesarquivarIntermediario(titular, lotaTitular, mob), null, null,
+				null, null, "once");
+
+		addAcao("hourglass_delete", "Deso_brestar", "/app/expediente/mov", "desobrestar_gravar",
+				Ex.getInstance().getComp().podeDesobrestar(titular, lotaTitular, mob), null, null, null, null, "once");
+
+		addAcao("page_white_go", "_Juntar", "/app/expediente/mov", "juntar",
+				Ex.getInstance().getComp().podeJuntar(titular, lotaTitular, mob));
+
+		addAcao("page_find", "Vi_ncular", "/app/expediente/mov", "referenciar",
+				Ex.getInstance().getComp().podeReferenciar(titular, lotaTitular, mob));
+
+		addAcao("link_add", "Apensar", "/app/expediente/mov", "apensar",
+				Ex.getInstance().getComp().podeApensar(titular, lotaTitular, mob));
+
+		// Não aparece a opção de Cancelar Movimentação para documentos
+		// temporários
+		if (mob.getExDocumento().isFinalizado() && mob.getUltimaMovimentacaoNaoCancelada() != null
+				&& mob.getUltimaMovimentacaoNaoCancelada().getExTipoMovimentacao()
+						.getIdTpMov() != ExTipoMovimentacao.TIPO_MOVIMENTACAO_INCLUSAO_DE_COSIGNATARIO
+				&& mob.getUltimaMovimentacaoNaoCancelada().getExTipoMovimentacao()
+						.getIdTpMov() != ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONTROLE_DE_COLABORACAO)
+			addAcao("arrow_undo", "Desfa_zer " + mob.getDescricaoUltimaMovimentacaoNaoCancelada(),
+					"/app/expediente/mov", "cancelarMovimentacao",
+					Ex.getInstance().getComp().podeCancelarMovimentacao(titular, lotaTitular, mob),
+					"Confirma o cancelamento da última movimentação(" + mob.getDescricaoUltimaMovimentacaoNaoCancelada()
+							+ ")?",
+					null, null, null, "once"); // popup,
+		// exibir+completo,
+		// confirmacao
+
+		addAcao("folder_page_white", "Encerrar Volume", "/app/expediente/mov", "encerrar_volume",
+				Ex.getInstance().getComp().podeEncerrarVolume(titular, lotaTitular, mob),
+				"Confirma o encerramento do volume?", null, null, null, "once");
+
+		addAcao("cancel", "Cancelar Via", "/app/expediente/mov", "cancelarMovimentacao",
+				Ex.getInstance().getComp().podeCancelarVia(titular, lotaTitular, mob),
+				"Confirma o cancelamento da via?", null, null, null, "once");
+
+		addAcao("page_white_get", "Autuar", "/app/expediente/doc", "editar",
+				Ex.getInstance().getComp().podeAutuar(titular, lotaTitular, mob), null,
+				"idMobilAutuado=" + mob.getId() + "&autuando=true", null, null, null);
+	}
+
+	public String getMarcadoresEmHtml(Set<ExMarca> marcasAtivas, DpPessoa pess, DpLotacao lota) {
+		StringBuilder sb = new StringBuilder();
+
+		if (pess != null && lota != null) {
+			// Marcacoes para a propria lotacao e para a propria pessoa ou sem
+			// informacao de pessoa
+			//
+			for (ExMarca mar : marcasAtivas) {
+				if (mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO_ELETRONICO
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_DOCUMENTO_ASSINADO_COM_SENHA
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_ASSINADA_COM_SENHA
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_CONFERIDA_COM_SENHA
+						&& ((mar.getDpLotacaoIni() != null
+								&& lota.getIdInicial().equals(mar.getDpLotacaoIni().getIdInicial()))
+								|| mar.getDpLotacaoIni() == null)
+						&& (mar.getDpPessoaIni() == null
+								|| pess.getIdInicial().equals(mar.getDpPessoaIni().getIdInicial()))) {
+					if (sb.length() > 0)
+						sb.append(", ");
+					sb.append(mar.getCpMarcador().getDescrMarcador());
+				}
+			}
+
+			// Marcacoes para a propria lotacao e para outra pessoa
+			//
+			if (sb.length() == 0) {
+				for (ExMarca mar : marcasAtivas) {
+					if (mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO
+							&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO_ELETRONICO
+							&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_DOCUMENTO_ASSINADO_COM_SENHA
+							&& mar.getCpMarcador()
+									.getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_ASSINADA_COM_SENHA
+							&& mar.getCpMarcador()
+									.getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_CONFERIDA_COM_SENHA) {
+						if (sb.length() > 0)
+							sb.append(", ");
+						if ((mar.getDpLotacaoIni() != null
+								&& lota.getIdInicial().equals(mar.getDpLotacaoIni().getIdInicial()))
+								&& (mar.getDpPessoaIni() != null
+										&& !pess.getIdInicial().equals(mar.getDpPessoaIni().getIdInicial()))) {
+							sb.append(mar.getCpMarcador().getDescrMarcador());
+							sb.append(" [<span title=\"");
+							sb.append(mar.getDpPessoaIni().getNomePessoa());
+							sb.append("\">");
+							sb.append(mar.getDpPessoaIni().getSigla());
+							sb.append("</span>]");
+						}
+					}
+				}
+			}
+		}
+
+		// Marcacoes para qualquer outra pessoa ou lotacao
+		//
+		if (sb.length() == 0) {
+			for (ExMarca mar : marcasAtivas) {
+				if (mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_EM_TRANSITO_ELETRONICO
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_DOCUMENTO_ASSINADO_COM_SENHA
+						&& mar.getCpMarcador().getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_ASSINADA_COM_SENHA
+						&& mar.getCpMarcador()
+								.getIdMarcador() != CpMarcador.MARCADOR_MOVIMENTACAO_CONFERIDA_COM_SENHA) {
+					if (sb.length() > 0)
+						sb.append(", ");
+					sb.append(mar.getCpMarcador().getDescrMarcador());
+					if (mar.getDpLotacaoIni() != null || mar.getDpPessoaIni() != null) {
+						sb.append(" [");
+						if (mar.getDpLotacaoIni() != null) {
+							sb.append(mar.getDpLotacaoIni().getLotacaoAtual().getSigla());
+						}
+						if (mar.getDpPessoaIni() != null) {
+							if (mar.getDpLotacaoIni() != null) {
+								sb.append(", ");
+							}
+							sb.append(" [<span title=\"");
+							sb.append(mar.getDpPessoaIni().getNomePessoa());
+							sb.append("\">");
+							sb.append(mar.getDpPessoaIni().getSigla());
+							sb.append("</span>]");
+						}
+						sb.append("]");
+					}
+				}
+			}
+		}
+		if (sb.length() == 0)
+			return null;
+		return sb.toString();
+	}
+
+	public String getSigla() {
+		return sigla;
+	}
+
+	public List getApensos() {
+		return apensos;
+	}
+
+	/*
+	 * public List getFilhos() { return filhos; }
+	 */
+
+	public List getExpedientesFilhosNaoCancelados() {
+		return expedientesFilhosNaoCancelados;
+	}
+
+	public List getAnexosNaoAssinados() {
+		return anexosNaoAssinados;
+	}
+
+	public List getDespachosNaoAssinados() {
+		return despachosNaoAssinados;
+	}
+
+	public List getExpedientesFilhosNaoJuntados() {
+		return expedientesFilhosNaoJuntados;
+	}
+
+	public List getProcessosFilhosNaoCancelados() {
+		return processosFilhosNaoCancelados;
+	}
+
+	public List<ExMobilApiVO> getExpedientesJuntadosNaoAssinados() {
+		return expedientesJuntadosNaoAssinados;
+	}
+
+	public List<ExMovimentacaoApiVO> getPendenciasDeAnexacao() {
+		return pendenciasDeAnexacao;
+	}
+
+	public List<ExMovimentacaoApiVO> getPendenciasDeColaboracao() {
+		return pendenciasDeColaboracao;
+	}
+
+	@Override
+	public String toString() {
+		return getSigla() + "[" + getAcoes() + "] ";
+	}
+
+	public List<DuracaoApiVO> getDuracoes() {
+		return duracoes;
+	}
+
+	public void setDuracoes(List<DuracaoApiVO> duracoes) {
+		this.duracoes = duracoes;
+	}
+
+	public Long getByteCount() {
+		return byteCount;
+	}
+
+	public Integer getPagInicial() {
+		return pagInicial;
+	}
+
+	public Integer getPagFinal() {
+		return pagFinal;
+	}
+
+	public String getTamanhoDeArquivo() {
+		return tamanhoDeArquivo;
+	}
+
+	public Long getPendenciaProximoModelo() {
+		return pendenciaProximoModelo;
+	}
+
+	public boolean isPendencias() {
+		return anexosNaoAssinados.size() > 0 || despachosNaoAssinados.size() > 0
+				|| expedientesFilhosNaoJuntados.size() > 0 || expedientesJuntadosNaoAssinados.size() > 0
+				|| pendenciasDeAnexacao.size() > 0 || pendenciasDeColaboracao.size() > 0
+				|| pendenciaProximoModelo != null;
+	}
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMovimentacaoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMovimentacaoApiVO.java
@@ -1,0 +1,561 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANEXACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANOTACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_APENSACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ARQUIVAMENTO_CORRENTE;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ARQUIVAMENTO_INTERMEDIARIO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ARQUIVAMENTO_PERMANENTE;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_MOVIMENTACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_MOVIMENTACAO_COM_SENHA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_DE_MOVIMENTACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_COM_SENHA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_DOCUMENTO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_COPIA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESAPENSACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_INTERNO_TRANSFERENCIA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA_EXTERNA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ENCERRAMENTO_DE_VOLUME;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_INCLUSAO_EM_EDITAL_DE_ELIMINACAO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA_EXTERNO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_NOTIFICACAO_PUBL_BI;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_RECEBIMENTO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_RECEBIMENTO_TRANSITORIO;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_REFERENCIA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA_EXTERNA;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.ocpsoft.prettytime.PrettyTime;
+
+import com.auth0.jwt.JWTVerifier;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+
+public class ExMovimentacaoApiVO extends ExApiVO {
+	private static final String JWT_FIXED_HEADER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.";
+	private static final String JWT_FIXED_HEADER_REPLACEMENT = "!";
+	String classe;
+	boolean originadaAqui;
+	boolean desabilitada;
+	boolean cancelada;
+	String descricao;
+	long idTpMov;
+	String complemento;
+	Map<String, ExParteApiVO> parte = new TreeMap<String, ExParteApiVO>();
+	Date dtIniMov;
+	String dtRegMovDDMMYYHHMMSS;
+	String dtFimMovDDMMYYHHMMSS;
+	String descrTipoMovimentacao;
+	long idMov;
+	// ExMobilVO mobVO;
+	int duracaoSpan;
+	int duracaoSpanExibirCompleto;
+	String duracao;
+	String mimeType;
+	String lotaCadastranteSigla;
+	String exTipoMovimentacaoSigla;
+	String tempoRelativo;
+
+	public ExMovimentacaoApiVO(ExMobilApiVO mobVO, ExMovimentacao mov,
+			DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular) {
+		originadaAqui = (mov.getExMobil().getId().equals(mobVO.id));
+		idTpMov = mov.getExTipoMovimentacao().getIdTpMov();
+		dtIniMov = mov.getDtIniMov();
+
+		mimeType = (mov.getConteudoTpMov() == null) ? "" : mov
+				.getConteudoTpMov();
+
+		this.idMov = mov.getIdMov();
+		this.dtRegMovDDMMYYHHMMSS = mov.getDtRegMovDDMMYYHHMMSS();
+		this.tempoRelativo = calcularTempoRelativo(mov.getDtIniMov());
+		this.descrTipoMovimentacao = mov.getDescrTipoMovimentacao();
+		this.cancelada = mov.getExMovimentacaoCanceladora() != null;
+		this.lotaCadastranteSigla = mov.getLotaCadastrante().getSigla();
+		this.exTipoMovimentacaoSigla = mov.getExTipoMovimentacao().getSigla();
+
+		if (mov.getLotaCadastrante() != null)
+			parte.put("lotaCadastrante",
+					new ExParteApiVO(mov.getLotaCadastrante()));
+		if (mov.getCadastrante() != null)
+			parte.put("cadastrante", new ExParteApiVO(mov.getCadastrante()));
+		if (mov.getLotaSubscritor() != null)
+			parte.put("lotaSubscritor", new ExParteApiVO(mov.getLotaSubscritor()));
+		if (mov.getSubscritor() != null)
+			parte.put("subscritor", new ExParteApiVO(mov.getSubscritor()));
+		if (mov.getLotaResp() != null)
+			parte.put("lotaResp", new ExParteApiVO(mov.getLotaResp()));
+		if (mov.getResp() != null)
+			parte.put("resp", new ExParteApiVO(mov.getResp()));
+
+		descricao = mov.getObs();
+
+		addAcoes(mov, cadastrante, titular, lotaTitular);
+
+		calcularClasse(mov);
+
+		desabilitada = mov.getExMovimentacaoRef() != null
+				&& mov.getExMovimentacaoRef().isCancelada()
+				|| mov.getExMovimentacaoCanceladora() != null
+				|| mov.getIdTpMov().equals(
+						TIPO_MOVIMENTACAO_CANCELAMENTO_DE_MOVIMENTACAO);
+
+	}
+
+	/**
+	 * @param mov
+	 * @param titular
+	 * @param lotaTitular
+	 * @throws Exception
+	 */
+	private void addAcoes(ExMovimentacao mov, DpPessoa cadastrante,
+			DpPessoa titular, DpLotacao lotaTitular) {
+		if (complemento == null)
+			complemento = "";
+
+		if (idTpMov == TIPO_MOVIMENTACAO_COPIA) {
+			descricao = null;
+			String mensagemPos = null;
+
+			if (!mov.getExMobilRef()
+					.getExDocumento()
+					.getDescrDocumento()
+					.equals(mov.getExMobil().getExDocumento()
+							.getDescrDocumento()))
+				mensagemPos = " Descrição: "
+						+ mov.getExMobilRef().getExDocumento()
+								.getDescrDocumento();
+
+			addAcao(null, mov.getExMobilRef().getSigla(),
+					"/app/expediente/doc", "exibir", true, null, "sigla="
+							+ mov.getExMobilRef().getSigla(),
+					"Copia do documento: ", mensagemPos, null);
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_JUNTADA
+				|| idTpMov == TIPO_MOVIMENTACAO_JUNTADA_EXTERNO) {
+			descricao = null;
+			if (originadaAqui) {
+				if (mov.getExMobilRef() != null) {
+
+					String mensagemPos = null;
+
+					if (!mov.getExMobilRef()
+							.getExDocumento()
+							.getDescrDocumento()
+							.equals(mov.getExMobil().getExDocumento()
+									.getDescrDocumento()))
+						mensagemPos = " Descrição: "
+								+ mov.getExMobilRef().getExDocumento()
+										.getDescrDocumento();
+
+					addAcao(null, mov.getExMobilRef().getSigla(),
+							"/app/expediente/doc", "exibir", true, null,
+							"sigla=" + mov.getExMobilRef().getSigla(),
+							"Juntado ao documento: ", mensagemPos, null);
+				} else {
+					descricao = "Juntado ao documento: " + mov.getDescrMov();
+				}
+			} else {
+
+				String mensagemPos = null;
+
+				if (!mov.getExMobil()
+						.getExDocumento()
+						.getDescrDocumento()
+						.equals(mov.getExMobilRef().getExDocumento()
+								.getDescrDocumento()))
+					mensagemPos = " Descrição: "
+							+ mov.getExDocumento().getDescrDocumento();
+
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(),
+						"Documento juntado: ", mensagemPos, null);
+			}
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA) {
+			descricao = null;
+			if (originadaAqui) {
+				if (mov.getExMobilRef() != null) {
+
+					String mensagemPos = null;
+
+					if (!mov.getExMobilRef()
+							.getExDocumento()
+							.getDescrDocumento()
+							.equals(mov.getExMobil().getExDocumento()
+									.getDescrDocumento()))
+						mensagemPos = " Descrição: "
+								+ mov.getExMobilRef().getExDocumento()
+										.getDescrDocumento();
+
+					addAcao(null, mov.getExMobilRef().getSigla(),
+							"/app/expediente/doc", "exibir", true, null,
+							"sigla=" + mov.getExMobilRef().getSigla(),
+							"Desentranhado do documento: ", mensagemPos, null);
+				} else {
+					descricao = "Desentranhado do documento: "
+							+ mov.getDescrMov();
+				}
+			} else {
+
+				String mensagemPos = null;
+
+				if (!mov.getExMobil()
+						.getExDocumento()
+						.getDescrDocumento()
+						.equals(mov.getExMobilRef().getExDocumento()
+								.getDescrDocumento()))
+					mensagemPos = " Descrição: "
+							+ mov.getExDocumento().getDescrDocumento();
+
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(),
+						"Documento desentranhado: ", mensagemPos, null);
+			}
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_APENSACAO) {
+			descricao = null;
+			if (originadaAqui) {
+				addAcao(null, mov.getExMobilRef().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobilRef().getSigla(),
+						"Apensado ao documento: ", null, null);
+			} else {
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(),
+						"Documento apensado: ", null, null);
+			}
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_DESAPENSACAO) {
+			descricao = null;
+			if (originadaAqui) {
+				addAcao(null, mov.getExMobilRef().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobilRef().getSigla(),
+						"Desapensado do documento: ", null, null);
+			} else {
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(),
+						"Documento desapensado: ", null, null);
+			}
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_NOTIFICACAO_PUBL_BI) {
+			addAcao(null, mov.getExMobilRef().getSigla(),
+					"/app/expediente/doc", "exibir", true, null, "sigla="
+							+ mov.getExMobilRef().getSigla(),
+					"Publicado no Boletim Interno: ",
+					" em " + mov.getDtMovDDMMYY(), null);
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_REFERENCIA) {
+			descricao = null;
+			if (originadaAqui) {
+				addAcao(null, mov.getExMobilRef().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobilRef().getSigla(),
+						"Ver também: ", " Descrição: "
+								+ mov.getExMobilRef().getExDocumento()
+										.getDescrDocumento(), null);
+			} else {
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(), "Ver também: ",
+						" Descrição: "
+								+ mov.getExDocumento().getDescrDocumento(),
+						null);
+			}
+		}
+
+		if (idTpMov == TIPO_MOVIMENTACAO_INCLUSAO_EM_EDITAL_DE_ELIMINACAO) {
+			descricao = null;
+			if (originadaAqui) {
+				addAcao(null, mov.getExMobilRef().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobilRef().getSigla(), "", null,
+						null);
+			} else {
+				addAcao(null, mov.getExMobil().getSigla(),
+						"/app/expediente/doc", "exibir", true, null, "sigla="
+								+ mov.getExMobil().getSigla(), "", null, null);
+			}
+		}
+	}
+
+	/**
+	 * @param mov
+	 */
+	private void calcularClasse(ExMovimentacao mov) {
+		if (mov.getExMovimentacaoCanceladora() == null) {
+			if (originadaAqui) {
+				switch (mov.getExTipoMovimentacao().getIdTpMov().intValue()) {
+				case (int) TIPO_MOVIMENTACAO_ANEXACAO:
+					classe = "anexacao";
+					break;
+				case (int) TIPO_MOVIMENTACAO_NOTIFICACAO_PUBL_BI:
+					classe = "publicacao";
+					break;
+				case (int) TIPO_MOVIMENTACAO_ANOTACAO:
+					classe = "anotacao";
+					break;
+				}
+			}
+
+			switch (mov.getExTipoMovimentacao().getIdTpMov().intValue()) {
+			case (int) TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_MOVIMENTACAO:
+			case (int) TIPO_MOVIMENTACAO_ASSINATURA_MOVIMENTACAO_COM_SENHA:
+			case (int) TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_COM_SENHA:
+			case (int) TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_DOCUMENTO:
+				classe = "assinaturaMov";
+				break;
+
+			case (int) TIPO_MOVIMENTACAO_ARQUIVAMENTO_CORRENTE:
+			case (int) TIPO_MOVIMENTACAO_ARQUIVAMENTO_PERMANENTE:
+			case (int) TIPO_MOVIMENTACAO_ARQUIVAMENTO_INTERMEDIARIO:
+				classe = "arquivamento";
+				break;
+			case (int) TIPO_MOVIMENTACAO_COPIA:
+				classe = "copia";
+				break;
+			case (int) TIPO_MOVIMENTACAO_JUNTADA:
+				classe = "juntada";
+				break;
+			case (int) TIPO_MOVIMENTACAO_JUNTADA_EXTERNO:
+				classe = "juntada_externo";
+				break;
+			case (int) TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA:
+				classe = "desentranhamento";
+				break;
+			case (int) TIPO_MOVIMENTACAO_REFERENCIA:
+				classe = "vinculo";
+				break;
+			case (int) TIPO_MOVIMENTACAO_ENCERRAMENTO_DE_VOLUME:
+				classe = "encerramento_volume";
+				break;
+			case (int) TIPO_MOVIMENTACAO_APENSACAO:
+				classe = "apensacao";
+				break;
+			case (int) TIPO_MOVIMENTACAO_DESAPENSACAO:
+				classe = "desapensacao";
+				break;
+			case (int) TIPO_MOVIMENTACAO_DESPACHO:
+			case (int) TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA:
+			case (int) TIPO_MOVIMENTACAO_DESPACHO_INTERNO_TRANSFERENCIA:
+			case (int) TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA_EXTERNA:
+				classe = "despacho";
+				break;
+			case (int) TIPO_MOVIMENTACAO_TRANSFERENCIA:
+			case (int) TIPO_MOVIMENTACAO_TRANSFERENCIA_EXTERNA:
+			case (int) TIPO_MOVIMENTACAO_RECEBIMENTO_TRANSITORIO:
+				classe = "transferencia";
+				break;
+			case (int) TIPO_MOVIMENTACAO_RECEBIMENTO:
+				classe = "recebimento";
+				break;
+			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CRIACAO:
+				classe = "criacao";
+				break;
+			}
+		}
+	}
+
+	public String getDescricao() {
+		if (descricao != null) {
+			descricao = descricao.trim();
+			if (descricao.length() == 0)
+				return null;
+		}
+		return descricao;
+	}
+
+	public String getDisabled() {
+		if (desabilitada)
+			return "disabled";
+		return "";
+	}
+
+	public Object getDtRegMovDDMMYYHHMMSS() {
+		return dtRegMovDDMMYYHHMMSS;
+	}
+
+	public Object getDtRegMovDDMMYY() {
+		return dtRegMovDDMMYYHHMMSS.substring(0, 8);
+	}
+
+	public Object getDtFimMovDDMMYYHHMMSS() {
+		return dtFimMovDDMMYYHHMMSS;
+	}
+
+	public long getIdMov() {
+		return idMov;
+	}
+
+	public long getIdTpMov() {
+		return idTpMov;
+	}
+
+	public Map<String, ExParteApiVO> getParte() {
+		return parte;
+	}
+
+	public boolean isCancelada() {
+		return cancelada;
+	}
+
+	public boolean isDesabilitada() {
+		return desabilitada;
+	}
+
+	public boolean isOriginadaAqui() {
+		return originadaAqui;
+	}
+
+	public void setClasse(String classe) {
+		this.classe = classe;
+	}
+
+	public void setDesabilitada(boolean desabilitada) {
+		this.desabilitada = desabilitada;
+	}
+
+	public void setOriginadaAqui(boolean originadaAqui) {
+		this.originadaAqui = originadaAqui;
+	}
+
+	@Override
+	public String toString() {
+		return getIdMov() + " - " + descrTipoMovimentacao + " - "
+				+ getDescricao() + "[" + getAcoes() + "] " + getDisabled();
+	}
+
+	public boolean isImage() {
+		return mimeType.startsWith("image/");
+	}
+
+	public boolean isPDF() {
+		return mimeType.endsWith("/pdf");
+	}
+
+	public boolean isWord() {
+		return mimeType.endsWith("/msword")
+				|| mimeType.endsWith(".wordprocessingml.document");
+	}
+
+	public boolean isExcel() {
+		return mimeType.endsWith("/vnd.ms-excel")
+				|| mimeType.endsWith(".spreadsheetml.sheet");
+	}
+
+	public boolean isPresentation() {
+		return mimeType.endsWith("/vnd.ms-powerpoint")
+				|| mimeType.endsWith(".presentationml.presentation");
+	}
+
+	public String getIcon() {
+		if (isImage())
+			return "image";
+		if (isPDF())
+			return "page_white_acrobat";
+		if (isWord())
+			return "page_white_word";
+		if (isExcel())
+			return "page_white_excel";
+		if (isPresentation())
+			return "page_white_powerpoint";
+
+		return "page_white";
+	}
+
+	public static String getWebdavPassword() {
+		String pwd = null;
+		try {
+			pwd = System.getProperty("siga.ex.webdav.pwd");
+		} catch (Exception e) {
+			throw new AplicacaoException(
+					"Erro obtendo propriedade siga.ex.webdav.pwd", 0, e);
+		}
+		return pwd;
+	}
+
+	// public static Algorithm getWebdavJwtAlgorithm(String pwd) {
+	// Algorithm algorithm;
+	// try {
+	// algorithm = Algorithm.HMAC256(pwd);
+	// } catch (IllegalArgumentException | UnsupportedEncodingException e) {
+	// throw new AplicacaoException("Erro criando algoritmo", 0, e);
+	// }
+	// return algorithm;
+	// }
+
+	public static Map<String, Object> getWebdavDecodedToken(String token) {
+		final JWTVerifier verifier = new JWTVerifier(getWebdavPassword());
+		try {
+			Map<String, Object> map = verifier.verify(token.replace("~", ".")
+					.replace(JWT_FIXED_HEADER_REPLACEMENT, JWT_FIXED_HEADER));
+			String a[] = map.get("d").toString().split("\\|");
+			map.put("mob", a[0]);
+			map.put("cad", a[1]);
+			map.put("tit", a[2]);
+			map.put("lot", a[3]);
+			return map;
+		} catch (Exception e) {
+			throw new AplicacaoException("Erro ao verificar token JWT", 0, e);
+		}
+		// Algorithm algorithm = getWebdavJwtAlgorithm(getWebdavPassword());
+		// JWTVerifier verificador = JWT.require(algorithm).build();
+		// DecodedJWT jwt = verificador.verify(token.replace("$", "."));
+		// return jwt;
+	}
+	
+	private String calcularTempoRelativo(Date anterior) {
+		PrettyTime p = new PrettyTime(new Date(), new Locale("pt"));
+
+		String tempo = p.format(anterior);
+		tempo = tempo.replace(" atrás", "");
+		tempo = tempo.replace(" dias", " dias");
+		tempo = tempo.replace(" horas", "h");
+		tempo = tempo.replace(" minutos", "min");
+		tempo = tempo.replace(" segundos", "s");
+		tempo = tempo.replace("agora há pouco", "agora");
+		return tempo;
+	}
+
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExParteApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExParteApiVO.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2011 SJRJ.
+ * 
+ *     This file is part of SIGA.
+ * 
+ *     SIGA is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     SIGA is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package br.gov.jfrj.sigale.ex.vo;
+
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+
+public class ExParteApiVO {
+	String sigla;
+	String siglaAmpliada;
+	String descricao;
+	String descricaoAmpliada;
+	String iniciais;
+	String siglaOrgao;
+
+	public String getSigla() {
+		return sigla;
+	}
+
+	public String getSiglaAmpliada() {
+		return siglaAmpliada;
+	}
+
+	public String getDescricao() {
+		return descricao;
+	}
+
+	public String getDescricaoAmpliada() {
+		return descricaoAmpliada;
+	}
+
+	public String getIniciais() {
+		return iniciais;
+	}
+	
+	public String getSiglaOrgao() {
+		return siglaOrgao;
+	}
+
+	public String getNomeAbreviado() {
+		if (descricao == null)
+			return "";
+		String a[] = descricao.split(" ");
+
+		String nomeAbreviado = "";
+		for (String n : a) {
+			if (nomeAbreviado.length() == 0)
+				nomeAbreviado = n.substring(0, 1).toUpperCase()
+						+ n.substring(1).toLowerCase();
+			// else if (!"|DA|DE|DO|DAS|DOS|E|".contains("|" + n + "|"))
+			// nomeAbreviado += " " + n.substring(0, 1) + ".";
+		}
+		return nomeAbreviado;
+	}
+
+	public ExParteApiVO(DpLotacao lota) {
+		sigla = lota.getSigla();
+		siglaAmpliada = lota.getSiglaAmpliada();
+		descricao = lota.getDescricao();
+		descricaoAmpliada = lota.getDescricaoAmpliada();
+		iniciais = lota.getIniciais();
+		siglaOrgao = lota.getOrgaoUsuario().getSigla();
+	}
+
+	public ExParteApiVO(DpPessoa pess) {
+		sigla = pess.getSigla();
+		siglaAmpliada = pess.getSigla();
+		descricao = pess.getDescricao();
+		descricaoAmpliada = pess.getDescricao();
+		iniciais = pess.getIniciais();
+		siglaOrgao = pess.getOrgaoUsuario().getSigla();
+	}
+}

--- a/siga/src/main/webapp/WEB-INF/web.xml
+++ b/siga/src/main/webapp/WEB-INF/web.xml
@@ -124,6 +124,7 @@
 	<filter-mapping>
 		<filter-name>SigaFilter</filter-name>
 		<url-pattern>/servicos/*</url-pattern>
+		<url-pattern>/api/*</url-pattern>
 	</filter-mapping>
 
 	<filter>

--- a/sigaex/pom.xml
+++ b/sigaex/pom.xml
@@ -268,5 +268,12 @@
 			<scope>compile</scope>
 		</dependency>
 		
+		<!-- https://mvnrepository.com/artifact/joda-time/joda-time -->
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.9</version>
+		</dependency>
+		
 	</dependencies>
 </project>

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/AcessosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/AcessosGet.java
@@ -1,0 +1,41 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.gov.jfrj.siga.cp.CpAcesso;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessoItem;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessosGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessosGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IAcessosGet;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class AcessosGet implements IAcessosGet {
+
+	@Override
+	public void run(AcessosGetRequest req, AcessosGetResponse resp) throws Exception {
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		resp.list = new ArrayList<>();
+
+
+		DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+
+		List<CpAcesso> l = ExDao.getInstance().consultarAcessosRecentes(cadastrante);
+
+		for (CpAcesso a : l) {
+			AcessoItem ai = new AcessoItem();
+			ai.datahora = a.getDtInicio();
+			ai.ip = a.getAuditIP();
+			resp.list.add(ai);
+		}
+	}
+
+
+	@Override
+	public String getContext() {
+		return "listar acessos recentes";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/AcessosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/AcessosGet.java
@@ -9,19 +9,19 @@ import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessoItem;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessosGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.AcessosGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IAcessosGet;
-import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
 import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class AcessosGet implements IAcessosGet {
 
 	@Override
 	public void run(AcessosGetRequest req, AcessosGetResponse resp) throws Exception {
-		Usuario u = TokenCriarPost.assertUsuario();
+		SwaggerHelper.buscarEValidarUsuarioLogado();
+		SigaObjects so = SwaggerHelper.getSigaObjects();
 
 		resp.list = new ArrayList<>();
 
-
-		DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+		DpPessoa cadastrante = so.getCadastrante();
 
 		List<CpAcesso> l = ExDao.getInstance().consultarAcessosRecentes(cadastrante);
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ApiContext_Remover.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ApiContext_Remover.java
@@ -12,12 +12,12 @@ import br.gov.jfrj.siga.hibernate.ExStarter;
 import br.gov.jfrj.siga.model.ContextoPersistencia;
 import br.gov.jfrj.siga.model.dao.ModeloDao;
 
-public class ApiContext implements Closeable {
+public class ApiContext_Remover implements Closeable {
 	EntityManager em;
 	boolean transacional;
 	long inicio = System.currentTimeMillis();
 
-	public ApiContext(boolean transacional) {
+	public ApiContext_Remover(boolean transacional) { 
 		this.transacional = transacional;
 		em = ExStarter.emf.createEntityManager();
 		ContextoPersistencia.setEntityManager(em);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/CacheControlFilterCache.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/CacheControlFilterCache.java
@@ -1,0 +1,35 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class CacheControlFilterCache implements Filter {
+	static long expires = java.util.concurrent.TimeUnit.DAYS.toSeconds(30);
+
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletResponse resp = (HttpServletResponse) response;
+		resp.setHeader("Cache-Control", "public,max-age=" + expires + ",must-revalidate");
+		resp.setDateHeader("Expires",
+				System.currentTimeMillis() + java.util.concurrent.TimeUnit.SECONDS.toMillis(expires));
+		resp.setHeader("Pragma", "");
+
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void init(FilterConfig arg0) throws ServletException {
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/CacheControlFilterNoCache.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/CacheControlFilterNoCache.java
@@ -1,0 +1,36 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.IOException;
+import java.util.Date;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class CacheControlFilterNoCache implements Filter {
+
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+
+        HttpServletResponse resp = (HttpServletResponse) response;
+        resp.setHeader("Expires", "Tue, 03 Jul 2001 06:00:00 GMT");
+        resp.setDateHeader("Last-Modified", new Date().getTime());
+        resp.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0");
+        resp.setHeader("Pragma", "no-cache");
+
+        chain.doFilter(request, response);
+    }
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void init(FilterConfig arg0) throws ServletException {
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAnotarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAnotarPost.java
@@ -1,0 +1,69 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExPapel;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaAnotarPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaAnotarPostResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaAnotarPost;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class DocSiglaAnotarPost implements IDocSiglaAnotarPost {
+
+	@Override
+	public void run(DocSiglaAnotarPostRequest req,
+			DocSiglaAnotarPostResponse resp) throws Exception {
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		try {
+			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpLotacao lotaCadastrante = cadastrante.getLotacao();
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+
+			ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
+			flt.setSigla(req.sigla);
+			ExMobil mob = ExDao.getInstance().consultarPorSigla(flt);
+			ExDocumento doc = mob.doc();
+
+			Utils.assertAcesso(mob, titular, lotaTitular);
+
+			Ex.getInstance()
+					.getBL()
+					.anotar(cadastrante, lotaCadastrante, mob, null, null,
+							null, null, cadastrante, req.anotacao, null);
+			ExDao.commitTransacao();
+			resp.status = "OK";
+		} catch (Exception ex) {
+			ExDao.rollbackTransacao();
+		}
+	}
+
+
+	@Override
+	public String getContext() {
+		return "Anotar documento";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAnotarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAnotarPost.java
@@ -22,7 +22,6 @@ public class DocSiglaAnotarPost implements IDocSiglaAnotarPost {
 			DocSiglaAnotarPostResponse resp) throws Exception {
 		
 		SwaggerHelper.buscarEValidarUsuarioLogado();
-		ApiContext apiContext = new ApiContext(true);
 		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
 		
 		SigaObjects so = SwaggerHelper.getSigaObjects();
@@ -44,11 +43,9 @@ public class DocSiglaAnotarPost implements IDocSiglaAnotarPost {
 					.getBL()
 					.anotar(cadastrante, lotaCadastrante, mob, null, null,
 							null, null, cadastrante, req.anotacao, null);
-			apiContext.close();
 			resp.status = "OK";
 		} catch (Exception e) {
 			e.printStackTrace(System.out);
-			apiContext.rollback(e);
 			throw e;
 		}
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAssinarComSenhaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAssinarComSenhaPost.java
@@ -33,8 +33,6 @@ public class DocSiglaAssinarComSenhaPost implements IDocSiglaAssinarComSenhaPost
 		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
 
 		SwaggerHelper.buscarEValidarUsuarioLogado();
-		
-		ApiContext apiContext = new ApiContext(true);
 		SigaObjects so = SwaggerHelper.getSigaObjects();
 		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
@@ -60,11 +58,9 @@ public class DocSiglaAssinarComSenhaPost implements IDocSiglaAssinarComSenhaPost
 			Ex.getInstance().getBL().assinarDocumentoComSenha(cadastrante, lotaTitular, doc, null, cadastrante.getSiglaCompleta(), null,
 					false, titular, false, null, false);
 
-			apiContext.close();
 			resp.status = "OK";
 		} catch (Exception e) {
 			e.printStackTrace(System.out);
-			apiContext.rollback(e);
 			throw e;
 		}
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAssinarComSenhaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaAssinarComSenhaPost.java
@@ -1,0 +1,161 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+
+import com.crivano.swaggerservlet.PresentableUnloggedException;
+import com.crivano.swaggerservlet.SwaggerServlet;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExPapel;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaAssinarComSenhaPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaAssinarComSenhaPostResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaAssinarComSenhaPost;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+
+public class DocSiglaAssinarComSenhaPost implements IDocSiglaAssinarComSenhaPost {
+
+	@Override
+	public void run(DocSiglaAssinarComSenhaPostRequest req, DocSiglaAssinarComSenhaPostResponse resp) throws Exception {
+		// Necessário pois é chamado o método "realPath" durante a criação do
+		// PDF.
+		CurrentRequest.set(
+				new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+
+		try {
+			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+
+			ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
+			flt.setSigla(req.sigla);
+			ExMobil mob = ExDao.getInstance().consultarPorSigla(flt);
+			ExDocumento doc = mob.doc();
+
+			assertAcesso(mob, titular, lotaTitular);
+
+			if (!Ex.getInstance().getComp().podeAssinarComSenha(titular, lotaTitular, mob))
+				throw new PresentableUnloggedException(
+						"O documento " + req.sigla + " não pode ser assinado com senha por "
+								+ titular.getSiglaCompleta() + "/" + lotaTitular.getSiglaCompleta());
+
+			Ex.getInstance().getBL().assinarDocumentoComSenha(cadastrante, lotaTitular, doc, null, u.usuario, null,
+					false, titular, false, null, false);
+
+			ExDao.commitTransacao();
+			resp.status = "OK";
+		} catch (Exception ex) {
+			ExDao.rollbackTransacao();
+		}
+	}
+	
+
+	private void assertAcesso(final ExMobil mob, DpPessoa titular, DpLotacao lotaTitular) throws Exception {
+		if (!Ex.getInstance().getComp().podeAcessarDocumento(titular, lotaTitular, mob)) {
+			String s = "";
+			s += mob.doc().getListaDeAcessosString();
+			s = "(" + s + ")";
+			s = " " + mob.doc().getExNivelAcessoAtual().getNmNivelAcesso() + " " + s;
+
+			Map<ExPapel, List<Object>> mapa = mob.doc().getPerfis();
+			boolean isInteressado = false;
+
+			for (ExPapel exPapel : mapa.keySet()) {
+				Iterator<Object> it = mapa.get(exPapel).iterator();
+
+				if ((exPapel != null) && (exPapel.getIdPapel() == exPapel.PAPEL_INTERESSADO)) {
+					while (it.hasNext() && !isInteressado) {
+						Object item = it.next();
+						isInteressado = item.toString().equals(titular.getSigla()) ? true : false;
+					}
+				}
+
+			}
+
+			if (mob.doc().isSemEfeito()) {
+				if (!mob.doc().getCadastrante().equals(titular) && !mob.doc().getSubscritor().equals(titular)
+						&& !isInteressado) {
+					throw new AplicacaoException("Documento " + mob.getSigla() + " cancelado ");
+				}
+			} else {
+				throw new AplicacaoException("Documento " + mob.getSigla() + " inacessível ao usuário "
+						+ titular.getSigla() + "/" + lotaTitular.getSiglaCompleta() + "." + s);
+			}
+		}
+	}
+
+	@Override
+	public String getContext() {
+		return "registrar assinatura com senha";
+	}
+
+	/**
+	 * This TypeAdapter unproxies Hibernate proxied objects, and serializes them
+	 * through the registered (or default) TypeAdapter of the base class.
+	 */
+	private static class HibernateProxyTypeAdapter extends TypeAdapter<HibernateProxy> {
+
+		public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+				return (HibernateProxy.class.isAssignableFrom(type.getRawType())
+						? (TypeAdapter<T>) new HibernateProxyTypeAdapter(gson) : null);
+			}
+		};
+		private final Gson context;
+
+		private HibernateProxyTypeAdapter(Gson context) {
+			this.context = context;
+		}
+
+		@Override
+		public HibernateProxy read(JsonReader in) throws IOException {
+			throw new UnsupportedOperationException("Not supported");
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Override
+		public void write(JsonWriter out, HibernateProxy value) throws IOException {
+			if (value == null) {
+				out.nullValue();
+				return;
+			}
+			// Retrieve the original (not proxy) class
+			Class<?> baseType = Hibernate.getClass(value);
+			// Get the TypeAdapter of the original class, to delegate the
+			// serialization
+			TypeAdapter delegate = context.getAdapter(TypeToken.get(baseType));
+			// Get a filled instance of the original class
+			Object unproxiedValue = ((HibernateProxy) value).getHibernateLazyInitializer().getImplementation();
+			// Serialize the value
+			// delegate.write(out, unproxiedValue);
+			delegate.write(out, "__OMITIDO__");
+		}
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
@@ -40,8 +40,6 @@ public class DocSiglaGet implements IDocSiglaGet {
 		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
 
 		SwaggerHelper.buscarEValidarUsuarioLogado();
-		
-		ApiContext apiContext = new ApiContext(true);
 		SigaObjects so = SwaggerHelper.getSigaObjects();
 		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
@@ -61,10 +59,8 @@ public class DocSiglaGet implements IDocSiglaGet {
 			if (Ex.getInstance().getComp().podeReceberEletronico(titular, lotaTitular, mob)) {
 				try {
 					Ex.getInstance().getBL().receber(cadastrante, lotaTitular, mob, new Date());
-					apiContext.close();
 				} catch (Exception e) {
 					e.printStackTrace(System.out);
-					apiContext.rollback(e);
 					throw e;
 				}
 			}
@@ -93,7 +89,6 @@ public class DocSiglaGet implements IDocSiglaGet {
 			resp.contenttype = "application/json";
 		} catch (Exception e) {
 			e.printStackTrace(System.out);
-			apiContext.rollback(e);
 			throw e;
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
@@ -1,0 +1,148 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExPapel;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.ex.vo.ExDocumentoVO;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaGet;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class DocSiglaGet implements IDocSiglaGet {
+
+	@Override
+	public void run(DocSiglaGetRequest req, DocSiglaGetResponse resp) throws Exception {
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		try {
+			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+
+			ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
+			flt.setSigla(req.sigla);
+			ExMobil mob = ExDao.getInstance().consultarPorSigla(flt);
+			ExDocumento doc = mob.doc();
+
+			Utils.assertAcesso(mob, titular, lotaTitular);
+
+			// Recebimento automático
+			if (Ex.getInstance().getComp().podeReceberEletronico(titular, lotaTitular, mob)) {
+				try {
+					ExDao.iniciarTransacao();
+					Ex.getInstance().getBL().receber(cadastrante, lotaTitular, mob, new Date());
+					ExDao.commitTransacao();
+				} catch (Exception ex) {
+					ExDao.rollbackTransacao();
+				}
+			}
+
+			// Mostra o último volume de um processo ou a primeira via de um
+			// expediente
+			if (mob == null || mob.isGeral()) {
+				if (mob.getDoc().isFinalizado()) {
+					if (doc.isProcesso())
+						mob = doc.getUltimoVolume();
+					else
+						mob = doc.getPrimeiraVia();
+				}
+			}
+
+			final ExDocumentoVO docVO = new ExDocumentoVO(doc, mob, cadastrante, titular, lotaTitular, true, false);
+
+			Type collectionType = new TypeToken<org.hibernate.proxy.HibernateProxy>() {
+			}.getType();
+			// Gson gson = new GsonBuilder().registerTypeAdapter(collectionType,
+			// new OutroParametroSerializer())
+			// .setExclusionStrategies(new
+			// ConsultaProcessualExclStrat()).create();
+			Gson gson = new GsonBuilder().registerTypeAdapterFactory(HibernateProxyTypeAdapter.FACTORY).create();
+			String json = gson.toJson(docVO);
+
+			resp.inputstream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+			resp.contenttype = "application/json";
+		} catch (Exception ex) {
+			ExDao.rollbackTransacao();
+		}
+
+	}
+
+	@Override
+	public String getContext() {
+		return "obter documento";
+	}
+
+	/**
+	 * This TypeAdapter unproxies Hibernate proxied objects, and serializes them
+	 * through the registered (or default) TypeAdapter of the base class.
+	 */
+	private static class HibernateProxyTypeAdapter extends TypeAdapter<HibernateProxy> {
+
+		public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+				return (HibernateProxy.class.isAssignableFrom(type.getRawType())
+						? (TypeAdapter<T>) new HibernateProxyTypeAdapter(gson) : null);
+			}
+		};
+		private final Gson context;
+
+		private HibernateProxyTypeAdapter(Gson context) {
+			this.context = context;
+		}
+
+		@Override
+		public HibernateProxy read(JsonReader in) throws IOException {
+			throw new UnsupportedOperationException("Not supported");
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Override
+		public void write(JsonWriter out, HibernateProxy value) throws IOException {
+			if (value == null) {
+				out.nullValue();
+				return;
+			}
+			// Retrieve the original (not proxy) class
+			Class<?> baseType = Hibernate.getClass(value);
+			// Get the TypeAdapter of the original class, to delegate the
+			// serialization
+			TypeAdapter delegate = context.getAdapter(TypeToken.get(baseType));
+			// Get a filled instance of the original class
+			Object unproxiedValue = ((HibernateProxy) value).getHibernateLazyInitializer().getImplementation();
+			// Serialize the value
+			// delegate.write(out, unproxiedValue);
+			delegate.write(out, "__OMITIDO__");
+		}
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaGet.java
@@ -28,10 +28,10 @@ import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaGet;
 import br.gov.jfrj.siga.ex.bl.CurrentRequest;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.RequestInfo;
-import br.gov.jfrj.siga.ex.vo.ExDocumentoSigaLeVO;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
 import br.gov.jfrj.siga.vraptor.SigaObjects;
+import br.gov.jfrj.sigale.ex.vo.ExDocumentoApiVO;
 
 public class DocSiglaGet implements IDocSiglaGet {
 
@@ -76,12 +76,11 @@ public class DocSiglaGet implements IDocSiglaGet {
 				}
 			}
 
-			final ExDocumentoSigaLeVO docVO = new ExDocumentoSigaLeVO(doc, mob, cadastrante, titular, lotaTitular, true, false);
+			final ExDocumentoApiVO docVO = new ExDocumentoApiVO(doc, mob, cadastrante, titular, lotaTitular, true, false);
 //TODO: Resolver o problema declares multiple JSON fields named serialVersionUID
 			//Usado o Expose temporariamente
 			Gson gson = new GsonBuilder().registerTypeAdapterFactory(HibernateProxyTypeAdapter.FACTORY)
 					.excludeFieldsWithModifiers(Modifier.TRANSIENT)
-					.excludeFieldsWithoutExposeAnnotation()
 					.create();
 			String json = gson.toJson(docVO);
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaJuntarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaJuntarPost.java
@@ -1,0 +1,56 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.Date;
+
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaJuntarPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaJuntarPostResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaJuntarPost;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
+
+public class DocSiglaJuntarPost implements IDocSiglaJuntarPost {
+
+	@Override
+	public void run(DocSiglaJuntarPostRequest req,
+			DocSiglaJuntarPostResponse resp) throws Exception {
+		
+		SwaggerHelper.buscarEValidarUsuarioLogado();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+		
+		SigaObjects so = SwaggerHelper.getSigaObjects();
+		so.assertAcesso("DOC:Módulo de Documentos;" + "");
+
+		try {
+			DpPessoa cadastrante = so.getCadastrante();
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+
+			ExMobil mobFilho = SwaggerHelper.buscarEValidarMobil(req.sigla, so, req, resp, "Documento Secundário");
+			ExMobil mobPai = SwaggerHelper.buscarEValidarMobil(req.siglapai, so, req, resp, "Documento Principal");
+			Date dt = ExDao.getInstance().consultarDataEHoraDoServidor(); 
+
+			Utils.assertAcesso(mobFilho, cadastrante, lotaTitular);
+
+			Ex.getInstance()
+					.getBL()
+					.juntarDocumento(cadastrante, cadastrante, lotaTitular,
+							null, mobFilho, mobPai, dt, cadastrante, cadastrante, "1");
+			resp.status = "OK";
+		} catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw e;
+		}
+	}
+
+	@Override
+	public String getContext() {
+		return "Juntar documento";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPdfCompletoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPdfCompletoGet.java
@@ -1,0 +1,43 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPdfCompletoGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPdfCompletoGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaPdfCompletoGet;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class DocSiglaPdfCompletoGet implements IDocSiglaPdfCompletoGet {
+
+	@Override
+	public void run(DocSiglaPdfCompletoGetRequest req,
+			DocSiglaPdfCompletoGetResponse resp) throws Exception {
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		try {
+			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+
+			ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
+			flt.setSigla(req.sigla);
+			ExMobil mob = ExDao.getInstance().consultarPorSigla(flt);
+
+			Utils.assertAcesso(mob, titular, lotaTitular);
+
+			resp.jwt = DownloadJwtFilenameGet.jwt(u.usuario,
+					mob.getCodigoCompacto(), null, null, null);
+		} catch (Exception e) {
+			// TODO: handle exception
+		}
+	}
+
+	@Override
+	public String getContext() {
+		return "obter documento";
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPdfCompletoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPdfCompletoGet.java
@@ -1,24 +1,32 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
+import com.crivano.swaggerservlet.SwaggerServlet;
+
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
-import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPdfCompletoGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPdfCompletoGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaPdfCompletoGet;
-import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
 import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class DocSiglaPdfCompletoGet implements IDocSiglaPdfCompletoGet {
 
 	@Override
 	public void run(DocSiglaPdfCompletoGetRequest req,
 			DocSiglaPdfCompletoGetResponse resp) throws Exception {
-		Usuario u = TokenCriarPost.assertUsuario();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+
+		SwaggerHelper.buscarEValidarUsuarioLogado();
+		SigaObjects so = SwaggerHelper.getSigaObjects();
+		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
 		try {
-			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpPessoa cadastrante = so.getCadastrante();
 			DpPessoa titular = cadastrante;
 			DpLotacao lotaTitular = cadastrante.getLotacao();
 
@@ -28,7 +36,7 @@ public class DocSiglaPdfCompletoGet implements IDocSiglaPdfCompletoGet {
 
 			Utils.assertAcesso(mob, titular, lotaTitular);
 
-			resp.jwt = DownloadJwtFilenameGet.jwt(u.usuario,
+			resp.jwt = DownloadJwtFilenameGet.jwt(cadastrante.getSiglaCompleta(),
 					mob.getCodigoCompacto(), null, null, null);
 		} catch (Exception e) {
 			// TODO: handle exception

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPesquisarSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPesquisarSiglaGet.java
@@ -1,0 +1,37 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPesquisarSiglaGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPesquisarSiglaGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaPesquisarSiglaGet;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class DocSiglaPesquisarSiglaGet implements IDocSiglaPesquisarSiglaGet {
+
+	@Override
+	public void run(DocSiglaPesquisarSiglaGetRequest req,
+			DocSiglaPesquisarSiglaGetResponse resp) throws Exception {
+		Usuario u = TokenCriarPost.assertUsuario();
+
+
+		DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+		ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
+		flt.setSigla(req.sigla);
+		if (flt.getIdOrgaoUsu() == null)
+			flt.setIdOrgaoUsu(cadastrante.getOrgaoUsuario().getIdOrgaoUsu());
+		ExMobil mob = ExDao.getInstance().consultarPorSigla(flt);
+		if (mob != null) {
+			resp.sigla = mob.getSigla();
+			resp.codigo = mob.getCodigoCompacto();
+		}
+
+	}
+
+	@Override
+	public String getContext() {
+		return "pesquisar mobil por sigla";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPesquisarSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaPesquisarSiglaGet.java
@@ -1,23 +1,31 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
+import com.crivano.swaggerservlet.SwaggerServlet;
+
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
-import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPesquisarSiglaGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaPesquisarSiglaGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaPesquisarSiglaGet;
-import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
 import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class DocSiglaPesquisarSiglaGet implements IDocSiglaPesquisarSiglaGet {
 
 	@Override
 	public void run(DocSiglaPesquisarSiglaGetRequest req,
 			DocSiglaPesquisarSiglaGetResponse resp) throws Exception {
-		Usuario u = TokenCriarPost.assertUsuario();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+
+		SwaggerHelper.buscarEValidarUsuarioLogado();
+		SigaObjects so = SwaggerHelper.getSigaObjects();
+		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
 
-		DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+		DpPessoa cadastrante = so.getCadastrante();
 		ExMobilDaoFiltro flt = new ExMobilDaoFiltro();
 		flt.setSigla(req.sigla);
 		if (flt.getIdOrgaoUsu() == null)

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarPost.java
@@ -26,7 +26,6 @@ public class DocSiglaTramitarPost implements IDocSiglaTramitarPost {
 
 		SwaggerHelper.buscarEValidarUsuarioLogado();
 		
-		ApiContext apiContext = new ApiContext(true);
 		SigaObjects so = SwaggerHelper.getSigaObjects();
 		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
@@ -64,11 +63,9 @@ public class DocSiglaTramitarPost implements IDocSiglaTramitarPost {
 							mob, null, null, null, lot, pes, null, null,
 							null, titular, null, true, null, null, null,
 							false, false);
-			apiContext.close();
 			resp.status = "OK";
 		} catch (Exception e) {
 			e.printStackTrace(System.out);
-			apiContext.rollback(e);
 			throw e;
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarPost.java
@@ -27,7 +27,7 @@ public class DocSiglaTramitarPost implements IDocSiglaTramitarPost {
 		SwaggerHelper.buscarEValidarUsuarioLogado();
 		
 		SigaObjects so = SwaggerHelper.getSigaObjects();
-		so.assertAcesso("DOC:Módulo de Documentos;" + "");
+//		so.assertAcesso("DOC:Módulo de Documentos;" + "");
 
 
 		try {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -1,31 +1,165 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.commons.lang3.tuple.Pair;
 
 import com.crivano.swaggerservlet.SwaggerException;
 
+import br.gov.jfrj.siga.dp.CpOrgao;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaTramitarSpPost;
+import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 
+	private static final String DESCR_MOV = "Tramitação executada através de WebService";
+
+	void efetuarTramitacaoLotacao(SigaObjects so, ExMobil mob, Date dtDevolucao, DocSiglaTramitarSpPostRequest req,
+			DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+		DpLotacao lot = new DpLotacao();
+		lot.setSigla(req.destinatario.replace("-", ""));
+		lot = ExDao.getInstance().consultarPorSigla(lot);
+		if (Objects.isNull(lot)) {
+			throw new SwaggerException("Não foi encontrado Órgão com sigla " + req.destinatario, 404, null, req, resp,
+					null);
+		}
+		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+
+		Ex.getInstance().getBL().transferir(//
+				null, // CpOrgao orgaoExterno
+				null, // String obsOrgao
+				so.getCadastrante(), // DpPessoa cadastrante
+				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+				mob, // ExMobil mob
+				dt, // final Date dtMov
+				dt, // Date dtMovIni
+				dtDevolucao, // Date dtFimMov
+				lot, // DpLotacao lotaResponsavel
+				null, // final DpPessoa responsavel
+				null, // DpLotacao lotaDestinoFinal
+				null, // DpPessoa destinoFinal
+				null, // DpPessoa subscritor
+				so.getCadastrante(), // DpPessoa titular
+				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+				true, // final boolean fInterno: QUANDO USO ISSO?
+				DESCR_MOV, // String descrMov
+				null, // String conteudo
+				null, // String nmFuncaoSubscritor
+				false, // boolean forcarTransferencia
+				false // boolean automatico
+		);
+
+	}
+
+	void efetuarTramitacaoParaUsuario(SigaObjects so, ExMobil mob, Date dtDevolucao, DocSiglaTramitarSpPostRequest req,
+			DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+		DpPessoa usuarioDestino = new DpPessoa();
+		usuarioDestino.setSigla(req.destinatario);
+		usuarioDestino = ExDao.getInstance().consultarPorSigla(usuarioDestino);
+		if (Objects.isNull(usuarioDestino)) {
+			throw new SwaggerException("Não foi encontrado Usuário com a Matrícula " + req.destinatario, 404, null, req, resp,
+					null);
+		}
+		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+// dao().getOrgaoFromSiglaExata(destinatarioStr);
+		Ex.getInstance().getBL().transferir(//
+				null, // CpOrgao orgaoExterno
+				null, // String obsOrgao
+				so.getCadastrante(), // DpPessoa cadastrante
+				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+				mob, // ExMobil mob
+				dt, // final Date dtMov
+				dt, // Date dtMovIni
+				dtDevolucao, // Date dtFimMov
+				usuarioDestino.getLotacao(), // DpLotacao lotaResponsavel
+				usuarioDestino, // final DpPessoa responsavel
+				null, // DpLotacao lotaDestinoFinal
+				null, // DpPessoa destinoFinal
+				null, // DpPessoa subscritor
+				so.getCadastrante(), // DpPessoa titular
+				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+				true, // final boolean fInterno: QUANDO USO ISSO?
+				null, // String descrMov
+				null, // String conteudo
+				null, // String nmFuncaoSubscritor
+				false, // boolean forcarTransferencia
+				false // boolean automatico
+		);
+	}
+
+	void efetuarTramitacaoParaOrgaoExtrno(SigaObjects so, ExMobil mob, Date dtDevolucao, DocSiglaTramitarSpPostRequest req,
+			DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+		CpOrgao orgaoExternoDestino = ExDao.getInstance().getOrgaoFromSiglaExata(req.destinatario);
+		if (Objects.isNull(orgaoExternoDestino)) {
+			throw new SwaggerException("Não foi encontrado Órgão Externo com o código " + req.destinatario, 404, null, req, resp,
+					null);
+		}
+
+		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+
+		Ex.getInstance().getBL().transferir(//
+				orgaoExternoDestino, // CpOrgao orgaoExterno
+				req.observacao, // String obsOrgao
+				so.getCadastrante(), // DpPessoa cadastrante
+				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+				mob, // ExMobil mob
+				dt, // final Date dtMov
+				dt, // Date dtMovIni
+				dtDevolucao, // Date dtFimMov
+				null, // DpLotacao lotaResponsavel
+				null, // final DpPessoa responsavel
+				null, // DpLotacao lotaDestinoFinal
+				null, // DpPessoa destinoFinal
+				null, // DpPessoa subscritor
+				so.getCadastrante(), // DpPessoa titular
+				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+				true, // final boolean fInterno: QUANDO USO ISSO?
+				null, // String descrMov
+				null, // String conteudo
+				null, // String nmFuncaoSubscritor
+				false, // boolean forcarTransferencia
+				false // boolean automatico
+		);
+	}
+
 	@Override
 	public String getContext() {
 		return "tramitar documento (SP sem Papel)";
 	}
-	
-	private Pair<TramitacaoTipoDestinoEnum, LocalDate> validarRequestEExtrairTipoDestinoEDataDevolucao(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception {
+
+	private Date getDataDevolucao(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp)
+			throws SwaggerException {
+		if (StringUtils.isEmpty(req.dataDevolucao)) {
+			return null;
+		}
+		try {
+			LocalDate localDate = LocalDate.parse(req.dataDevolucao);
+			if (localDate.isBefore(LocalDate.now())) {
+				throw new SwaggerException(
+						"Data de devolução não pode ser anterior à data de hoje: " + req.dataDevolucao, 400, null, req,
+						resp, null);
+			}
+			return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+		} catch (DateTimeParseException e) {
+			throw new SwaggerException("Data de Devolução inválida: " + req.dataDevolucao, 400, null, req, resp, null);
+		}
+	}
+
+	private TramitacaoTipoDestinoEnum getTipoTramitcao(DocSiglaTramitarSpPostRequest req,
+			DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
 		try {
 			TramitacaoTipoDestinoEnum tipoTramitacao = TramitacaoTipoDestinoEnum.valueOf(req.tipoDestinatario);
 
@@ -36,44 +170,56 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 				throw new SwaggerException(tipoTramitacao.descricao + " (" + req.destinatario + ") Inválido. "
 						+ tipoTramitacao.msgErroPattern, 400, null, req, resp, null);
 			}
-
-			LocalDate dataDevolucao = null;
-			if (StringUtils.isNotEmpty(req.dataDevolucao)) {
-				dataDevolucao = LocalDate.parse(req.dataDevolucao);
-				if (dataDevolucao.isBefore(LocalDate.now())) {
-					throw new SwaggerException(
-							"Data de devolução não pode ser anterior à data de hoje: " + req.dataDevolucao, 400, null,
-							req, resp, null);
-				}
-			}
-
-			return Pair.of(tipoTramitacao, dataDevolucao);
+			return tipoTramitacao;
 		} catch (IllegalArgumentException e) {
 			throw new SwaggerException("Tipo de Tramitação inválido: " + req.tipoDestinatario, 400, null, req, resp,
 					null);
-		} catch (DateTimeParseException e) {
-			throw new SwaggerException("Data de Devolução inválida: " + req.dataDevolucao, 400, null, req, resp, null);
 		}
 	}
+
+//	public void transferir(final CpOrgao orgaoExterno, final String obsOrgao, final DpPessoa cadastrante,
+//			final DpLotacao lotaCadastrante, final ExMobil mob, final Date dtMov, final Date dtMovIni,
+//			final Date dtFimMov, DpLotacao lotaResponsavel, final DpPessoa responsavel,
+//			final DpLotacao lotaDestinoFinal, final DpPessoa destinoFinal, final DpPessoa subscritor,
+//			final DpPessoa titular, final ExTipoDespacho tpDespacho, final boolean fInterno, final String descrMov,
+//			final String conteudo, String nmFuncaoSubscritor, boolean forcarTransferencia, boolean automatico) {
 
 	@Override
 	public void run(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception {
 		req.sigla = SwaggerHelper.decodePathParam(req.sigla);
-		Pair<TramitacaoTipoDestinoEnum, LocalDate> tipoDestinoDataDevolucao = validarRequestEExtrairTipoDestinoEDataDevolucao(req, resp);
-		System.out.println(
-				"MobilTramitarSiglaPost: " + ToStringBuilder.reflectionToString(req, ToStringStyle.SHORT_PREFIX_STYLE)
-						+ ", " + tipoDestinoDataDevolucao);
+		TramitacaoTipoDestinoEnum tipoDestino = getTipoTramitcao(req, resp);
+		Date dataDevolucao = getDataDevolucao(req, resp);
+		System.out.println("MobilTramitarSiglaPost: "
+				+ ToStringBuilder.reflectionToString(req, ToStringStyle.SHORT_PREFIX_STYLE) + ", " + tipoDestino);
 
 		ApiContext_Remover apiContext = new ApiContext_Remover(true);
 		try {
 			SwaggerHelper.buscarEValidarUsuarioLogado();
-
 			SigaObjects so = SwaggerHelper.getSigaObjects();
 
 			ExMobil mob = SwaggerHelper.buscarEValidarMobil(req.sigla, req, resp);
 			System.out.println("MobilTramitarSiglaPost.run(): " + mob);
 
-			Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+			Utils.assertAcesso(mob, so.getCadastrante(), so.getCadastrante().getLotacao());
+
+			if (!Ex.getInstance().getComp().podeTransferir(so.getCadastrante(), so.getCadastrante().getLotacao(),
+					mob)) {
+				throw new SwaggerException("O documento " + req.sigla + " não pode ser tramitado por "
+						+ so.getCadastrante().getSiglaCompleta() + "/"
+						+ so.getCadastrante().getLotacao().getSiglaCompleta(), 403, null, req, resp, null);
+			}
+
+			switch (tipoDestino) {
+			case ORGAO:
+				this.efetuarTramitacaoLotacao(so, mob, dataDevolucao, req, resp);
+				break;
+			case USUARIO:
+				this.efetuarTramitacaoParaUsuario(so, mob, dataDevolucao, req, resp);
+				break;
+			case EXTERNO:
+				this.efetuarTramitacaoParaOrgaoExtrno(so, mob, dataDevolucao, req, resp);
+				break;
+			}
 
 			apiContext.close();
 			return;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -4,15 +4,11 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
-import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.crivano.swaggerservlet.SwaggerException;
 
-import br.gov.jfrj.siga.dp.CpOrgao;
-import br.gov.jfrj.siga.dp.DpLotacao;
-import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostResponse;
@@ -22,109 +18,6 @@ import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
-
-	void efetuarTramitacaoParaLotacao(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
-			DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
-		DpLotacao lot = new DpLotacao();
-		lot.setSigla(req.destinatario.replace("-", ""));
-		lot = ExDao.getInstance().consultarPorSigla(lot);
-		if (Objects.isNull(lot)) {
-			throw new SwaggerException("Não foi encontrado Órgão com sigla " + req.destinatario, 404, null, req, resp,
-					null);
-		}
-		Ex.getInstance().getBL().transferir(//
-				null, // CpOrgao orgaoExterno
-				null, // String obsOrgao
-				so.getCadastrante(), // DpPessoa cadastrante
-				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
-				mob, // ExMobil mob
-				dt, // final Date dtMov
-				dt, // Date dtMovIni
-				dtDevolucao, // Date dtFimMov
-				lot, // DpLotacao lotaResponsavel
-				null, // final DpPessoa responsavel
-				null, // DpLotacao lotaDestinoFinal
-				null, // DpPessoa destinoFinal
-				null, // DpPessoa subscritor
-				so.getCadastrante(), // DpPessoa titular
-				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
-				true, // final boolean fInterno: QUANDO USO ISSO?
-				null, // String descrMov
-				null, // String conteudo
-				null, // String nmFuncaoSubscritor
-				false, // boolean forcarTransferencia
-				false // boolean automatico
-		);
-
-	}
-
-	void efetuarTramitacaoParaUsuario(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
-			DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
-		DpPessoa usuarioDestino = new DpPessoa();
-		usuarioDestino.setSigla(req.destinatario);
-		usuarioDestino = ExDao.getInstance().consultarPorSigla(usuarioDestino);
-		if (Objects.isNull(usuarioDestino)) {
-			throw new SwaggerException("Não foi encontrado Usuário com a Matrícula " + req.destinatario, 404, null, req,
-					resp, null);
-		}
-
-		Ex.getInstance().getBL().transferir(//
-				null, // CpOrgao orgaoExterno
-				null, // String obsOrgao
-				so.getCadastrante(), // DpPessoa cadastrante
-				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
-				mob, // ExMobil mob
-				dt, // final Date dtMov
-				dt, // Date dtMovIni
-				dtDevolucao, // Date dtFimMov
-				usuarioDestino.getLotacao(), // DpLotacao lotaResponsavel
-				usuarioDestino, // final DpPessoa responsavel
-				null, // DpLotacao lotaDestinoFinal
-				null, // DpPessoa destinoFinal
-				null, // DpPessoa subscritor
-				so.getCadastrante(), // DpPessoa titular
-				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
-				true, // final boolean fInterno: QUANDO USO ISSO?
-				null, // String descrMov
-				null, // String conteudo
-				null, // String nmFuncaoSubscritor
-				false, // boolean forcarTransferencia
-				false // boolean automatico
-		);
-	}
-
-	void efetuarTramitacaoParaOrgaoExtrno(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
-			DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
-		CpOrgao orgaoExternoDestino = ExDao.getInstance().getOrgaoFromSiglaExata(req.destinatario);
-		if (Objects.isNull(orgaoExternoDestino)) {
-			throw new SwaggerException("Não foi encontrado Órgão Externo com o código " + req.destinatario, 404, null,
-					req, resp, null);
-		}
-
-		Ex.getInstance().getBL().transferir(//
-				orgaoExternoDestino, // CpOrgao orgaoExterno
-				req.observacao, // String obsOrgao
-				so.getCadastrante(), // DpPessoa cadastrante
-				so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
-				mob, // ExMobil mob
-				dt, // final Date dtMov
-				dt, // Date dtMovIni
-				dtDevolucao, // Date dtFimMov
-				null, // DpLotacao lotaResponsavel
-				null, // final DpPessoa responsavel
-				null, // DpLotacao lotaDestinoFinal
-				null, // DpPessoa destinoFinal
-				null, // DpPessoa subscritor
-				so.getCadastrante(), // DpPessoa titular
-				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
-				true, // final boolean fInterno: QUANDO USO ISSO?
-				null, // String descrMov
-				null, // String conteudo
-				null, // String nmFuncaoSubscritor
-				false, // boolean forcarTransferencia
-				false // boolean automatico
-		);
-	}
 
 	@Override
 	public String getContext() {
@@ -192,19 +85,7 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 
 			Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
 
-			switch (tipoDestino) {
-			case ORGAO:
-				this.efetuarTramitacaoParaLotacao(so, mob, dataDevolucao, dt, req, resp);
-				break;
-			case USUARIO:
-				this.efetuarTramitacaoParaUsuario(so, mob, dataDevolucao, dt, req, resp);
-				break;
-			case EXTERNO:
-				this.efetuarTramitacaoParaOrgaoExtrno(so, mob, dataDevolucao, dt, req, resp);
-				break;
-			}
-
-			return;
+			tipoDestino.efetuarTramitacaoParaDestino(so, mob, dataDevolucao, dt, req, resp);
 		} catch (Exception e) {
 			e.printStackTrace(System.out);
 			throw e;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -55,7 +55,7 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 				so.getCadastrante(), // DpPessoa titular
 				null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
 				true, // final boolean fInterno: QUANDO USO ISSO?
-				DESCR_MOV, // String descrMov
+				null, // String descrMov
 				null, // String conteudo
 				null, // String nmFuncaoSubscritor
 				false, // boolean forcarTransferencia
@@ -70,8 +70,8 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 		usuarioDestino.setSigla(req.destinatario);
 		usuarioDestino = ExDao.getInstance().consultarPorSigla(usuarioDestino);
 		if (Objects.isNull(usuarioDestino)) {
-			throw new SwaggerException("Não foi encontrado Usuário com a Matrícula " + req.destinatario, 404, null, req, resp,
-					null);
+			throw new SwaggerException("Não foi encontrado Usuário com a Matrícula " + req.destinatario, 404, null, req,
+					resp, null);
 		}
 		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
 // dao().getOrgaoFromSiglaExata(destinatarioStr);
@@ -100,12 +100,12 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 		);
 	}
 
-	void efetuarTramitacaoParaOrgaoExtrno(SigaObjects so, ExMobil mob, Date dtDevolucao, DocSiglaTramitarSpPostRequest req,
-			DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+	void efetuarTramitacaoParaOrgaoExtrno(SigaObjects so, ExMobil mob, Date dtDevolucao,
+			DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
 		CpOrgao orgaoExternoDestino = ExDao.getInstance().getOrgaoFromSiglaExata(req.destinatario);
 		if (Objects.isNull(orgaoExternoDestino)) {
-			throw new SwaggerException("Não foi encontrado Órgão Externo com o código " + req.destinatario, 404, null, req, resp,
-					null);
+			throw new SwaggerException("Não foi encontrado Órgão Externo com o código " + req.destinatario, 404, null,
+					req, resp, null);
 		}
 
 		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -1,0 +1,22 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaTramitarSpPost;
+
+public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
+
+	@Override
+	public String getContext() {
+		return "tramitar documento (SP sem Papel)";
+	}
+
+	@Override
+	public void run(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception {
+		System.out.println(ToStringBuilder.reflectionToString(req, ToStringStyle.SHORT_PREFIX_STYLE));
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -38,7 +38,6 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 			}
 
 			LocalDate dataDevolucao = null;
-			/*
 			if (StringUtils.isNotEmpty(req.dataDevolucao)) {
 				dataDevolucao = LocalDate.parse(req.dataDevolucao);
 				if (dataDevolucao.isBefore(LocalDate.now())) {
@@ -47,7 +46,6 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 							req, resp, null);
 				}
 			}
-			*/
 
 			return Pair.of(tipoTramitacao, dataDevolucao);
 		} catch (IllegalArgumentException e) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocSiglaTramitarSpPost.java
@@ -1,11 +1,22 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.tuple.Pair;
 
+import com.crivano.swaggerservlet.SwaggerException;
+
+import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocSiglaTramitarSpPost;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 
@@ -13,10 +24,66 @@ public class DocSiglaTramitarSpPost implements IDocSiglaTramitarSpPost {
 	public String getContext() {
 		return "tramitar documento (SP sem Papel)";
 	}
+	
+	private Pair<TramitacaoTipoDestinoEnum, LocalDate> validarRequestEExtrairTipoDestinoEDataDevolucao(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception {
+		try {
+			TramitacaoTipoDestinoEnum tipoTramitacao = TramitacaoTipoDestinoEnum.valueOf(req.tipoDestinatario);
+
+			if (StringUtils.isEmpty(req.destinatario)) {
+				throw new SwaggerException(tipoTramitacao.descricao + " não Fornecido", 400, null, req, resp, null);
+			}
+			if (!req.destinatario.matches(tipoTramitacao.pattern)) {
+				throw new SwaggerException(tipoTramitacao.descricao + " (" + req.destinatario + ") Inválido. "
+						+ tipoTramitacao.msgErroPattern, 400, null, req, resp, null);
+			}
+
+			LocalDate dataDevolucao = null;
+			/*
+			if (StringUtils.isNotEmpty(req.dataDevolucao)) {
+				dataDevolucao = LocalDate.parse(req.dataDevolucao);
+				if (dataDevolucao.isBefore(LocalDate.now())) {
+					throw new SwaggerException(
+							"Data de devolução não pode ser anterior à data de hoje: " + req.dataDevolucao, 400, null,
+							req, resp, null);
+				}
+			}
+			*/
+
+			return Pair.of(tipoTramitacao, dataDevolucao);
+		} catch (IllegalArgumentException e) {
+			throw new SwaggerException("Tipo de Tramitação inválido: " + req.tipoDestinatario, 400, null, req, resp,
+					null);
+		} catch (DateTimeParseException e) {
+			throw new SwaggerException("Data de Devolução inválida: " + req.dataDevolucao, 400, null, req, resp, null);
+		}
+	}
 
 	@Override
 	public void run(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception {
-		System.out.println(ToStringBuilder.reflectionToString(req, ToStringStyle.SHORT_PREFIX_STYLE));
+		req.sigla = SwaggerHelper.decodePathParam(req.sigla);
+		Pair<TramitacaoTipoDestinoEnum, LocalDate> tipoDestinoDataDevolucao = validarRequestEExtrairTipoDestinoEDataDevolucao(req, resp);
+		System.out.println(
+				"MobilTramitarSiglaPost: " + ToStringBuilder.reflectionToString(req, ToStringStyle.SHORT_PREFIX_STYLE)
+						+ ", " + tipoDestinoDataDevolucao);
+
+		ApiContext_Remover apiContext = new ApiContext_Remover(true);
+		try {
+			SwaggerHelper.buscarEValidarUsuarioLogado();
+
+			SigaObjects so = SwaggerHelper.getSigaObjects();
+
+			ExMobil mob = SwaggerHelper.buscarEValidarMobil(req.sigla, req, resp);
+			System.out.println("MobilTramitarSiglaPost.run(): " + mob);
+
+			Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+
+			apiContext.close();
+			return;
+		} catch (Exception e) {
+			e.printStackTrace(System.out);
+			apiContext.rollback(e);
+			throw e;
+		}
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentoSiglaArquivoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentoSiglaArquivoGet.java
@@ -26,7 +26,7 @@ public class DocumentoSiglaArquivoGet implements IDocumentoSiglaArquivoGet {
 
 	@Override
 	public void run(DocumentoSiglaArquivoGetRequest req, DocumentoSiglaArquivoGetResponse resp) throws Exception {
-		try (ApiContext ctx = new ApiContext(false)) {
+		try {
 			String usuario = ContextoPersistencia.getUserPrincipal();
 
 			if (usuario == null)
@@ -53,6 +53,9 @@ public class DocumentoSiglaArquivoGet implements IDocumentoSiglaArquivoGet {
 			final String contextpath = request.getContextPath();
 
 			iniciarGeracaoDePdf(req, resp, usuario, filename, contextpath, servernameport);
+		}catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw e;
 		}
 	}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
@@ -7,6 +7,7 @@ import com.crivano.swaggerservlet.SwaggerServlet;
 import com.crivano.swaggerservlet.SwaggerUtils;
 
 import br.gov.jfrj.itextpdf.Documento;
+import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.base.log.RequestExceptionLogger;
 import br.gov.jfrj.siga.ex.ExMobil;
@@ -64,7 +65,7 @@ public class DownloadAssincrono implements Callable<String> {
 	}
 
 	public static String getBufName(String uuid, String contenttype, String sigla) {
-		String dirTemp = SwaggerServlet.getProperty("upload.dir.temp");
+		String dirTemp = Prop.get("upload.dir.temp");
 		return dirTemp + "/" + Texto.slugify(sigla, true, false) + "-completo-" + uuid
 				+ ("text/html".equals(contenttype) ? ".html" : ".pdf");
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
@@ -39,7 +39,7 @@ public class DownloadAssincrono implements Callable<String> {
 	@Override
 	public String call() throws Exception {
 		String bufName = null;
-		try (ApiContext ctx = new ApiContext(false)) {
+		try {
 			ExDao dao = ExDao.getInstance();
 
 			final ExMobilDaoFiltro filter = new ExMobilDaoFiltro();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadJwtFilenameGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadJwtFilenameGet.java
@@ -25,7 +25,7 @@ public class DownloadJwtFilenameGet implements IDownloadJwtFilenameGet {
 	public void run(DownloadJwtFilenameGetRequest req, DownloadJwtFilenameGetResponse resp) throws Exception {
 		Map<String, Object> map = verify(req.jwt);
 
-		String principal = (String) map.get("principal");
+		//String principal = (String) map.get("principal");
 		String uuid = (String) map.get("uuid");
 		String doc = (String) map.get("doc");
 		String filename = (String) map.get("fname");

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -45,9 +45,9 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 		defineProperties();
 
 		// Threadpool
-		if (SwaggerServlet.getProperty("redis.password") != null)
+		if (Prop.get("redis.password") != null)
 			SwaggerUtils.setCache(new MemCacheRedis());
-		executor = Executors.newFixedThreadPool(new Integer(SwaggerServlet.getProperty("threadpool.size")));
+		executor = Executors.newFixedThreadPool(Prop.getInt("threadpool.size"));
 
 		class HttpGetDependency extends TestableDependency {
 			String testsite;
@@ -96,7 +96,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 		}
 
 		addDependency(
-				new FileSystemWriteDependency("upload.dir.temp", getProperty("upload.dir.temp"), false, 0, 10000));
+				new FileSystemWriteDependency("upload.dir.temp", Prop.get("upload.dir.temp"), false, 0, 10000));
 
 		addDependency(new HttpGetDependency("rest", "www.google.com/recaptcha",
 				"https://www.google.com/recaptcha/api/siteverify", false, 0, 10000));
@@ -105,7 +105,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 
 			@Override
 			public String getUrl() {
-				return getProperty("datasource.name");
+				return Prop.get("datasource.name");
 			}
 
 			@Override
@@ -121,7 +121,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 			}
 		});
 
-		if (SwaggerServlet.getProperty("redis.password") != null)
+		if (Prop.get("redis.password") != null)
 			addDependency(new TestableDependency("cache", "redis", false, 0, 10000) {
 
 				@Override
@@ -159,7 +159,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 //		addPublicProperty("cookie.renew.seconds", Long.toString(15 * 60L)); // Renova 15min antes de expirar
 
 		addRestrictedProperty("datasource.url", null);
-		if (getProperty("datasource.url") != null) {
+		if (Prop.get("datasource.url") != null) {
 			addRestrictedProperty("datasource.username");
 			addPrivateProperty("datasource.password");
 			addRestrictedProperty("datasource.name", null);
@@ -270,5 +270,6 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 	public String getProp(String nome) {
 		return getProperty(nome);
 	}
+
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -110,8 +110,11 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 
 			@Override
 			public boolean test() throws Exception {
-				try (ApiContext ctx = new ApiContext(true)) {
+				try {
 					return ExDao.getInstance().dt() != null;
+				} catch (Exception e) {
+					e.printStackTrace(System.out);
+					throw e;
 				}
 			}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -219,6 +219,10 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 				
 		addPublicProperty("modelos.cabecalho.titulo", "JUSTIÇA FEDERAL");
 		addPublicProperty("modelos.cabecalho.subtitulo", null);
+		
+		//Siga-Le
+		addPublicProperty("smtp.sugestao.destinatario");
+		addPublicProperty("smtp.sugestao.assunto", "Siga-Le: Sugestão");
 	}
 
 	@Override

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -299,6 +299,21 @@ public interface IExApiV1 {
 		public void run(DocSiglaTramitarPostRequest req, DocSiglaTramitarPostResponse resp) throws Exception;
 	}
 
+	public class DocSiglaTramitarSpPostRequest implements ISwaggerRequest {
+		public String sigla;
+		public String tipoDestinatario;
+		public String destinatario;
+		public String observacao;
+		public Date dataDevolucao;
+	}
+
+	public class DocSiglaTramitarSpPostResponse implements ISwaggerResponse {
+	}
+
+	public interface IDocSiglaTramitarSpPost extends ISwaggerMethod {
+		public void run(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception;
+	}
+
 	public class DocSiglaAnotarPostRequest implements ISwaggerRequest {
 		public String sigla;
 		public String anotacao;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -304,7 +304,7 @@ public interface IExApiV1 {
 		public String tipoDestinatario;
 		public String destinatario;
 		public String observacao;
-		public Date dataDevolucao;
+		public String dataDevolucao;
 	}
 
 	public class DocSiglaTramitarSpPostResponse implements ISwaggerResponse {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -314,6 +314,19 @@ public interface IExApiV1 {
 		public void run(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws Exception;
 	}
 
+	public class DocSiglaJuntarPostRequest implements ISwaggerRequest {
+		public String sigla;
+		public String siglapai;
+	}
+
+	public class DocSiglaJuntarPostResponse implements ISwaggerResponse {
+		public String status;
+	}
+
+	public interface IDocSiglaJuntarPost extends ISwaggerMethod {
+		public void run(DocSiglaJuntarPostRequest req, DocSiglaJuntarPostResponse resp) throws Exception;
+	}
+
 	public class DocSiglaAnotarPostRequest implements ISwaggerRequest {
 		public String sigla;
 		public String anotacao;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1,6 +1,7 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
 import java.io.InputStream;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +25,62 @@ public interface IExApiV1 {
 		public String errormsg;
 	}
 
+	public class MesaItem implements ISwaggerModel {
+		public String tipo;
+		public Date datahora;
+		public String tempoRelativo;
+		public String codigo;
+		public String sigla;
+		public String descr;
+		public String origem;
+		public String grupo;
+		public String grupoNome;
+		public String grupoOrdem;
+		public Boolean podeAnotar;
+		public Boolean podeAssinar;
+		public Boolean podeAssinarEmLote;
+		public Boolean podeTramitar;
+		public List<Marca> list;
+	}
+
+	public class AcessoItem implements ISwaggerModel {
+		public Date datahora;
+		public String ip;
+	}
+
+	public class Marca implements ISwaggerModel {
+		public String pessoa;
+		public String lotacao;
+		public String nome;
+		public String icone;
+		public String titulo;
+		public Date inicio;
+		public Date termino;
+		public Boolean daPessoa;
+		public Boolean deOutraPessoa;
+		public Boolean daLotacao;
+	}
+
+	public class Acao implements ISwaggerModel {
+		public String nome;
+		public String icone;
+		public Boolean ativa;
+	}
+
+	public class Documento implements ISwaggerModel {
+		public String sigla;
+		public String html;
+		public String data;
+		public String descr;
+		public List<Marca> marca;
+		public List<Acao> acao;
+	}
+
+	public class ResultadoDePesquisa implements ISwaggerModel {
+		public String sigla;
+		public String nome;
+	}
+
 	public class AutenticarPostRequest implements ISwaggerRequest {
 	}
 
@@ -41,7 +98,7 @@ public interface IExApiV1 {
 		public Boolean estampa;
 		public Boolean completo;
 		public Boolean volumes;
-		public Boolean exibirReordenacao;  
+		public Boolean exibirReordenacao;
 	}
 
 	public class DocumentoSiglaArquivoGetResponse implements ISwaggerResponse {
@@ -69,39 +126,30 @@ public interface IExApiV1 {
 		public String getContenttype() {
 			return contenttype;
 		}
-
 		public void setContenttype(String contenttype) {
 			this.contenttype = contenttype;
 		}
-
 		public String getContentdisposition() {
 			return contentdisposition;
 		}
-
 		public void setContentdisposition(String contentdisposition) {
 			this.contentdisposition = contentdisposition;
 		}
-
 		public Long getContentlength() {
 			return contentlength;
 		}
-
 		public void setContentlength(Long contentlength) {
 			this.contentlength = contentlength;
 		}
-
 		public InputStream getInputstream() {
 			return inputstream;
 		}
-
 		public void setInputstream(InputStream inputstream) {
 			this.inputstream = inputstream;
 		}
-
 		public Map<String, List<String>> getHeaderFields() {
 			return headerFields;
 		}
-
 		public void setHeaderFields(Map<String, List<String>> headerFields) {
 			this.headerFields = headerFields;
 		}
@@ -126,6 +174,218 @@ public interface IExApiV1 {
 
 	public interface IStatusChaveGet extends ISwaggerMethod {
 		public void run(StatusChaveGetRequest req, StatusChaveGetResponse resp) throws Exception;
+	}
+
+	public class MesaGetRequest implements ISwaggerRequest {
+	}
+
+	public class MesaGetResponse implements ISwaggerResponse {
+		public List<MesaItem> list;
+	}
+
+	public interface IMesaGet extends ISwaggerMethod {
+		public void run(MesaGetRequest req, MesaGetResponse resp) throws Exception;
+	}
+
+	public class DocSiglaGetRequest implements ISwaggerRequest {
+		public String sigla;
+	}
+
+	public class DocSiglaGetResponse implements ISwaggerResponse, ISwaggerResponseFile {
+		public String contenttype = "application/pdf";
+		public String contentdisposition = "attachment";
+		public Long contentlength;
+		public InputStream inputstream;
+		public Map<String, List<String>> headerFields;
+
+		public String getContenttype() {
+			return contenttype;
+		}
+		public void setContenttype(String contenttype) {
+			this.contenttype = contenttype;
+		}
+		public String getContentdisposition() {
+			return contentdisposition;
+		}
+		public void setContentdisposition(String contentdisposition) {
+			this.contentdisposition = contentdisposition;
+		}
+		public Long getContentlength() {
+			return contentlength;
+		}
+		public void setContentlength(Long contentlength) {
+			this.contentlength = contentlength;
+		}
+		public InputStream getInputstream() {
+			return inputstream;
+		}
+		public void setInputstream(InputStream inputstream) {
+			this.inputstream = inputstream;
+		}
+		public Map<String, List<String>> getHeaderFields() {
+			return headerFields;
+		}
+		public void setHeaderFields(Map<String, List<String>> headerFields) {
+			this.headerFields = headerFields;
+		}
+	}
+
+	public interface IDocSiglaGet extends ISwaggerMethod {
+		public void run(DocSiglaGetRequest req, DocSiglaGetResponse resp) throws Exception;
+	}
+
+	public class DocSiglaPdfGetRequest implements ISwaggerRequest {
+		public String sigla;
+	}
+
+	public class DocSiglaPdfGetResponse implements ISwaggerResponse {
+		public String jwt;
+	}
+
+	public interface IDocSiglaPdfGet extends ISwaggerMethod {
+		public void run(DocSiglaPdfGetRequest req, DocSiglaPdfGetResponse resp) throws Exception;
+	}
+
+	public class DocSiglaPdfCompletoGetRequest implements ISwaggerRequest {
+		public String sigla;
+	}
+
+	public class DocSiglaPdfCompletoGetResponse implements ISwaggerResponse {
+		public String jwt;
+	}
+
+	public interface IDocSiglaPdfCompletoGet extends ISwaggerMethod {
+		public void run(DocSiglaPdfCompletoGetRequest req, DocSiglaPdfCompletoGetResponse resp) throws Exception;
+	}
+
+	public class DocSiglaMovIdPdfGetRequest implements ISwaggerRequest {
+		public String sigla;
+		public String id;
+	}
+
+	public class DocSiglaMovIdPdfGetResponse implements ISwaggerResponse {
+		public String jwt;
+	}
+
+	public interface IDocSiglaMovIdPdfGet extends ISwaggerMethod {
+		public void run(DocSiglaMovIdPdfGetRequest req, DocSiglaMovIdPdfGetResponse resp) throws Exception;
+	}
+
+	public class DocSiglaAssinarComSenhaPostRequest implements ISwaggerRequest {
+		public String sigla;
+		public String username;
+		public String password;
+	}
+
+	public class DocSiglaAssinarComSenhaPostResponse implements ISwaggerResponse {
+		public String status;
+	}
+
+	public interface IDocSiglaAssinarComSenhaPost extends ISwaggerMethod {
+		public void run(DocSiglaAssinarComSenhaPostRequest req, DocSiglaAssinarComSenhaPostResponse resp) throws Exception;
+	}
+
+	public class DocSiglaTramitarPostRequest implements ISwaggerRequest {
+		public String sigla;
+		public String lotacao;
+		public String matricula;
+	}
+
+	public class DocSiglaTramitarPostResponse implements ISwaggerResponse {
+		public String status;
+	}
+
+	public interface IDocSiglaTramitarPost extends ISwaggerMethod {
+		public void run(DocSiglaTramitarPostRequest req, DocSiglaTramitarPostResponse resp) throws Exception;
+	}
+
+	public class DocSiglaAnotarPostRequest implements ISwaggerRequest {
+		public String sigla;
+		public String anotacao;
+	}
+
+	public class DocSiglaAnotarPostResponse implements ISwaggerResponse {
+		public String status;
+	}
+
+	public interface IDocSiglaAnotarPost extends ISwaggerMethod {
+		public void run(DocSiglaAnotarPostRequest req, DocSiglaAnotarPostResponse resp) throws Exception;
+	}
+
+	public class DocSiglaPesquisarSiglaGetRequest implements ISwaggerRequest {
+		public String sigla;
+		public String matricula;
+	}
+
+	public class DocSiglaPesquisarSiglaGetResponse implements ISwaggerResponse {
+		public String codigo;
+		public String sigla;
+	}
+
+	public interface IDocSiglaPesquisarSiglaGet extends ISwaggerMethod {
+		public void run(DocSiglaPesquisarSiglaGetRequest req, DocSiglaPesquisarSiglaGetResponse resp) throws Exception;
+	}
+
+	public class SugestaoPostRequest implements ISwaggerRequest {
+		public String nome;
+		public String email;
+		public String mensagem;
+	}
+
+	public class SugestaoPostResponse implements ISwaggerResponse {
+		public String status;
+	}
+
+	public interface ISugestaoPost extends ISwaggerMethod {
+		public void run(SugestaoPostRequest req, SugestaoPostResponse resp) throws Exception;
+	}
+
+	public class TokenCriarPostRequest implements ISwaggerRequest {
+		public String username;
+		public String password;
+	}
+
+	public class TokenCriarPostResponse implements ISwaggerResponse {
+		public String id_token;
+	}
+
+	public interface ITokenCriarPost extends ISwaggerMethod {
+		public void run(TokenCriarPostRequest req, TokenCriarPostResponse resp) throws Exception;
+	}
+
+	public class AcessosGetRequest implements ISwaggerRequest {
+	}
+
+	public class AcessosGetResponse implements ISwaggerResponse {
+		public List<AcessoItem> list;
+	}
+
+	public interface IAcessosGet extends ISwaggerMethod {
+		public void run(AcessosGetRequest req, AcessosGetResponse resp) throws Exception;
+	}
+
+	public class PessoaTextoPesquisarGetRequest implements ISwaggerRequest {
+		public String texto;
+	}
+
+	public class PessoaTextoPesquisarGetResponse implements ISwaggerResponse {
+		public List<ResultadoDePesquisa> list;
+	}
+
+	public interface IPessoaTextoPesquisarGet extends ISwaggerMethod {
+		public void run(PessoaTextoPesquisarGetRequest req, PessoaTextoPesquisarGetResponse resp) throws Exception;
+	}
+
+	public class LotacaoTextoPesquisarGetRequest implements ISwaggerRequest {
+		public String texto;
+	}
+
+	public class LotacaoTextoPesquisarGetResponse implements ISwaggerResponse {
+		public List<ResultadoDePesquisa> list;
+	}
+
+	public interface ILotacaoTextoPesquisarGet extends ISwaggerMethod {
+		public void run(LotacaoTextoPesquisarGetRequest req, LotacaoTextoPesquisarGetResponse resp) throws Exception;
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/LotacaoTextoPesquisarGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/LotacaoTextoPesquisarGet.java
@@ -1,0 +1,44 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.gov.jfrj.siga.base.Texto;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.dao.DpLotacaoDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ILotacaoTextoPesquisarGet;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.LotacaoTextoPesquisarGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.LotacaoTextoPesquisarGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ResultadoDePesquisa;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class LotacaoTextoPesquisarGet implements ILotacaoTextoPesquisarGet {
+
+	@Override
+	public void run(LotacaoTextoPesquisarGetRequest req,
+			LotacaoTextoPesquisarGetResponse resp) throws Exception {
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		resp.list = new ArrayList<>();
+		final DpLotacaoDaoFiltro flt = new DpLotacaoDaoFiltro();
+		flt.setNome(Texto.removeAcentoMaiusculas(req.texto));
+		//TODO: ver se precisa de outros parametros listarLotacoes
+		List<DpLotacao> l = ExDao.getInstance().consultarPorFiltro(flt);
+		
+		for (DpLotacao p : l) {
+			ResultadoDePesquisa rp = new ResultadoDePesquisa();
+			rp.nome = p.getNomeLotacao();
+			rp.sigla = p.getSiglaCompleta();
+			resp.list.add(rp);
+		}
+
+
+	}
+
+	@Override
+	public String getContext() {
+		return "selecionar pessoas";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/LotacaoTextoPesquisarGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/LotacaoTextoPesquisarGet.java
@@ -3,6 +3,8 @@ package br.gov.jfrj.siga.ex.api.v1;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.crivano.swaggerservlet.SwaggerServlet;
+
 import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.dao.DpLotacaoDaoFiltro;
@@ -10,7 +12,8 @@ import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ILotacaoTextoPesquisarGet;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.LotacaoTextoPesquisarGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.LotacaoTextoPesquisarGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ResultadoDePesquisa;
-import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
 import br.gov.jfrj.siga.hibernate.ExDao;
 
 public class LotacaoTextoPesquisarGet implements ILotacaoTextoPesquisarGet {
@@ -18,8 +21,9 @@ public class LotacaoTextoPesquisarGet implements ILotacaoTextoPesquisarGet {
 	@Override
 	public void run(LotacaoTextoPesquisarGetRequest req,
 			LotacaoTextoPesquisarGetResponse resp) throws Exception {
-		String authorization = TokenCriarPost.assertAuthorization();
-		Usuario u = TokenCriarPost.assertUsuario();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+
+		SwaggerHelper.buscarEValidarUsuarioLogado();
 
 		resp.list = new ArrayList<>();
 		final DpLotacaoDaoFiltro flt = new DpLotacaoDaoFiltro();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MemCacheRedis.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MemCacheRedis.java
@@ -3,6 +3,7 @@ package br.gov.jfrj.siga.ex.api.v1;
 import com.crivano.swaggerservlet.IMemCache;
 import com.crivano.swaggerservlet.SwaggerServlet;
 
+import br.gov.jfrj.siga.base.Prop;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
@@ -36,27 +37,27 @@ public class MemCacheRedis implements IMemCache {
 	}
 
 	public static int getDatabase() {
-		return Integer.parseInt(SwaggerServlet.getProperty("redis.database"));
+		return Integer.parseInt(Prop.get("redis.database"));
 	}
 
 	public static String getPassword() {
-		return SwaggerServlet.getProperty("redis.password");
+		return Prop.get("redis.password");
 	}
 
 	public static int getSlavePort() {
-		return Integer.parseInt(SwaggerServlet.getProperty("redis.slave.port"));
+		return Prop.getInt("redis.slave.port");
 	}
 
 	public static String getSlaveHost() {
-		return SwaggerServlet.getProperty("redis.slave.host");
+		return Prop.get("redis.slave.host");
 	}
 
 	public static String getMasterHost() {
-		return SwaggerServlet.getProperty("redis.master.host");
+		return Prop.get("redis.master.host");
 	}
 
 	public static int getMasterPort() {
-		return Integer.parseInt(SwaggerServlet.getProperty("redis.master.port"));
+		return Prop.getInt("redis.master.port");
 	}
 
 	@Override

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
@@ -8,21 +8,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.crivano.swaggerservlet.SwaggerServlet;
+
 import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
 import br.gov.jfrj.siga.dp.CpMarcador;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMarca;
 import br.gov.jfrj.siga.ex.ExMobil;
-import br.gov.jfrj.siga.ex.bl.Ex;
-import br.gov.jfrj.siga.ex.bl.ExCompetenciaBL;
-import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IMesaGet;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.Marca;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaItem;
 import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExCompetenciaBL;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
 
 public class MesaGet implements IMesaGet {
 
@@ -59,11 +64,11 @@ public class MesaGet implements IMesaGet {
 		NENHUM("Nenhum", "inbox");
 
 		private final String nome;
-		private final String icone;
+		//private final String icone;
 
 		private GrupoDeMarcadorEnum(String nome, String icone) {
 			this.nome = nome;
-			this.icone = icone;
+			//this.icone = icone;
 		}
 	}
 
@@ -235,7 +240,7 @@ public class MesaGet implements IMesaGet {
 			this.id = id;
 			this.nome = nome;
 			this.icone = icone;
-			this.descricao = descricao;
+			//this.descricao = descricao;
 			this.grupo = grupo;
 		}
 
@@ -258,7 +263,7 @@ public class MesaGet implements IMesaGet {
 		private final int id;
 		private final String nome;
 		private final String icone;
-		private final String descricao;
+		//private final String descricao;
 		private final GrupoDeMarcadorEnum grupo;
 
 	}
@@ -268,13 +273,18 @@ public class MesaGet implements IMesaGet {
 		CpMarcador marcador;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void run(MesaGetRequest req, MesaGetResponse resp) throws Exception {
-		String authorization = TokenCriarPost.assertAuthorization();
-		Usuario u = TokenCriarPost.assertUsuario();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
 
+		SwaggerHelper.buscarEValidarUsuarioLogado();
+		SigaObjects so = SwaggerHelper.getSigaObjects();
+		Usuario u = TokenCriarPost.assertUsuario();
+		so.assertAcesso("DOC:Módulo de Documentos;" + "");
+		
 		try {
-			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			DpPessoa cadastrante = so.getCadastrante();
 			
 			List<Object[]> l = ExDao.getInstance().listarDocumentosPorPessoaOuLotacao(cadastrante, cadastrante.getLotacao());
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
@@ -26,6 +26,7 @@ import br.gov.jfrj.siga.ex.bl.CurrentRequest;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.ExCompetenciaBL;
 import br.gov.jfrj.siga.ex.bl.RequestInfo;
+import br.gov.jfrj.siga.ex.bl.Mesa2.GrupoDeMarcadorEnum;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.vraptor.SigaObjects;
 
@@ -36,205 +37,328 @@ public class MesaGet implements IMesaGet {
 	}
 
 	public enum GrupoDeMarcadorEnum {
+		PRONTO_PARA_ASSINAR(1, "Pronto para Assinar", "fas fa-inbox", true, true, false),
 		//
-		PRONTO_PARA_ASSINAR("Pronto para Assinar", "inbox"),
+		ALERTA(2, "Alertas", "fas fa-hourglass-end", true, false, false),
 		//
-		ALERTA("Alertas", "hourglass-end"),
+		A_REVISAR(3, "Pendente de Revisão", "fas fa-glasses", true, true, false),
 		//
-		A_ASSINAR("Pendente de Assinatura", "inbox"),
+		A_ASSINAR(4, "Pendente de Assinatura", "fas fa-key", true, false, false),
 		//
-		CAIXA_DE_ENTRADA("Caixa de Entrada", "inbox"),
+		CAIXA_DE_ENTRADA(5, "Caixa de Entrada", "fas fa-inbox", true, false, false),
 		//
-		EM_ELABORACAO("Em Elaboração", "inbox"),
+		EM_ELABORACAO(6, "Em Elaboração", "fas fa-lightbulb", true, false, false),
 		//
-		AGUARDANDO_ANDAMENTO("Aguardando Andamento", "lightbulb"),
+		AGUARDANDO_ANDAMENTO(7, "Aguardando Andamento", "fas fa-clock", true, true, false),
 		//
-		CAIXA_DE_SAIDA("Caixa de Saída", "inbox"),
+		CAIXA_DE_SAIDA(8, "Caixa de Saída", "fas fa-inbox", false, true, true),
 		//
-		ACOMPANHANDO("Acompanhando", "key"),
+		ACOMPANHANDO(9, "Acompanhando", "fas fa-tags", true, true, false),
 		//
-		MONITORANDO("Monitorando", "hourglass-half"),
+		MONITORANDO(10, "Monitorando", "fas fa-hourglass-half", true, true, false),
 		//
-		AGUARDANDO_ACAO_DE_TEMPORALIDADE("Aguardando Ação de Temporalidade", "hourglass-half"),
+		AGUARDANDO_ACAO_DE_TEMPORALIDADE(11, "Aguardando Ação de Temporalidade",
+				"fas fa-hourglass-half", true, true, true),
 		//
-		OUTROS("Outros", "paper-plane"),
+		OUTROS(12, "Outros", "fas fa-inbox", true, true, false),
 		//
-		QUALQUER("Qualquer", "inbox"),
+		QUALQUER(13, "Qualquer", "fas fa-inbox", false, true, true),
 		//
-		NENHUM("Nenhum", "inbox");
+		NENHUM(14, "Nenhum", "fas fa-inbox", false, true, true);
 
+		private final Integer id;
 		private final String nome;
-		//private final String icone;
+		private final String icone;
+		private final boolean visible;
+		private final boolean collapsed;
+		private final boolean hide;
 
-		private GrupoDeMarcadorEnum(String nome, String icone) {
+		private GrupoDeMarcadorEnum(Integer id, String nome, String icone, boolean visible, boolean collapsed, boolean hide) {
+			this.id = id;
 			this.nome = nome;
-			//this.icone = icone;
+			this.icone = icone;
+			this.visible = visible;
+			this.collapsed = collapsed;
+			this.hide = hide;
+		}
+		public String getNome() {
+			return this.nome;
+		}
+		public Integer getId() {
+			return this.id;
+		}
+		public static GrupoDeMarcadorEnum getByNome(String nome) {
+			for (GrupoDeMarcadorEnum i : GrupoDeMarcadorEnum.values()) {
+				if (i.nome.equals(nome))
+					return i;
+			}
+			return null;
+		}
+		public static GrupoDeMarcadorEnum getById(Integer id) {
+			for (GrupoDeMarcadorEnum i : GrupoDeMarcadorEnum.values()) {
+				if (id.equals(i.id))
+					return i;
+			}
+			return null;
+		}
+		public static List<String> getIdList() {
+			List<String> idList = new ArrayList<String>();
+			for (GrupoDeMarcadorEnum i : GrupoDeMarcadorEnum.values()) {
+				idList.add((i.id).toString());
+			}
+			return idList;
 		}
 	}
 
 	public enum MarcadorEnum {
 		//
-		EM_ELABORACAO(1, "Em Elaboração", "lightbulb", "", GrupoDeMarcadorEnum.EM_ELABORACAO),
+		EM_ELABORACAO(1, "Em Elaboração", "fas fa-lightbulb", "",
+				GrupoDeMarcadorEnum.EM_ELABORACAO),
 		//
-		EM_ANDAMENTO(2, "Aguardando Andamento", "clock-o", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		EM_ANDAMENTO(2, "Aguardando Andamento", "fas fa-clock", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		A_RECEBER(3, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		A_RECEBER(3, "A Receber", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
 		//
-		EXTRAVIADO(4, "Extraviado", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		EXTRAVIADO(4, "Extraviado", "fas fa-inbox", "", GrupoDeMarcadorEnum.ALERTA),
 		//
-		A_ARQUIVAR(5, "A Arquivar", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		A_ARQUIVAR(5, "A Arquivar", "fas fa-inbox", "", GrupoDeMarcadorEnum.OUTROS),
 		//
-		ARQUIVADO_CORRENTE(6, "Arquivado Corrente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		ARQUIVADO_CORRENTE(6, "Arquivado Corrente", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		A_ELIMINAR(7, "A Eliminar", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+		A_ELIMINAR(7, "A Eliminar", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
 		//
-		ELIMINADO(8, "Eliminado", "power-off", "", GrupoDeMarcadorEnum.OUTROS),
+		ELIMINADO(8, "Eliminado", "fas fa-power-off", "", GrupoDeMarcadorEnum.OUTROS),
 		//
-		JUNTADO(9, "Juntado", "lock", "", GrupoDeMarcadorEnum.OUTROS),
+		JUNTADO(9, "Juntado", "fas fa-lock", "", GrupoDeMarcadorEnum.OUTROS),
 		//
-		CANCELADO(10, "Cancelado", "ban", "", GrupoDeMarcadorEnum.OUTROS),
+		JUNTADO_EXTERNO(16, "Juntado Externo", "fas fa-lock", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		TRANSFERIDO_A_ORGAO_EXTERNO(11, "Tranferido a Órgão Externo", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		CANCELADO(10, "Cancelado", "fas fa-ban", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		TRANSFERIDO_A_ORGAO_EXTERNO(11, "Tranferido a Órgão Externo", "fas fa-paper-plane",
+				"", GrupoDeMarcadorEnum.OUTROS),
 
 		//
-		ARQUIVADO_INTERMEDIARIO(12, "Arquivado Intermediário", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		ARQUIVADO_INTERMEDIARIO(12, "Arquivado Intermediário", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		CAIXA_DE_ENTRADA(14, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		CAIXA_DE_ENTRADA(14, "A Receber", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
 		//
-		ARQUIVADO_PERMANENTE(13, "Arquivado Permanente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		ARQUIVADO_PERMANENTE(13, "Arquivado Permanente", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		PENDENTE_DE_ASSINATURA(15, "Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		PENDENTE_DE_ASSINATURA(15, "Pendente de Assinatura", "fas fa-key", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		JUNTADO_A_DOCUMENTO_EXTERNO(16, "Juntado a Documento Externo", "lock", "", GrupoDeMarcadorEnum.OUTROS),
+		JUNTADO_A_DOCUMENTO_EXTERNO(16, "Juntado a Documento Externo", "fas fa-inbox",
+				"", GrupoDeMarcadorEnum.OUTROS),
 		//
-		A_REMETER_PARA_PUBLICACAO(17, "A Remeter para Publicação", "inbox", "",
+		A_REMETER_PARA_PUBLICACAO(17, "A Remeter para Publicação", "fas fa-scroll", "",
 				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 
 		//
-		REMETIDO_PARA_PUBLICACAO(18, "Remetido para Publicação", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		REMETIDO_PARA_PUBLICACAO(18, "Remetido para Publicação", "fas fa-scroll", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		A_REMETER_MANUALMENTE(19, "A Remeter Manualmente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		A_REMETER_MANUALMENTE(19, "A Remeter Manualmente", "fas fa-scroll", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		PUBLICADO(20, "Publicado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		PUBLICADO(20, "Publicado", "fas fa-scroll", "", GrupoDeMarcadorEnum.OUTROS),
 		//
-		PUBLICACAO_SOLICITADA(21, "Publicação Solicitada", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		PUBLICACAO_SOLICITADA(21, "Publicação Solicitada", "fas fa-scroll", "",
+				GrupoDeMarcadorEnum.OUTROS),
 		//
-		DISPONIBILIZADO(22, "Disponibilizado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		DISPONIBILIZADO(22, "Disponibilizado", "fas fa-scroll", "",
+				GrupoDeMarcadorEnum.OUTROS),
 
 		//
-		EM_TRANSITO(23, "Em Trâmite Físico", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_SAIDA),
+		EM_TRANSITO(23, "Em Trâmite Físico", "fas fa-truck", "",
+				GrupoDeMarcadorEnum.CAIXA_DE_SAIDA),
 		//
-		EM_TRANSITO_ELETRONICO(24, "Em Trâmite", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		EM_TRANSITO_ELETRONICO(24, "Em Trâmite", "fas fa-shipping-fast", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		COMO_SUBSCRITOR(25, "Como Subscritor", "key", "", GrupoDeMarcadorEnum.A_ASSINAR),
+		COMO_SUBSCRITOR(25, "Como Subscritor", "fas fa-key", "",
+				GrupoDeMarcadorEnum.A_ASSINAR),
 		//
-		APENSADO(26, "Apensado", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		APENSADO(26, "Apensado", "fas fa-compress-arrows-alt", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		MARCADOR_COMO_GESTOR(27, "Gestor", "pushpin", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		MARCADOR_COMO_GESTOR(27, "Gestor", "fas fa-tag", "",
+				GrupoDeMarcadorEnum.ACOMPANHANDO),
 
 		//
-		MARCADOR_COMO_INTERESSADO(28, "Interessado", "pushpin", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		MARCADOR_COMO_INTERESSADO(28, "Interessado", "fas fa-tag", "",
+				GrupoDeMarcadorEnum.ACOMPANHANDO),
 		//
-		DESPACHO_PENDENTE_DE_ASSINATURA(29, "Despacho Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.ALERTA),
+		DESPACHO_PENDENTE_DE_ASSINATURA(29, "Despacho Pendente de Assinatura",
+				"fas fa-key", "", GrupoDeMarcadorEnum.ALERTA),
 		//
-		ANEXO_PENDENTE_DE_ASSINATURA(30, "Anexo Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.ALERTA),
+		ANEXO_PENDENTE_DE_ASSINATURA(30, "Anexo Pendente de Assinatura", "fas fa-key",
+				"", GrupoDeMarcadorEnum.ALERTA),
 		//
-		SOBRESTADO(31, "Sobrestado", "hourglass-1", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		SOBRESTADO(31, "Sobrestado", "fas fa-hourglass-start", "",
+				GrupoDeMarcadorEnum.ACOMPANHANDO),
 		//
-		SEM_EFEITO(32, "Sem Efeito", "power-off", "", GrupoDeMarcadorEnum.NENHUM),
+		SEM_EFEITO(32, "Sem Efeito", "fas fa-power-off", "",
+				GrupoDeMarcadorEnum.NENHUM),
 
 		//
-		ATIVO(36, "Ativo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		ATIVO(36, "Ativo", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
 		NOVO(37, "Novo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
 		POPULAR(38, "Popular", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
 		//
-		REVISAR(39, "A Revisar", "search", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		TOMAR_CIENCIA(40, "Tomar Ciência", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-
-		//
-		SOLICITACAO_A_RECEBER(41, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
-		//
-		SOLICITACAO_EM_ANDAMENTO(42, "Em Andamento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_FECHADO(43, "Fechado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
-		//
-		SOLICITACAO_PENDENTE(44, "Pendente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
-		//
-		SOLICITACAO_CANCELADO(45, "Cancelado", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
-
-		//
-		SOLICITACAO_PRE_ATENDIMENTO(46, "Pré-atendimento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_POS_ATENDIMENTO(47, "Pós-atendimento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_COMO_CADASTRANTE(48, "Cadastrante", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_COMO_SOLICITANTE(49, "Solicitante", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		RECOLHER_PARA_ARQUIVO_PERMANENTE(50, "Recolher Arq. Permante", "inbox", "",
-				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
-
-		//
-		TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO(51, "Transferir Arq. Intermediário", "inbox", "",
-				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
-		//
-		EM_EDITAL_DE_ELIMINACAO(52, "Em Edital de Eliminação", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_FECHADO_PARCIAL(53, "Fechado Parcial", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
-		//
-		SOLICITACAO_EM_CONTROLE_QUALIDADE(54, "Em Controle de Qualidade", "inbox", "",
+		REVISAR(39, "A Revisar", "fas fa-glasses", "",
 				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		A_DEVOLVER(56, "A Devolver", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		TOMAR_CIENCIA(40, "Tomar Ciência", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 
 		//
-		AGUARDANDO(57, "Aguardando", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		SOLICITACAO_A_RECEBER(41, "A Receber", "inbox", "",
+				GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
 		//
-		A_DEVOLVER_FORA_DO_PRAZO(58, "A Devolver Fora do Prazo", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		SOLICITACAO_EM_ANDAMENTO(42, "Em Andamento", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		AGUARDANDO_DEVOLUCAO_FORA_DO_PRAZO(59, "Aguardando Devolução Fora Do Prazo", "inbox", "",
+		SOLICITACAO_FECHADO(43, "Fechado", "inbox", "",
+				GrupoDeMarcadorEnum.OUTROS),
+		//
+		SOLICITACAO_PENDENTE(44, "Pendente", "inbox", "",
+				GrupoDeMarcadorEnum.OUTROS),
+		//
+		SOLICITACAO_CANCELADO(45, "Cancelado", "inbox", "",
+				GrupoDeMarcadorEnum.NENHUM),
+
+		//
+		SOLICITACAO_PRE_ATENDIMENTO(46, "Pré-atendimento", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_POS_ATENDIMENTO(47, "Pós-atendimento", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_COMO_CADASTRANTE(48, "Cadastrante", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_COMO_SOLICITANTE(49, "Solicitante", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		RECOLHER_PARA_ARQUIVO_PERMANENTE(50, "Recolher Arq. Permante", "fas fa-inbox",
+				"", GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+
+		//
+		TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO(51,
+				"Transferir Arq. Intermediário", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+		//
+		EM_EDITAL_DE_ELIMINACAO(52, "Em Edital de Eliminação", "fas fa-inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_FECHADO_PARCIAL(53, "Fechado Parcial", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_EM_CONTROLE_QUALIDADE(54, "Em Controle de Qualidade",
+				"inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		A_DEVOLVER(56, "A Devolver", "fas fa-exchange-alt", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		AGUARDANDO(57, "Aguardando", "fas fa-clock", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		A_DEVOLVER_FORA_DO_PRAZO(58, "A Devolver Fora do Prazo", "fas fa-exchange-alt", "",
 				GrupoDeMarcadorEnum.ALERTA),
 		//
-		PENDENTE_DE_ANEXACAO(60, "Pendente de Anexação", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		AGUARDANDO_DEVOLUCAO_FORA_DO_PRAZO(59,
+				"Aguardando Devolução Fora Do Prazo", "fas fa-exchange-alt", "",
+				GrupoDeMarcadorEnum.ALERTA),
 		//
-		SOLICITACAO_EM_ELABORACAO(61, "Em Elaboração", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		PENDENTE_DE_ANEXACAO(60, "Pendente de Anexação", "fas fa-arrow-alt-circle-up", "",
+				GrupoDeMarcadorEnum.ALERTA),
+		//
+		SOLICITACAO_EM_ELABORACAO(61, "Em Elaboração", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 
 		//
-		DOCUMENTO_ASSINADO_COM_SENHA(62, "Assinado com Senha", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
-		//
-		MOVIMENTACAO_ASSINADA_COM_SENHA(63, "Movimentação Ass. com Senha", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
-		//
-		MOVIMENTACAO_CONFERIDA_COM_SENHA(64, "Movimentação Autenticada com Senha", "inbox", "",
+		DOCUMENTO_ASSINADO_COM_SENHA(62, "Assinado com Senha", "fas fa-key", "",
 				GrupoDeMarcadorEnum.NENHUM),
 		//
-		SOLICITACAO_FORA_DO_PRAZO(65, "Fora do Prazo", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		MOVIMENTACAO_ASSINADA_COM_SENHA(63, "Movimentação Ass. com Senha",
+				"fas fa-key", "", GrupoDeMarcadorEnum.NENHUM),
 		//
-		SOLICITACAO_ATIVO(66, "Ativo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		MOVIMENTACAO_CONFERIDA_COM_SENHA(64,
+				"Movimentação Autenticada com Senha", "fas fa-key", "",
+				GrupoDeMarcadorEnum.NENHUM),
+		//
+		SOLICITACAO_FORA_DO_PRAZO(65, "Fora do Prazo", "inbox", "",
+				GrupoDeMarcadorEnum.ALERTA),
+		//
+		SOLICITACAO_ATIVO(66, "Ativo", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 
 		//
-		PENDENTE_DE_COLABORACAO(67, "Pendente de Colaboração", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		PENDENTE_DE_COLABORACAO(67, "Pendente de Colaboração", "fas fa-users-cog", "",
+				GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
 		//
-		FINALIZAR_DOCUMENTO_COLABORATIVO(68, "Finalizar Documento Colaborativo", "inbox", "",
+		FINALIZAR_DOCUMENTO_COLABORATIVO(68,
+				"Finalizar Documento Colaborativo", "fas fa-users-cog", "",
 				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
 		//
-		SOLICITACAO_NECESSITA_PROVIDENCIA(69, "Necessita Providência", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		SOLICITACAO_NECESSITA_PROVIDENCIA(69, "Necessita Providência", "inbox",
+				"", GrupoDeMarcadorEnum.ALERTA),
 		//
-		COMO_EXECUTOR(70, "Executor", "inbox", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		COMO_EXECUTOR(70, "Executor", "inbox", "",
+				GrupoDeMarcadorEnum.ACOMPANHANDO),
 		//
-		MARCADOR_PRONTO_PARA_ASSINAR(71, "Pronto para Assinar", "key", "", GrupoDeMarcadorEnum.PRONTO_PARA_ASSINAR),
+		MARCADOR_PRONTO_PARA_ASSINAR(71, "Pronto para Assinar", "fas fa-check-circle", "",
+				GrupoDeMarcadorEnum.PRONTO_PARA_ASSINAR),
 		//
-		COMO_REVISOR(72, "Como Revisor", "key", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		MARCADOR_COMO_REVISOR(72, "Como Revisor", "fas fa-glasses", "",
+				GrupoDeMarcadorEnum.A_REVISAR),
 		//
-		URGENTE(1000, "Urgente", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		MARCADOR_PORTAL_TRANSPARENCIA(73, "Portal da Transparência", "fas fa-globe", "",
+				GrupoDeMarcadorEnum.NENHUM),
+		//
+		URGENTE(1000, "Urgente", "fas fa-bomb", "", GrupoDeMarcadorEnum.ALERTA),
 
 		//
-		IDOSO(1001, "Idoso", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		IDOSO(1001, "Idoso", "fas fa-user-tag", "", GrupoDeMarcadorEnum.ALERTA),
 
 		//
-		RETENCAO_INSS(1002, "Retenção de INSS", "inbox", "", GrupoDeMarcadorEnum.ALERTA);
+		RETENCAO_INSS(1002, "Retenção de INSS", "fas fa-tag", "",
+				GrupoDeMarcadorEnum.ALERTA),
+		//
+		PRIORITARIO(1003, "Prioritário", "fas fa-star", "", GrupoDeMarcadorEnum.ALERTA),
+		//		
+		RESTRICAO_ACESSO(1004, "Restrição de Acesso", "fas fa-user-secret", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		DOCUMENTO_ANALISADO(1005, "Documento Analisado", "fas fa-book-reader", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		COVID_19(1006, "COVID-19", "fas fa-tag", "",
+				GrupoDeMarcadorEnum.NENHUM),
+		//
+		NOTA_EMPENHO(1007, "Nota de Empenho", "fas fa-tag", "",
+				GrupoDeMarcadorEnum.NENHUM),
+		//
+		DEMANDA_JUDICIAL_BAIXA(1008, "Demanda Judicial Prioridade Baixa", "fas fa-tag", "",
+                GrupoDeMarcadorEnum.ALERTA),
+		//
+		DEMANDA_JUDICIAL_MEDIA(1009, "Demanda Judicial Prioridade Média", "fas fa-tag", "",
+                GrupoDeMarcadorEnum.ALERTA),
+		//
+		DEMANDA_JUDICIAL_ALTA(1010, "Demanda Judicial Prioridade Alta", "fas fa-tag", "",
+                GrupoDeMarcadorEnum.ALERTA);
 
 		private MarcadorEnum(int id, String nome, String icone, String descricao, GrupoDeMarcadorEnum grupo) {
 			this.id = id;
@@ -306,7 +430,8 @@ public class MesaGet implements IMesaGet {
 			resp.list = listarReferencias(TipoDePainelEnum.UNIDADE, map, cadastrante, cadastrante.getLotacao(), u,
 					ExDao.getInstance().consultarDataEHoraDoServidor());
 		}catch (Exception e) {
-			// TODO: handle exception
+			e.printStackTrace(System.out);
+			throw e;
 		}
 
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
@@ -1,0 +1,405 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
+import br.gov.jfrj.siga.dp.CpMarcador;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMarca;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExCompetenciaBL;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IMesaGet;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.Marca;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.MesaItem;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+
+public class MesaGet implements IMesaGet {
+
+	public enum TipoDePainelEnum {
+		PESSOAL, UNIDADE;
+	}
+
+	public enum GrupoDeMarcadorEnum {
+		//
+		PRONTO_PARA_ASSINAR("Pronto para Assinar", "inbox"),
+		//
+		ALERTA("Alertas", "hourglass-end"),
+		//
+		A_ASSINAR("Pendente de Assinatura", "inbox"),
+		//
+		CAIXA_DE_ENTRADA("Caixa de Entrada", "inbox"),
+		//
+		EM_ELABORACAO("Em Elaboração", "inbox"),
+		//
+		AGUARDANDO_ANDAMENTO("Aguardando Andamento", "lightbulb"),
+		//
+		CAIXA_DE_SAIDA("Caixa de Saída", "inbox"),
+		//
+		ACOMPANHANDO("Acompanhando", "key"),
+		//
+		MONITORANDO("Monitorando", "hourglass-half"),
+		//
+		AGUARDANDO_ACAO_DE_TEMPORALIDADE("Aguardando Ação de Temporalidade", "hourglass-half"),
+		//
+		OUTROS("Outros", "paper-plane"),
+		//
+		QUALQUER("Qualquer", "inbox"),
+		//
+		NENHUM("Nenhum", "inbox");
+
+		private final String nome;
+		private final String icone;
+
+		private GrupoDeMarcadorEnum(String nome, String icone) {
+			this.nome = nome;
+			this.icone = icone;
+		}
+	}
+
+	public enum MarcadorEnum {
+		//
+		EM_ELABORACAO(1, "Em Elaboração", "lightbulb", "", GrupoDeMarcadorEnum.EM_ELABORACAO),
+		//
+		EM_ANDAMENTO(2, "Aguardando Andamento", "clock-o", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		A_RECEBER(3, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		//
+		EXTRAVIADO(4, "Extraviado", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		A_ARQUIVAR(5, "A Arquivar", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		ARQUIVADO_CORRENTE(6, "Arquivado Corrente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		A_ELIMINAR(7, "A Eliminar", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+		//
+		ELIMINADO(8, "Eliminado", "power-off", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		JUNTADO(9, "Juntado", "lock", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		CANCELADO(10, "Cancelado", "ban", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		TRANSFERIDO_A_ORGAO_EXTERNO(11, "Tranferido a Órgão Externo", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+
+		//
+		ARQUIVADO_INTERMEDIARIO(12, "Arquivado Intermediário", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		CAIXA_DE_ENTRADA(14, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		//
+		ARQUIVADO_PERMANENTE(13, "Arquivado Permanente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		PENDENTE_DE_ASSINATURA(15, "Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		JUNTADO_A_DOCUMENTO_EXTERNO(16, "Juntado a Documento Externo", "lock", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		A_REMETER_PARA_PUBLICACAO(17, "A Remeter para Publicação", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		REMETIDO_PARA_PUBLICACAO(18, "Remetido para Publicação", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		A_REMETER_MANUALMENTE(19, "A Remeter Manualmente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		PUBLICADO(20, "Publicado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		PUBLICACAO_SOLICITADA(21, "Publicação Solicitada", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		DISPONIBILIZADO(22, "Disponibilizado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+
+		//
+		EM_TRANSITO(23, "Em Trâmite Físico", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_SAIDA),
+		//
+		EM_TRANSITO_ELETRONICO(24, "Em Trâmite", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		COMO_SUBSCRITOR(25, "Como Subscritor", "key", "", GrupoDeMarcadorEnum.A_ASSINAR),
+		//
+		APENSADO(26, "Apensado", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		MARCADOR_COMO_GESTOR(27, "Gestor", "pushpin", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+
+		//
+		MARCADOR_COMO_INTERESSADO(28, "Interessado", "pushpin", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		//
+		DESPACHO_PENDENTE_DE_ASSINATURA(29, "Despacho Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		ANEXO_PENDENTE_DE_ASSINATURA(30, "Anexo Pendente de Assinatura", "key", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		SOBRESTADO(31, "Sobrestado", "hourglass-1", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		//
+		SEM_EFEITO(32, "Sem Efeito", "power-off", "", GrupoDeMarcadorEnum.NENHUM),
+
+		//
+		ATIVO(36, "Ativo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		NOVO(37, "Novo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		POPULAR(38, "Popular", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		REVISAR(39, "A Revisar", "search", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		TOMAR_CIENCIA(40, "Tomar Ciência", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		SOLICITACAO_A_RECEBER(41, "A Receber", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		//
+		SOLICITACAO_EM_ANDAMENTO(42, "Em Andamento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_FECHADO(43, "Fechado", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		SOLICITACAO_PENDENTE(44, "Pendente", "inbox", "", GrupoDeMarcadorEnum.OUTROS),
+		//
+		SOLICITACAO_CANCELADO(45, "Cancelado", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
+
+		//
+		SOLICITACAO_PRE_ATENDIMENTO(46, "Pré-atendimento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_POS_ATENDIMENTO(47, "Pós-atendimento", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_COMO_CADASTRANTE(48, "Cadastrante", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_COMO_SOLICITANTE(49, "Solicitante", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		RECOLHER_PARA_ARQUIVO_PERMANENTE(50, "Recolher Arq. Permante", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+
+		//
+		TRANSFERIR_PARA_ARQUIVO_INTERMEDIARIO(51, "Transferir Arq. Intermediário", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ACAO_DE_TEMPORALIDADE),
+		//
+		EM_EDITAL_DE_ELIMINACAO(52, "Em Edital de Eliminação", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_FECHADO_PARCIAL(53, "Fechado Parcial", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_EM_CONTROLE_QUALIDADE(54, "Em Controle de Qualidade", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		A_DEVOLVER(56, "A Devolver", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		AGUARDANDO(57, "Aguardando", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		A_DEVOLVER_FORA_DO_PRAZO(58, "A Devolver Fora do Prazo", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		AGUARDANDO_DEVOLUCAO_FORA_DO_PRAZO(59, "Aguardando Devolução Fora Do Prazo", "inbox", "",
+				GrupoDeMarcadorEnum.ALERTA),
+		//
+		PENDENTE_DE_ANEXACAO(60, "Pendente de Anexação", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		SOLICITACAO_EM_ELABORACAO(61, "Em Elaboração", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		DOCUMENTO_ASSINADO_COM_SENHA(62, "Assinado com Senha", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
+		//
+		MOVIMENTACAO_ASSINADA_COM_SENHA(63, "Movimentação Ass. com Senha", "inbox", "", GrupoDeMarcadorEnum.NENHUM),
+		//
+		MOVIMENTACAO_CONFERIDA_COM_SENHA(64, "Movimentação Autenticada com Senha", "inbox", "",
+				GrupoDeMarcadorEnum.NENHUM),
+		//
+		SOLICITACAO_FORA_DO_PRAZO(65, "Fora do Prazo", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		SOLICITACAO_ATIVO(66, "Ativo", "inbox", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+
+		//
+		PENDENTE_DE_COLABORACAO(67, "Pendente de Colaboração", "inbox", "", GrupoDeMarcadorEnum.CAIXA_DE_ENTRADA),
+		//
+		FINALIZAR_DOCUMENTO_COLABORATIVO(68, "Finalizar Documento Colaborativo", "inbox", "",
+				GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		SOLICITACAO_NECESSITA_PROVIDENCIA(69, "Necessita Providência", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+		//
+		COMO_EXECUTOR(70, "Executor", "inbox", "", GrupoDeMarcadorEnum.ACOMPANHANDO),
+		//
+		MARCADOR_PRONTO_PARA_ASSINAR(71, "Pronto para Assinar", "key", "", GrupoDeMarcadorEnum.PRONTO_PARA_ASSINAR),
+		//
+		COMO_REVISOR(72, "Como Revisor", "key", "", GrupoDeMarcadorEnum.AGUARDANDO_ANDAMENTO),
+		//
+		URGENTE(1000, "Urgente", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+
+		//
+		IDOSO(1001, "Idoso", "inbox", "", GrupoDeMarcadorEnum.ALERTA),
+
+		//
+		RETENCAO_INSS(1002, "Retenção de INSS", "inbox", "", GrupoDeMarcadorEnum.ALERTA);
+
+		private MarcadorEnum(int id, String nome, String icone, String descricao, GrupoDeMarcadorEnum grupo) {
+			this.id = id;
+			this.nome = nome;
+			this.icone = icone;
+			this.descricao = descricao;
+			this.grupo = grupo;
+		}
+
+		public static MarcadorEnum getById(int id) {
+			for (MarcadorEnum i : MarcadorEnum.values()) {
+				if (i.id == id)
+					return i;
+			}
+			return null;
+		}
+
+		public String getIcone() {
+			return icone;
+		}
+
+		public String getNome() {
+			return nome;
+		}
+
+		private final int id;
+		private final String nome;
+		private final String icone;
+		private final String descricao;
+		private final GrupoDeMarcadorEnum grupo;
+
+	}
+
+	private static class MeM {
+		ExMarca marca;
+		CpMarcador marcador;
+	}
+
+	@Override
+	public void run(MesaGetRequest req, MesaGetResponse resp) throws Exception {
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		try {
+			DpPessoa cadastrante = ExDao.getInstance().getPessoaPorPrincipal(u.usuario);
+			
+			List<Object[]> l = ExDao.getInstance().listarDocumentosPorPessoaOuLotacao(cadastrante, cadastrante.getLotacao());
+
+			HashMap<ExMobil, List<MeM>> map = new HashMap<>();
+
+			for (Object[] reference : l) {
+				ExMarca marca = (ExMarca) reference[0];
+				CpMarcador marcador = (CpMarcador) reference[1];
+				ExMobil mobil = (ExMobil) reference[2];
+
+				if (!map.containsKey(mobil))
+					map.put(mobil, new ArrayList<MeM>());
+				MeM mm = new MeM();
+				mm.marca = marca;
+				mm.marcador = marcador;
+				map.get(mobil).add(mm);
+			}
+
+			resp.list = listarReferencias(TipoDePainelEnum.UNIDADE, map, cadastrante, cadastrante.getLotacao(), u,
+					ExDao.getInstance().consultarDataEHoraDoServidor());
+		}catch (Exception e) {
+			// TODO: handle exception
+		}
+
+	}
+
+	@Override
+	public String getContext() {
+		return "obter classe processual";
+	}
+
+	public static List<MesaItem> listarReferencias(TipoDePainelEnum tipo, Map<ExMobil, List<MeM>> references,
+			DpPessoa pessoa, DpLotacao unidade, Usuario usuario, Date currentDate) {
+		List<MesaItem> l = new ArrayList<>();
+
+		for (ExMobil mobil : references.keySet()) {
+			MesaItem r = new MesaItem();
+			r.tipo = "Documento";
+
+			Date datahora = null;
+			if (mobil.getUltimaMovimentacao() != null)
+				datahora = mobil.getUltimaMovimentacao().getDtIniMov();
+			else
+				datahora = mobil.getDoc().getDtAltDoc();
+			r.datahora = datahora;
+			r.tempoRelativo = Utils.calcularTempoRelativo(datahora);
+
+			r.codigo = mobil.getCodigoCompacto();
+			r.sigla = mobil.getSigla();
+			r.descr = mobil.doc().getDescrCurta();
+
+			if (mobil.doc().getSubscritor() != null && mobil.doc().getSubscritor().getLotacao() != null)
+				r.origem = mobil.doc().getSubscritor().getLotacao().getSigla();
+
+			r.grupo = GrupoDeMarcadorEnum.NENHUM.name();
+			r.grupoOrdem = Integer.toString(GrupoDeMarcadorEnum.valueOf(r.grupo).ordinal());
+			r.grupoNome = GrupoDeMarcadorEnum.valueOf(r.grupo).nome;
+			
+			ExCompetenciaBL comp = Ex.getInstance().getComp();
+			r.podeAnotar = comp.podeFazerAnotacao(pessoa, unidade, mobil);
+			r.podeAssinar = comp.podeAssinar(pessoa, unidade, mobil);
+			
+			boolean apenasComSolicitacaoDeAssinatura = !Ex.getInstance().getConf().podePorConfiguracao(pessoa, CpTipoConfiguracao.TIPO_CONFIG_PODE_ASSINAR_SEM_SOLICITACAO);
+			
+			r.podeAssinarEmLote = apenasComSolicitacaoDeAssinatura ? r.podeAssinar && mobil.doc().isAssinaturaSolicitada() : r.podeAssinar;
+			r.podeTramitar = comp.podeTransferir(pessoa, unidade, mobil);
+
+			r.list = new ArrayList<IExApiV1.Marca>();
+
+			for (MeM tag : references.get(mobil)) {
+				if (tag.marca.getDtIniMarca() != null && tag.marca.getDtIniMarca().getTime() > currentDate.getTime())
+					continue;
+				if (tag.marca.getDtFimMarca() != null && tag.marca.getDtFimMarca().getTime() < currentDate.getTime())
+					continue;
+
+				Marca t = new Marca();
+				MarcadorEnum mar = MarcadorEnum.getById(tag.marcador.getIdMarcador().intValue());
+
+				t.nome = mar.getNome();
+				t.icone = mar.getIcone();
+				t.titulo = Utils.calcularTempoRelativo(tag.marca.getDtIniMarca());
+
+				if (tag.marca.getDpPessoaIni() != null) {
+					DpPessoa pes = tag.marca.getDpPessoaIni().getPessoaAtual();
+					if (pes.getNomeExibicao() != null)
+						t.pessoa = pes.getNomeExibicao();
+				}
+				if (tag.marca.getDpLotacaoIni() != null)
+					t.lotacao = tag.marca.getDpLotacaoIni().getLotacaoAtual().getSigla();
+				t.inicio = tag.marca.getDtIniMarca();
+				t.termino = tag.marca.getDtFimMarca();
+
+				if (GrupoDeMarcadorEnum.valueOf(r.grupo).ordinal() > mar.grupo.ordinal()) {
+					r.grupo = mar.grupo.name();
+					r.grupoOrdem = Integer.toString(mar.grupo.ordinal());
+					r.grupoNome = mar.grupo.nome;
+				}
+
+				r.list.add(t);
+				if (pessoa != null && tag.marca.getDpPessoaIni() != null) {
+					if (pessoa.getIdInicial().equals(tag.marca.getDpPessoaIni().getId()))
+						t.daPessoa = true;
+					else
+						t.deOutraPessoa = tag.marca.getDpPessoaIni() != null;
+				}
+				if (unidade != null && tag.marca.getDpLotacaoIni() != null
+						&& unidade.getId().equals(tag.marca.getDpLotacaoIni().getId()))
+					t.daLotacao = true;
+			}
+			l.add(r);
+		}
+
+		Collections.sort(l, new Comparator<MesaItem>() {
+			@Override
+			public int compare(MesaItem o1, MesaItem o2) {
+				int i = Integer.compare(Integer.parseInt(o1.grupoOrdem), Integer.parseInt(o2.grupoOrdem));
+				if (i != 0)
+					return i;
+				i = o2.datahora.compareTo(o1.datahora);
+				if (i != 0)
+					return i;
+				return 0;
+			}
+		});
+		return l;
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/PessoaTextoPesquisarGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/PessoaTextoPesquisarGet.java
@@ -1,0 +1,47 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.gov.jfrj.siga.base.Texto;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.dp.dao.DpPessoaDaoFiltro;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IPessoaTextoPesquisarGet;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.PessoaTextoPesquisarGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.PessoaTextoPesquisarGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ResultadoDePesquisa;
+import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class PessoaTextoPesquisarGet implements IPessoaTextoPesquisarGet {
+
+	@Override
+	public void run(PessoaTextoPesquisarGetRequest req,
+			PessoaTextoPesquisarGetResponse resp) throws Exception {
+		String authorization = TokenCriarPost.assertAuthorization();
+		Usuario u = TokenCriarPost.assertUsuario();
+
+		resp.list = new ArrayList<>();
+		try {
+			final DpPessoaDaoFiltro flt = new DpPessoaDaoFiltro();
+			flt.setNome(Texto.removeAcentoMaiusculas(req.texto));
+			//TODO: ver se precisa de outros parametros listarPessoa
+			List<DpPessoa> l = ExDao.getInstance().consultarPorFiltro (flt);
+
+			for (DpPessoa p : l) {
+				ResultadoDePesquisa rp = new ResultadoDePesquisa();
+				rp.nome = p.getNomePessoa();
+				rp.sigla = p.getSigla();
+				resp.list.add(rp);
+			}
+		}catch (Exception e) {
+			// TODO: handle exception
+		}
+
+	}
+
+	@Override
+	public String getContext() {
+		return "selecionar pessoas";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/PessoaTextoPesquisarGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/PessoaTextoPesquisarGet.java
@@ -3,6 +3,8 @@ package br.gov.jfrj.siga.ex.api.v1;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.crivano.swaggerservlet.SwaggerServlet;
+
 import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.dp.dao.DpPessoaDaoFiltro;
@@ -10,7 +12,8 @@ import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IPessoaTextoPesquisarGet;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.PessoaTextoPesquisarGetRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.PessoaTextoPesquisarGetResponse;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ResultadoDePesquisa;
-import br.gov.jfrj.siga.ex.api.v1.TokenCriarPost.Usuario;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
 import br.gov.jfrj.siga.hibernate.ExDao;
 
 public class PessoaTextoPesquisarGet implements IPessoaTextoPesquisarGet {
@@ -18,15 +21,15 @@ public class PessoaTextoPesquisarGet implements IPessoaTextoPesquisarGet {
 	@Override
 	public void run(PessoaTextoPesquisarGetRequest req,
 			PessoaTextoPesquisarGetResponse resp) throws Exception {
-		String authorization = TokenCriarPost.assertAuthorization();
-		Usuario u = TokenCriarPost.assertUsuario();
+		CurrentRequest.set(new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+		SwaggerHelper.buscarEValidarUsuarioLogado();
 
 		resp.list = new ArrayList<>();
 		try {
 			final DpPessoaDaoFiltro flt = new DpPessoaDaoFiltro();
 			flt.setNome(Texto.removeAcentoMaiusculas(req.texto));
 			//TODO: ver se precisa de outros parametros listarPessoa
-			List<DpPessoa> l = ExDao.getInstance().consultarPorFiltro (flt);
+			List<DpPessoa> l = ExDao.getInstance().consultarPorFiltro(flt);
 
 			for (DpPessoa p : l) {
 				ResultadoDePesquisa rp = new ResultadoDePesquisa();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
@@ -1,0 +1,273 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import br.gov.jfrj.itextpdf.Documento;
+import br.gov.jfrj.siga.Service;
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.bluc.service.BlucService;
+import br.gov.jfrj.siga.bluc.service.HashRequest;
+import br.gov.jfrj.siga.bluc.service.HashResponse;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.ExNivelAcesso;
+import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+import br.gov.jfrj.siga.ex.bl.Ex;
+
+import com.lowagie.text.pdf.codec.Base64;
+
+public class SigaDocPdfUtils {
+	private static final String TEXT_HTML = "text/html";
+	private static final String APPLICATION_PDF = "application/pdf";
+	private static final String TEXT_PLAIN = "text/plain";
+	private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+	private static byte[] idPattern = "/ModDate(D:20".getBytes();
+	private static int[] failure = computeFailure();
+
+	public static InputStreamDownload exibir(final String sigla,
+			final boolean popup, final String arquivo, byte[] certificado,
+			String hash, final String HASH_ALGORITHM,
+			final String certificadoB64, boolean completo,
+			final boolean semmarcas, DpPessoa titular, DpLotacao lotaTitular,
+			Date dataEHoraDoServidor, HttpServletRequest request,
+			HttpServletResponse response) {
+		try {
+			final String servernameport = request.getServerName() + ":"
+					+ request.getServerPort();
+			final String contextpath = request.getContextPath();
+			final boolean pacoteAssinavel = (certificadoB64 != null);
+			final boolean fB64 = request.getHeader("Accept") != null
+					&& request.getHeader("Accept").startsWith(
+							"text/vnd.siga.b64encoded");
+			final boolean fJSON = request.getHeader("Accept") != null
+					&& request.getHeader("Accept").startsWith(
+							"application/json");
+			final boolean isPdf = arquivo.endsWith(".pdf");
+			final boolean isHtml = arquivo.endsWith(".html");
+			boolean estampar = !semmarcas;
+			final boolean somenteHash = (hash != null)
+					|| (HASH_ALGORITHM != null);
+			if (somenteHash) {
+				if (hash == null)
+					hash = HASH_ALGORITHM;
+				if (hash != null) {
+					if (!(hash.equals("SHA1") || hash.equals("SHA-256")
+							|| hash.equals("SHA-512") || hash.equals("MD5"))) {
+						throw new AplicacaoException(
+								"Algoritmo de hash inválido. Os permitidos são: SHA1, SHA-256, SHA-512 e MD5.");
+					}
+				}
+				completo = false;
+				estampar = false;
+			}
+			if (pacoteAssinavel) {
+				certificado = Base64.decode(certificadoB64);
+				completo = false;
+				estampar = false;
+			}
+			final ExMobil mob = Documento.getMobil(arquivo);
+			if (mob == null) {
+				throw new AplicacaoException(
+						"A sigla informada não corresponde a um documento da base de dados.");
+			}
+			if (!Ex.getInstance().getComp()
+					.podeAcessarDocumento(titular, lotaTitular, mob)) {
+				throw new AplicacaoException("Documento " + mob.getSigla()
+						+ " inacessível ao usuário " + titular.getSigla() + "/"
+						+ lotaTitular.getSiglaCompleta() + ".");
+			}
+			final ExMovimentacao mov = Documento.getMov(mob, arquivo);
+			final boolean isArquivoAuxiliar = mov != null
+					&& mov.getExTipoMovimentacao()
+							.getId()
+							.equals(ExTipoMovimentacao.TIPO_MOVIMENTACAO_ANEXACAO_DE_ARQUIVO_AUXILIAR);
+			final boolean imutavel = (mov != null) && !completo && !estampar
+					&& !somenteHash && !pacoteAssinavel;
+			String cacheControl = "private";
+			final Integer grauNivelAcesso = mob.doc().getExNivelAcesso()
+					.getGrauNivelAcesso();
+			if (ExNivelAcesso.NIVEL_ACESSO_PUBLICO == grauNivelAcesso
+					|| ExNivelAcesso.NIVEL_ACESSO_ENTRE_ORGAOS == grauNivelAcesso) {
+				cacheControl = "public";
+			}
+			byte ab[] = null;
+			if (isArquivoAuxiliar) {
+				ab = mov.getConteudoBlobMov2();
+				return new InputStreamDownload(makeByteArrayInputStream(ab,
+						fB64), APPLICATION_OCTET_STREAM, mov.getNmArqMov(),
+						(!fB64) ? ab.length : null);
+			}
+			if (isPdf) {
+				if (mov != null && !completo && !estampar && hash == null) {
+					ab = mov.getConteudoBlobpdf();
+				} else {
+					ByteArrayOutputStream baos = new ByteArrayOutputStream();
+					Documento.getDocumento(baos, null, mob, null, completo, semmarcas, false, null, null);
+					ab = baos.toByteArray();
+				}
+				if (ab == null) {
+					throw new Exception("PDF inválido!");
+				}
+				if (pacoteAssinavel) {
+					response.setHeader("Atributo-Assinavel-Data-Hora",
+							Long.toString(dataEHoraDoServidor.getTime()));
+
+					// Chamar o BluC para criar o pacote assinavel
+					//
+					BlucService bluc = Service.getBlucService();
+					HashRequest hashreq = new HashRequest();
+					hashreq.setCertificate(certificadoB64);
+					hashreq.setCrl("true");
+					hashreq.setPolicy("AD-RB");
+					hashreq.setSha1(bluc.bytearray2b64(bluc.calcSha1(ab)));
+					hashreq.setSha256(bluc.bytearray2b64(bluc.calcSha256(ab)));
+					hashreq.setTime(dataEHoraDoServidor);
+					HashResponse hashresp = bluc.hash(hashreq);
+					if (hashresp.getErrormsg() != null)
+						throw new Exception(
+								"BluC não conseguiu produzir o pacote assinável. "
+										+ hashresp.getErrormsg());
+					byte[] sa = Base64.decode(hashresp.getHash());
+
+					return new InputStreamDownload(makeByteArrayInputStream(sa,
+							fB64), APPLICATION_OCTET_STREAM, arquivo,
+							(!fB64) ? sa.length : null);
+				}
+				if (hash != null) {
+					return new InputStreamDownload(makeByteArrayInputStream(ab,
+							fB64), APPLICATION_OCTET_STREAM, arquivo,
+							(!fB64) ? ab.length : null);
+				}
+			}
+			if (isHtml) {
+				ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				Documento.getDocumentoHTML(baos, null, mob, mov, completo, false, contextpath, servernameport);
+				ab = baos.toByteArray();
+
+				if (ab == null) {
+					throw new Exception("HTML inválido!");
+				}
+			}
+			if (imutavel) {
+				response.setHeader("Cache-Control", cacheControl);
+				response.setDateHeader("Expires", new Date().getTime()
+						+ (365 * 24 * 3600 * 1000L));
+			} else {
+				final MessageDigest md = MessageDigest.getInstance("MD5");
+				final int m = match(ab);
+				if (m != -1) {
+					md.update(ab, 0, m);
+				} else {
+					md.update(ab);
+				}
+				final String etag = Base64.encodeBytes(md.digest());
+				final String ifNoneMatch = request.getHeader("If-None-Match");
+				response.setHeader("Cache-Control", "must-revalidate, "
+						+ cacheControl);
+				response.setDateHeader("Expires",
+						(new Date()).getTime() + 30000);
+				response.setHeader("ETag", etag);
+
+				if ((etag).equals(ifNoneMatch) && ifNoneMatch != null) {
+					response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+					return new InputStreamDownload(makeByteArrayInputStream(
+							(new byte[0]), false), TEXT_PLAIN,
+							"arquivo inválido", 0);
+				}
+			}
+			response.setHeader("Pragma", "");
+			return new InputStreamDownload(makeByteArrayInputStream(ab, fB64),
+					checkDownloadType(ab, isPdf, fB64), arquivo,
+					(!fB64) ? ab.length : null);
+		} catch (Exception e) {
+			if (e.getClass().getSimpleName().equals("ClientAbortException")) {
+				return new InputStreamDownload(makeByteArrayInputStream(
+						(new byte[0]), false), TEXT_PLAIN, "arquivo inválido",
+						0);
+			}
+			throw new RuntimeException("erro na geração do documento.", e);
+		}
+	}
+
+	private static ByteArrayInputStream makeByteArrayInputStream(
+			final byte[] content, final boolean fB64) {
+		final byte[] conteudo = (fB64 ? Base64.encodeBytes(content).getBytes()
+				: content);
+		return (new ByteArrayInputStream(conteudo));
+	}
+
+	public static class InputStreamDownload {
+		InputStream is;
+		String contentyType;
+		String fileName;
+		Integer contentLength;
+
+		public InputStreamDownload(InputStream is, String contentType,
+				String fileName, Integer contentLength) {
+			super();
+			this.is = is;
+			this.contentyType = contentType;
+			this.fileName = fileName;
+			this.contentLength = contentLength;
+		}
+	}
+
+	private static int match(byte[] text) {
+		int j = 0;
+		if (text.length == 0) {
+			return -1;
+		}
+
+		for (int i = 0; i < text.length; i++) {
+			while (j > 0 && idPattern[j] != text[i]) {
+				j = failure[j - 1];
+			}
+			if (idPattern[j] == text[i]) {
+				j++;
+			}
+			if (j == idPattern.length) {
+				return i - idPattern.length + 1;
+			}
+		}
+		return -1;
+	}
+
+	private static int[] computeFailure() {
+		failure = new int[idPattern.length];
+		int j = 0;
+		for (int i = 1; i < idPattern.length; i++) {
+			while (j > 0 && idPattern[j] != idPattern[i]) {
+				j = failure[j - 1];
+			}
+			if (idPattern[j] == idPattern[i]) {
+				j++;
+			}
+			failure[i] = j;
+		}
+		return failure;
+	}
+
+	private static String checkDownloadType(final byte[] content,
+			final boolean isPdf, final boolean isFB64) {
+		String contentType;
+		if (isFB64) {
+			contentType = TEXT_PLAIN;
+		} else {
+			if (isPdf) {
+				contentType = APPLICATION_PDF;
+			} else {
+				contentType = TEXT_HTML;
+			}
+		}
+		return contentType;
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
@@ -9,6 +9,8 @@ import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.lowagie.text.pdf.codec.Base64;
+
 import br.gov.jfrj.itextpdf.Documento;
 import br.gov.jfrj.siga.Service;
 import br.gov.jfrj.siga.base.AplicacaoException;
@@ -22,8 +24,6 @@ import br.gov.jfrj.siga.ex.ExMovimentacao;
 import br.gov.jfrj.siga.ex.ExNivelAcesso;
 import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
 import br.gov.jfrj.siga.ex.bl.Ex;
-
-import com.lowagie.text.pdf.codec.Base64;
 
 public class SigaDocPdfUtils {
 	private static final String TEXT_HTML = "text/html";

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SugestaoPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SugestaoPost.java
@@ -1,0 +1,30 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.base.Correio;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ISugestaoPost;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.SugestaoPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.SugestaoPostResponse;
+
+public class SugestaoPost implements ISugestaoPost {
+
+	@Override
+	public void run(SugestaoPostRequest req, SugestaoPostResponse resp) throws Exception {
+		StringBuilder sb = new StringBuilder();
+		sb.append("Nome: ");
+		sb.append(req.nome);
+		sb.append("\nEmail: ");
+		sb.append(req.email);
+		sb.append("\n\nMensagem: ");
+		sb.append(req.mensagem);
+		Correio.enviar(SwaggerServlet.getProperty("smtp.sugestao.destinatario"),
+				SwaggerServlet.getProperty("smtp.sugestao.assunto"), sb.toString());
+	}
+
+	@Override
+	public String getContext() {
+		return "enviar sugestao";
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SugestaoPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SugestaoPost.java
@@ -3,6 +3,7 @@ package br.gov.jfrj.siga.ex.api.v1;
 import com.crivano.swaggerservlet.SwaggerServlet;
 
 import br.gov.jfrj.siga.base.Correio;
+import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ISugestaoPost;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.SugestaoPostRequest;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.SugestaoPostResponse;
@@ -18,8 +19,8 @@ public class SugestaoPost implements ISugestaoPost {
 		sb.append(req.email);
 		sb.append("\n\nMensagem: ");
 		sb.append(req.mensagem);
-		Correio.enviar(SwaggerServlet.getProperty("smtp.sugestao.destinatario"),
-				SwaggerServlet.getProperty("smtp.sugestao.assunto"), sb.toString());
+		Correio.enviar(Prop.get("smtp.sugestao.destinatario"),
+				Prop.get("smtp.sugestao.assunto"), sb.toString());
 	}
 
 	@Override

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SwaggerHelper.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SwaggerHelper.java
@@ -1,0 +1,133 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import com.crivano.swaggerservlet.ISwaggerRequest;
+import com.crivano.swaggerservlet.ISwaggerResponse;
+import com.crivano.swaggerservlet.SwaggerAuthorizationException;
+import com.crivano.swaggerservlet.SwaggerException;
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import static java.util.Objects.isNull;
+
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.model.ContextoPersistencia;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
+
+/**
+ * Métodos auxiliares.
+ */
+class SwaggerHelper {
+
+	/**
+	 * Verifica a presença de um usuário logado e o retorna.
+	 * 
+	 * @return O login do Usuário na sessão
+	 * @throws SwaggerAuthorizationException Se não achar nenhum usuário logado na
+	 *                                       sessão.
+	 * @see ContextoPersistencia#getUserPrincipal()
+	 */
+	static String buscarEValidarUsuarioLogado() throws SwaggerAuthorizationException {
+		String userPrincipal = ContextoPersistencia.getUserPrincipal();
+		if (isNull(userPrincipal)) {
+			throw new SwaggerAuthorizationException("Usuário não está logado");
+		}
+
+		return userPrincipal;
+	}
+
+	/**
+	 * Retorna uma instância de {@link SigaObjects} a partir do Request do
+	 * {@link SwaggerServlet}.
+	 * 
+	 * @return Instância de {@link SigaObjects} a partir do Request do
+	 *         {@link SwaggerServlet}.
+	 * @throws Exception Se houver algo de errado.
+	 */
+	static SigaObjects getSigaObjects() throws Exception {
+		return new SigaObjects(SwaggerServlet.getHttpServletRequest());
+	}
+
+	/**
+	 * Retorna um {@link ExMobil Mobil} relacionado a uma certa
+	 * {@link ExMobil#getSigla() sigla} contanto que esse exista e que o usuário
+	 * tenha autorização para acessá-lo.
+	 * 
+	 * @param sigla              Sigla do documeto solicitado
+	 * @param so                 SigaObjects previamente carregado via
+	 *                           {@link #getSigaObjects()} . Será usado na
+	 *                           validação.
+	 * @param req                Requisição do Swagger. Usado no disparo da exceção.
+	 * @param resp               Resposta do Swagger. Usado no disparo da exceção.
+	 * @param descricaoDocumento Descrição do documento a ser usada em caso de erro.
+	 * @return Mobil relacionado a sigla soliciatada.
+	 * @throws SwaggerException Se não achar um Mobil com a sigla solicitada (
+	 *                          {@link SwaggerException#getStatus() Status} 404) ou
+	 *                          se o usário não tiver autorização para tratá-lo
+	 *                          ({@link SwaggerException#getStatus() Status} 403)
+	 */
+	static ExMobil buscarEValidarMobil(final String sigla, SigaObjects so, ISwaggerRequest req, ISwaggerResponse resp,
+			String descricaoDocumento) throws SwaggerException {
+		final ExMobilDaoFiltro filter = new ExMobilDaoFiltro();
+		filter.setSigla(sigla);
+		ExMobil mob = ExDao.getInstance().consultarPorSigla(filter);
+
+		if (isNull(mob)) {
+			throw new SwaggerException("Número do " + descricaoDocumento + " não existe no SPSP", 404, null, req, resp,
+					null);
+		}
+		if (!Ex.getInstance().getComp().podeAcessarDocumento(so.getTitular(), so.getLotaTitular(), mob))
+			throw new SwaggerException("Acesso ao " + descricaoDocumento + " " + mob.getSigla()
+					+ " permitido somente a usuários autorizados. (" + so.getTitular().getSigla() + "/"
+					+ so.getLotaTitular().getSiglaCompleta() + ")", 403, null, req, resp, null);
+
+		return mob;
+	}
+
+	/**
+	 * Retorna um {@link ExMobil Mobil} relacionado a uma certa
+	 * {@link ExMobil#getSigla() sigla} contanto que esse exista e que o usuário
+	 * tenha autorização para acessá-lo.
+	 * 
+	 * @param sigla Sigla do documeto solicitado
+	 * @param req   Requisição do Swagger. Usado no disparo da exceção.
+	 * @param resp  Resposta do Swagger. Usado no disparo da exceção.
+	 * @return Mobil relacionado a sigla soliciatada.
+	 * @throws SwaggerException Se não achar um Mobil com a sigla solicitada (
+	 *                          {@link SwaggerException#getStatus() Status} 404) ou
+	 *                          se o usário não tiver autorização para tratá-lo
+	 *                          ({@link SwaggerException#getStatus() Status} 403).
+	 * @see #buscarEValidarMobil(String, SigaObjects, ISwaggerRequest,
+	 *      ISwaggerResponse, String)
+	 */
+	static ExMobil buscarEValidarMobil(final String sigla, ISwaggerRequest req, ISwaggerResponse resp)
+			throws Exception {
+		return buscarEValidarMobil(sigla, getSigaObjects(), req, resp, "Documento");
+	}
+
+	/**
+	 * Realiza o <i>decode</i> de uma valor de uma {@link String} vinda numa url.
+	 * Por exemplo: Uma string que originalmente seria algo como
+	 * <code>abcd/efg hij ç:ã</code> apareceria na URL na como
+	 * <code>abcd%2Fefg%20hij%20%C3%A7%3A%C3%A3</code>. Este método então
+	 * "restauraria" a string no formato original.
+	 * 
+	 * @param pathParamValue String original "encodada", orignada de uma URL tal
+	 *                       como <code>abcd%2Fefg%20hij%20%C3%A7%3A%C3%A3</code>.
+	 * @return A String original "decodada"
+	 * @throws UnsupportedEncodingException If character encoding needs to be
+	 *                                      consulted, butnamed character encoding
+	 *                                      is not supported. Provavelmente nunca
+	 *                                      será disparada.
+	 * @see {@link URLDecoder#decode(String, String)}
+	 */
+	static String decodePathParam(String pathParamValue) throws UnsupportedEncodingException {
+		return URLDecoder.decode(pathParamValue, StandardCharsets.UTF_8.toString());
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SwaggerHelper.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SwaggerHelper.java
@@ -24,6 +24,8 @@ import br.gov.jfrj.siga.vraptor.SigaObjects;
  */
 class SwaggerHelper {
 
+	private static final String DOC_MÓDULO_DE_DOCUMENTOS = "DOC:Módulo de Documentos;";
+
 	/**
 	 * Verifica a presença de um usuário logado e o retorna.
 	 * 
@@ -44,13 +46,27 @@ class SwaggerHelper {
 	/**
 	 * Retorna uma instância de {@link SigaObjects} a partir do Request do
 	 * {@link SwaggerServlet}.
+	 * @throws Exception Se houver algo de errado.
+	 */
+	static SigaObjects getSigaObjects(String acesso) throws Exception {
+		SigaObjects sigaObjects = new SigaObjects(SwaggerServlet.getHttpServletRequest());
+		sigaObjects.assertAcesso(DOC_MÓDULO_DE_DOCUMENTOS + acesso);
+
+		return sigaObjects;
+	}
+
+	/**
+	 * Retorna uma instância de {@link SigaObjects} a partir do Request do
+	 * {@link SwaggerServlet}. Ainda verifica se o usuário tem aceso ao serviço
+	 * <code>{@value #DOC_MÓDULO_DE_DOCUMENTOS}<code>.
 	 * 
+	 * @param acesso Acesso solicitado.
 	 * @return Instância de {@link SigaObjects} a partir do Request do
 	 *         {@link SwaggerServlet}.
 	 * @throws Exception Se houver algo de errado.
 	 */
 	static SigaObjects getSigaObjects() throws Exception {
-		return new SigaObjects(SwaggerServlet.getHttpServletRequest());
+		return getSigaObjects("");
 	}
 
 	/**

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TokenCriarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TokenCriarPost.java
@@ -1,0 +1,189 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.auth0.jwt.JWTSigner;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.JWTVerifyException;
+import com.auth0.jwt.internal.org.apache.commons.lang3.ArrayUtils;
+import com.crivano.swaggerservlet.PresentableUnloggedException;
+import com.crivano.swaggerservlet.SwaggerAuthorizationException;
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.base.GeraMessageDigest;
+import br.gov.jfrj.siga.base.HttpRequestUtils;
+import br.gov.jfrj.siga.cp.AbstractCpAcesso;
+import br.gov.jfrj.siga.cp.CpIdentidade;
+import br.gov.jfrj.siga.cp.bl.Cp;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ITokenCriarPost;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.TokenCriarPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.TokenCriarPostResponse;
+import br.gov.jfrj.siga.hibernate.ExDao;
+
+public class TokenCriarPost implements ITokenCriarPost {
+	@Override
+	public void run(TokenCriarPostRequest req, TokenCriarPostResponse resp) throws Exception {
+
+		try {
+			String usuariosRestritos = Utils.getUsuariosRestritos();
+			if (usuariosRestritos != null) {
+				if (!ArrayUtils.contains(usuariosRestritos.split(","), req.username))
+					throw new PresentableUnloggedException("Usuário não autorizado.");
+			}
+
+			String origem = "int";
+			DpPessoa pessoa = null;
+
+			if (req.username == null || req.username.isEmpty())
+				throw new PresentableUnloggedException("Matrícula não foi informada.");
+
+			if (req.password == null || req.password.isEmpty())
+				throw new PresentableUnloggedException("Senha não foi informada.");
+
+			final String hashAtual = GeraMessageDigest.executaHash(req.password.getBytes(), "MD5");
+
+			final CpIdentidade id = ExDao.getInstance().consultaIdentidadeCadastrante(req.username.toUpperCase(), true);
+
+			// se o usuário não existir
+			if (id == null)
+				throw new PresentableUnloggedException("O usuário não está cadastrado.");
+
+			pessoa = id.getDpPessoa().getPessoaAtual();
+
+			boolean senhaValida = id.getDscSenhaIdentidade().equals(hashAtual);
+
+			if (!senhaValida) {
+				throw new PresentableUnloggedException("Senha inválida.");
+			}
+
+			String jwt = jwt(origem, req.username.toUpperCase(), Long.toString(pessoa.getCpfPessoa()),
+					pessoa.getNomePessoa(), pessoa.getEmailPessoaAtual());
+			Map<String, Object> decodedNewToken = verify(jwt);
+
+			Cp.getInstance().getBL().logAcesso(AbstractCpAcesso.CpTipoAcessoEnum.AUTENTICACAO,
+					(String) decodedNewToken.get("sub"), (Integer) decodedNewToken.get("iat"),
+					(Integer) decodedNewToken.get("exp"),
+					HttpRequestUtils.getIpAudit(SwaggerServlet.getHttpServletRequest()));
+			ExDao.commitTransacao();
+
+			resp.id_token = jwt;
+		} catch (PresentableUnloggedException ex) {
+			throw ex;
+		} catch (SwaggerAuthorizationException ex) {
+			throw new PresentableUnloggedException(ex.getMessage(), ex);
+		} catch (Throwable ex) {
+			throw new PresentableUnloggedException("Erro no login: " + ex.getMessage(), ex);
+		}
+	}
+
+	private static Map<String, Object> verify(String jwt) throws SwaggerAuthorizationException {
+		final JWTVerifier verifier = new JWTVerifier(Utils.getJwtSecret());
+		Map<String, Object> map;
+		try {
+			map = verifier.verify(jwt);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | IllegalStateException | SignatureException
+				| IOException | JWTVerifyException e) {
+			throw new SwaggerAuthorizationException(e);
+		}
+		return map;
+	}
+
+	public static class UsuarioDetalhe {
+		Long id;
+		Long unidade;
+	}
+
+	public static class Usuario {
+		String origem;
+		String email;
+		String nome;
+		String usuario;
+		String cpf;
+		Map<String, UsuarioDetalhe> usuarios;
+
+		boolean isInterno() {
+			return origem != null && origem.startsWith("int");
+		}
+	}
+
+	public static Usuario assertUsuario() throws Exception {
+		Map<String, Object> jwt = assertUsuarioAutorizado();
+		Usuario u = new Usuario();
+
+		u.origem = (String) jwt.get("origin");
+		u.email = (String) jwt.get("email");
+		u.nome = (String) jwt.get("name");
+		u.cpf = (String) jwt.get("cpf");
+		u.usuario = (String) jwt.get("sub");
+		String users = (String) jwt.get("users");
+		if (users != null && users.length() > 0) {
+			u.usuarios = new HashMap<>();
+			for (String s : users.split(";")) {
+				String[] ss = s.split(",");
+				UsuarioDetalhe ud = new UsuarioDetalhe();
+				if (!"null".equals(ss[1]))
+					ud.id = Long.valueOf(ss[1]);
+				if (!"null".equals(ss[2]))
+					ud.unidade = Long.valueOf(ss[2]);
+				u.usuarios.put(ss[0], ud);
+			}
+		}
+		return u;
+	}
+
+	public static Map<String, Object> assertUsuarioAutorizado() throws Exception {
+		String authorization = getAuthorizationHeader();
+		return verify(authorization);
+	}
+
+	private static String getAuthorizationHeader() throws SwaggerAuthorizationException {
+		String authorization = ExApiV1Servlet.getHttpServletRequest().getHeader("Authorization");
+		if (authorization == null)
+			throw new SwaggerAuthorizationException("Authorization header is missing");
+		if (authorization.startsWith("Bearer "))
+			authorization = authorization.substring(7);
+		return authorization;
+	}
+
+	public static String assertAuthorization() throws SwaggerAuthorizationException {
+		String authorization = getAuthorizationHeader();
+		verify(authorization);
+		return authorization;
+	}
+
+	private static String jwt(String origin, String username, String cpf, String name, String email) {
+		final String issuer = Utils.getJwtIssuer();
+
+		final long iat = System.currentTimeMillis() / 1000L; // issued at claim
+		final long exp = iat + 18 * 60 * 60L; // token expires in 18 hours
+
+		final JWTSigner signer = new JWTSigner(Utils.getJwtSecret());
+		final HashMap<String, Object> claims = new HashMap<String, Object>();
+		if (issuer != null)
+			claims.put("iss", issuer);
+		claims.put("exp", exp);
+		claims.put("iat", iat);
+
+		if (origin != null)
+			claims.put("origin", origin);
+		claims.put("sub", username);
+		claims.put("cpf", cpf);
+		claims.put("name", name);
+		claims.put("email", email);
+
+		final String jwt = signer.sign(claims);
+		return jwt;
+	}
+
+	@Override
+	public String getContext() {
+		return "autenticar usuário";
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
@@ -1,0 +1,25 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+enum TramitacaoTipoDestinoEnum {
+
+	ORGAO("Código de Órgão", "^[A-Z]+-[A-Z0-9]+$", "Deve estar no formato 'OO-UUU', "
+			+ "onde 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito "
+			+ "e 'UUU' (letras maiúsculas e dígitos, quantidade variável) correspondem ao código da unidade."),
+	USUARIO("Código do Usuário", "^[A-Z]+\\d+$", "Deve estar no formato OONNNNN, "
+			+ "onde 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito "
+			+ "e 'NNNN' (apenas dígitos, quantidade variável) à sua respectiva matrícula nesse órgão."),
+	EXTERNO("Código de Órgão Externo", "^[A-Z]+$", "Código do órgão externo ao São Paulo Sem Papel");
+
+	final String descricao;
+
+	final String pattern;
+
+	final String msgErroPattern;
+
+	private TramitacaoTipoDestinoEnum(String descricao, String pattern, String msgErroPattern) {
+		this.descricao = descricao;
+		this.pattern = pattern;
+		this.msgErroPattern = msgErroPattern;
+	}
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
@@ -8,7 +8,7 @@ enum TramitacaoTipoDestinoEnum {
 	USUARIO("Código do Usuário", "^[A-Z]+\\d+$", "Deve estar no formato OONNNNN, "
 			+ "onde 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito "
 			+ "e 'NNNN' (apenas dígitos, quantidade variável) à sua respectiva matrícula nesse órgão."),
-	EXTERNO("Código de Órgão Externo", "^[A-Z]+$", "Código do órgão externo ao São Paulo Sem Papel");
+	EXTERNO("Código de Órgão Externo", "^[A-Z]{1,10}$", "Deve ter até 10 letras maiúsculas.");
 
 	final String descricao;
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/TramitacaoTipoDestinoEnum.java
@@ -1,14 +1,159 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
+import java.util.Date;
+import java.util.Objects;
+
+import com.crivano.swaggerservlet.SwaggerException;
+
+import br.gov.jfrj.siga.dp.CpOrgao;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocSiglaTramitarSpPostResponse;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
+
 enum TramitacaoTipoDestinoEnum {
 
 	ORGAO("Código de Órgão", "^[A-Z]+-[A-Z0-9]+$", "Deve estar no formato 'OO-UUU', "
 			+ "onde 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito "
-			+ "e 'UUU' (letras maiúsculas e dígitos, quantidade variável) correspondem ao código da unidade."),
+			+ "e 'UUU' (letras maiúsculas e dígitos, quantidade variável) correspondem ao código da unidade.") {
+
+		private DpLotacao getLoacaoDestino(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp)
+				throws SwaggerException {
+			DpLotacao lotacaoDestino = new DpLotacao();
+			lotacaoDestino.setSigla(req.destinatario.replace("-", ""));
+			lotacaoDestino = ExDao.getInstance().consultarPorSigla(lotacaoDestino);
+			if (Objects.isNull(lotacaoDestino)) {
+				throw new SwaggerException("Não foi encontrado Órgão com sigla " + req.destinatario, 404, null, req,
+						resp, null);
+			}
+			return lotacaoDestino;
+		}
+
+		@Override
+		void efetuarTramitacaoParaDestino(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
+				DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+			DpLotacao lotacaoDestino = getLoacaoDestino(req, resp);
+
+			Ex.getInstance().getBL().transferir(//
+					null, // CpOrgao orgaoExterno
+					null, // String obsOrgao
+					so.getCadastrante(), // DpPessoa cadastrante
+					so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+					mob, // ExMobil mob
+					dt, // final Date dtMov
+					dt, // Date dtMovIni
+					dtDevolucao, // Date dtFimMov
+					lotacaoDestino, // DpLotacao lotaResponsavel
+					null, // final DpPessoa responsavel
+					null, // DpLotacao lotaDestinoFinal
+					null, // DpPessoa destinoFinal
+					null, // DpPessoa subscritor
+					so.getCadastrante(), // DpPessoa titular
+					null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+					true, // final boolean fInterno: QUANDO USO ISSO?
+					null, // String descrMov
+					null, // String conteudo
+					null, // String nmFuncaoSubscritor
+					false, // boolean forcarTransferencia
+					false // boolean automatico
+			);
+		}
+
+	},
 	USUARIO("Código do Usuário", "^[A-Z]+\\d+$", "Deve estar no formato OONNNNN, "
 			+ "onde 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito "
-			+ "e 'NNNN' (apenas dígitos, quantidade variável) à sua respectiva matrícula nesse órgão."),
-	EXTERNO("Código de Órgão Externo", "^[A-Z]{1,10}$", "Deve ter até 10 letras maiúsculas.");
+			+ "e 'NNNN' (apenas dígitos, quantidade variável) à sua respectiva matrícula nesse órgão.") {
+
+		@Override
+		void efetuarTramitacaoParaDestino(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
+				DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+			DpPessoa usuarioDestino = getUsuarioDestino(req, resp);
+
+			Ex.getInstance().getBL().transferir(//
+					null, // CpOrgao orgaoExterno
+					null, // String obsOrgao
+					so.getCadastrante(), // DpPessoa cadastrante
+					so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+					mob, // ExMobil mob
+					dt, // final Date dtMov
+					dt, // Date dtMovIni
+					dtDevolucao, // Date dtFimMov
+					usuarioDestino.getLotacao(), // DpLotacao lotaResponsavel
+					usuarioDestino, // final DpPessoa responsavel
+					null, // DpLotacao lotaDestinoFinal
+					null, // DpPessoa destinoFinal
+					null, // DpPessoa subscritor
+					so.getCadastrante(), // DpPessoa titular
+					null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+					true, // final boolean fInterno: QUANDO USO ISSO?
+					null, // String descrMov
+					null, // String conteudo
+					null, // String nmFuncaoSubscritor
+					false, // boolean forcarTransferencia
+					false // boolean automatico
+			);
+		}
+
+		private DpPessoa getUsuarioDestino(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp)
+				throws SwaggerException {
+			DpPessoa usuarioDestino = new DpPessoa();
+			usuarioDestino.setSigla(req.destinatario);
+			usuarioDestino = ExDao.getInstance().consultarPorSigla(usuarioDestino);
+			if (Objects.isNull(usuarioDestino)) {
+				throw new SwaggerException("Não foi encontrado Usuário com a Matrícula " + req.destinatario, 404, null,
+						req, resp, null);
+			}
+			return usuarioDestino;
+		}
+
+	},
+	EXTERNO("Código de Órgão Externo", "^[A-Z]{1,10}$", "Deve ter até 10 letras maiúsculas.") {
+
+		private CpOrgao getUsuarioExterno(DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp)
+				throws SwaggerException {
+			CpOrgao orgaoExternoDestino = ExDao.getInstance().getOrgaoFromSiglaExata(req.destinatario);
+			if (Objects.isNull(orgaoExternoDestino)) {
+				throw new SwaggerException("Não foi encontrado Órgão Externo com o código " + req.destinatario, 404,
+						null, req, resp, null);
+			}
+			return orgaoExternoDestino;
+		}
+
+		@Override
+		void efetuarTramitacaoParaDestino(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
+				DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException {
+			CpOrgao orgaoExternoDestino = getUsuarioExterno(req, resp);
+		
+			Ex.getInstance().getBL().transferir(//
+					orgaoExternoDestino, // CpOrgao orgaoExterno
+					req.observacao, // String obsOrgao
+					so.getCadastrante(), // DpPessoa cadastrante
+					so.getCadastrante().getLotacao(), // DpLotacao lotaCadastrante
+					mob, // ExMobil mob
+					dt, // final Date dtMov
+					dt, // Date dtMovIni
+					dtDevolucao, // Date dtFimMov
+					null, // DpLotacao lotaResponsavel
+					null, // final DpPessoa responsavel
+					null, // DpLotacao lotaDestinoFinal
+					null, // DpPessoa destinoFinal
+					null, // DpPessoa subscritor
+					so.getCadastrante(), // DpPessoa titular
+					null, // ExTipoDespacho tpDespacho. Que tipo de despacho?
+					true, // final boolean fInterno: QUANDO USO ISSO?
+					null, // String descrMov
+					null, // String conteudo
+					null, // String nmFuncaoSubscritor
+					false, // boolean forcarTransferencia
+					false // boolean automatico
+			);
+		}
+
+	};
 
 	final String descricao;
 
@@ -21,5 +166,8 @@ enum TramitacaoTipoDestinoEnum {
 		this.pattern = pattern;
 		this.msgErroPattern = msgErroPattern;
 	}
+
+	abstract void efetuarTramitacaoParaDestino(SigaObjects so, ExMobil mob, Date dtDevolucao, Date dt,
+			DocSiglaTramitarSpPostRequest req, DocSiglaTramitarSpPostResponse resp) throws SwaggerException;
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
@@ -1,0 +1,251 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.ocpsoft.prettytime.PrettyTime;
+
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExPapel;
+import br.gov.jfrj.siga.ex.bl.Ex;
+
+public class Utils {
+
+	public static String getUsuariosRestritos() {
+		try {
+			return SwaggerServlet.getProperty("username.restriction");
+		} catch (Exception e) {
+			throw new RuntimeException("Erro de configuração", e);
+		}
+
+	}
+
+	public static String getJwtIssuer() {
+		return "jwt.issuer";
+	}
+
+	public static String getJwtSecret() {
+		return SwaggerServlet.getProperty("/siga.jwt.secret");
+	}
+
+	/**
+	 * Remove os acentos da string
+	 * 
+	 * @param acentuado - String acentuada
+	 * @return String sem acentos
+	 */
+	public static String removeAcento(String acentuado) {
+		if (acentuado == null)
+			return null;
+		String temp = new String(acentuado);
+		temp = temp.replaceAll("[ÃÂÁÀ]", "A");
+		temp = temp.replaceAll("[ÉÈÊ]", "E");
+		temp = temp.replaceAll("[ÍÌÎ]", "I");
+		temp = temp.replaceAll("[ÕÔÓÒ]", "O");
+		temp = temp.replaceAll("[ÛÚÙÜ]", "U");
+		temp = temp.replaceAll("[Ç]", "C");
+		temp = temp.replaceAll("[ãâáà]", "a");
+		temp = temp.replaceAll("[éèê]", "e");
+		temp = temp.replaceAll("[íìî]", "i");
+		temp = temp.replaceAll("[õôóò]", "o");
+		temp = temp.replaceAll("[ûúùü]", "u");
+		temp = temp.replaceAll("[ç]", "c");
+		return temp;
+	}
+
+	public static String removePontuacao(String s) {
+		if (s == null)
+			return null;
+		return s.replace("-", "").replace(".", "").replace("/", "");
+	}
+
+	private static final DateTimeFormatter dtfMNI = DateTimeFormat.forPattern("yyyyMMddHHmmss");
+
+	public static String formatarApoloDataHoraMinuto(Date d) {
+		DateTime dt = new DateTime(d.getTime());
+		return dt.toString(dtfMNI);
+	}
+
+	public static Date parsearApoloDataHoraMinuto(String s) {
+		if (s == null)
+			return null;
+		DateTime dt = DateTime.parse(s, dtfMNI);
+		return dt.toDate();
+	}
+
+	private static final DateTimeFormatter dtfBRHHMM = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm");
+
+	public static String formatarDataHoraMinuto(Date d) {
+		DateTime dt = new DateTime(d.getTime());
+		return dt.toString(dtfBRHHMM);
+	}
+
+	public static Date parsearDataHoraMinuto(String s) {
+		if (s == null)
+			return null;
+		DateTime dt = DateTime.parse(s, dtfBRHHMM);
+		return dt.toDate();
+	}
+
+	private static final DateTimeFormatter dtfBRHHMMSS = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss");
+
+	public static String formatarDataHoraMinutoSegundo(Date d) {
+		DateTime dt = new DateTime(d.getTime());
+		return dt.toString(dtfBRHHMMSS);
+	}
+
+	public static Date parsearDataHoraMinutoSegundo(String s) {
+		if (s == null)
+			return null;
+		DateTime dt = DateTime.parse(s, dtfBRHHMMSS);
+		return dt.toDate();
+	}
+
+	private static final DateTimeFormatter dtfBR = DateTimeFormat.forPattern("dd/MM/yyyy");
+
+	public static String formatarData(Date d) {
+		DateTime dt = new DateTime(d.getTime());
+		return dt.toString(dtfBR);
+
+	}
+
+	public static Date parsearData(String s) {
+		if (s == null)
+			return null;
+		DateTime dt = DateTime.parse(s, dtfBR);
+		return dt.toDate();
+	}
+
+	private static final DateTimeFormatter dtfJPHHMMSS = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
+
+	public static Date parsearDataHoraFormatoJapones(String s) {
+		if (s == null)
+			return null;
+		DateTime dt = DateTime.parse(s, dtfJPHHMMSS);
+		return dt.toDate();
+	}
+
+	public static String formatarNumeroProcesso(String numProc) {
+		String numProcFormated = numProc;
+		try {
+			numProcFormated = numProc.replaceAll("^(\\d{7})-?(\\d{2})\\.?(\\d{4})\\.?(4)\\.?(02)\\.?(\\d{4})(\\d{2})?",
+					"$1-$2.$3.$4.$5.$6$7");
+		} catch (Exception ex) {
+		}
+		return numProcFormated;
+	}
+
+	public static Date parsearDataHoraFormatoJS(String s) {
+		if (s == null)
+			return null;
+		s = s.replace("T", " ");
+		DateTime dt = DateTime.parse(s, dtfJPHHMMSS);
+		return dt.toDate();
+	}
+
+	public static byte[] calcSha1(byte[] content) {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-1");
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException(e);
+		}
+		md.reset();
+		md.update(content);
+		byte[] output = md.digest();
+		return output;
+	}
+
+	final private static char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+	public static String bytesToHex(byte[] bytes) {
+
+		char[] hexChars = new char[bytes.length * 2];
+		for (int j = 0; j < bytes.length; j++) {
+			int v = bytes[j] & 0xFF;
+			hexChars[j * 2] = hexArray[v >>> 4];
+			hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+		}
+		return new String(hexChars);
+	}
+
+	public static String makeSecret(String s) {
+		if (s == null || s.length() == 0)
+			return null;
+		byte[] bytes = s.getBytes();
+		return bytesToHex(calcSha1(bytes));
+	}
+
+	public static double parsearValor(String s) {
+		if (s == null)
+			return 0;
+		s = s.trim();
+		if (s.length() == 0)
+			return 0;
+		s = s.replace(".", "").replace(",", ".");
+		return Double.parseDouble(s);
+	}
+
+	public static String calcularTempoRelativo(Date anterior) {
+		PrettyTime p = new PrettyTime(new Date(), new Locale("pt"));
+
+		String tempo = p.format(anterior);
+		tempo = tempo.replace(" atrás", "");
+		tempo = tempo.replace(" dias", " dias");
+		tempo = tempo.replace(" horas", "h");
+		tempo = tempo.replace(" minutos", "min");
+		tempo = tempo.replace(" segundos", "s");
+		tempo = tempo.replace("agora há pouco", "agora");
+		return tempo;
+	}
+
+	public static void assertAcesso(final ExMobil mob, DpPessoa titular, DpLotacao lotaTitular) throws Exception {
+		if (!Ex.getInstance().getComp().podeAcessarDocumento(titular, lotaTitular, mob)) {
+			String s = "";
+			s += mob.doc().getListaDeAcessosString();
+			s = "(" + s + ")";
+			s = " " + mob.doc().getExNivelAcessoAtual().getNmNivelAcesso() + " " + s;
+
+			Map<ExPapel, List<Object>> mapa = mob.doc().getPerfis();
+			boolean isInteressado = false;
+
+			for (ExPapel exPapel : mapa.keySet()) {
+				Iterator<Object> it = mapa.get(exPapel).iterator();
+
+				if ((exPapel != null) && (exPapel.getIdPapel() == exPapel.PAPEL_INTERESSADO)) {
+					while (it.hasNext() && !isInteressado) {
+						Object item = it.next();
+						isInteressado = item.toString().equals(titular.getSigla()) ? true : false;
+					}
+				}
+
+			}
+
+			if (mob.doc().isSemEfeito()) {
+				if (!mob.doc().getCadastrante().equals(titular) && !mob.doc().getSubscritor().equals(titular)
+						&& !isInteressado) {
+					throw new AplicacaoException("Documento " + mob.getSigla() + " cancelado ");
+				}
+			} else {
+				throw new AplicacaoException("Documento " + mob.getSigla() + " inacessível ao usuário "
+						+ titular.getSigla() + "/" + lotaTitular.getSiglaCompleta() + "." + s);
+			}
+		}
+	}
+	
+	
+
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
@@ -16,6 +16,7 @@ import org.ocpsoft.prettytime.PrettyTime;
 import com.crivano.swaggerservlet.SwaggerServlet;
 
 import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
@@ -26,7 +27,7 @@ public class Utils {
 
 	public static String getUsuariosRestritos() {
 		try {
-			return SwaggerServlet.getProperty("username.restriction");
+			return Prop.get("username.restriction");
 		} catch (Exception e) {
 			throw new RuntimeException("Erro de configuração", e);
 		}
@@ -38,7 +39,7 @@ public class Utils {
 	}
 
 	public static String getJwtSecret() {
-		return SwaggerServlet.getProperty("/siga.jwt.secret");
+		return Prop.get("/siga.jwt.secret");
 	}
 
 	/**

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/Utils.java
@@ -226,7 +226,7 @@ public class Utils {
 			for (ExPapel exPapel : mapa.keySet()) {
 				Iterator<Object> it = mapa.get(exPapel).iterator();
 
-				if ((exPapel != null) && (exPapel.getIdPapel() == exPapel.PAPEL_INTERESSADO)) {
+				if ((exPapel != null) && (exPapel.getIdPapel() == ExPapel.PAPEL_INTERESSADO)) {
 					while (it.hasNext() && !isInteressado) {
 						Object item = it.next();
 						isInteressado = item.toString().equals(titular.getSigla()) ? true : false;

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -49,24 +49,28 @@ parameters:
     in: query
     description: Informar true se deseja receber todos os arquivos juntados e anexos
     required: false
+    default: false
     type: boolean
   estampa:
     name: estampa
     in: query
     description: Informar true se deseja receber o PDF sem estampas
     required: false
+    default: false
     type: boolean
   volumes:
     name: volumes
     in: query
     description: Informar true se deseja receber uma compilação com todos os volumes de um processo
     required: false
+    default: false
     type: boolean
   exibirReordenacao:
     name: exibirReordenacao
     in: query
     description: Informar true se deseja habilitar a reordenação dos documentos
     required: false
+    default: false
     type: boolean    
   pdf:
     name: pdf
@@ -92,12 +96,20 @@ parameters:
     description: Informar attachment se desejar receber como um download
     required: false
     type: string
+    default: inline
+    enum:
+      - attachment
+      - inline
   contenttype:
     name: contenttype
     in: query
     description: Informar o tipo de arquivo desejado, pode ser application/pdf ou text/html
     required: false
     type: string
+    default: application/pdf
+    enum:
+      - application/pdf 
+      - text/html
   chave:
     name: chave
     in: path
@@ -115,6 +127,7 @@ parameters:
     in: formData
     description: Email do usuário
     type: string
+    format: email
     required: false
   mensagem:
     name: mensagem
@@ -170,9 +183,35 @@ parameters:
     description: Texto a ser pesquisado
     required: true
     type: string    
-    
-    
-
+  tipoDestinatario:
+    name: tipoDestinatario
+    in: formData
+    description: Tipo do Destinatário. Órgão Integrado e Usuário e Externo
+    required: true
+    type: string
+    enum: 
+      - ORGAO
+      - USUARIO
+      - EXTERNO
+  destinatario:
+    name: destinatario
+    in: formData
+    description: Destinatário. Pode ser Órgão Integrado e Usuário e Externo
+    required: true
+    type: string
+  observacao:
+    name: observacao
+    in: formData
+    description: Somente quando `tipoDestinatario` = `EXTERNO`. Poderá ser preenchido com e-mail do destinatário.
+    required: false
+    type: string            
+  dataDevolucao:
+    name: dataDevolucao
+    in: formData
+    description: Data de Devolução do documento (por exemplo, `2020-12-02T10:57:23.000-03:00`)
+    required: false
+    type: string
+    format: date
 
 ################################################################################
 #                                           Paths                              #
@@ -434,6 +473,36 @@ paths:
           description: Error ocurred
           schema:
             $ref: "#/definitions/Error"
+
+  /doc/{sigla}/tramitar-sp:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      description: Tramitar documento (SP Sem Papel) 
+      summary: Tramita (transfere) um documento para outra pessoa ou órgão (interno ou externo).
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: '#/parameters/tipoDestinatario'
+        - $ref: '#/parameters/destinatario'
+        - $ref: '#/parameters/observacao'
+        - $ref: '#/parameters/dataDevolucao'
+      responses:
+#Tive que adicionar o 200 porque se tivesse apenas o 201 swaggerservlet soltaria uma exceção
+        200:
+          description: Ok
+        403:
+          description: Acesso ao documento não permitido
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+          description: Via ou volume não encontrado
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: Erro na Tramitação
+          schema:
+            $ref: "#/definitions/Error"
+
 
   /doc/{sigla}/anotar:
     post:

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -186,7 +186,11 @@ parameters:
   tipoDestinatario:
     name: tipoDestinatario
     in: formData
-    description: Tipo do Destinatário. Órgão Integrado e Usuário e Externo
+    description: > 
+      Tipo do Destinatário. 
+        * ORGAO - Órgão Integrado ao São Paulo sem Papel
+        * USUARIO - Usuário do São Paulo sem Papel
+        * EXTERNO - Órgão Externo ao São Paulo sem Papel
     required: true
     type: string
     enum: 
@@ -196,7 +200,15 @@ parameters:
   destinatario:
     name: destinatario
     in: formData
-    description: Destinatário. Pode ser Órgão Integrado e Usuário e Externo
+    description: >
+      Destinatário. Dependendo do `tipoDestinatario` deverá ter os seguintes significados e formatos
+        * ORGAO - Deve estar no formato `OO-UUU`, onde 
+          - 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito 
+          - 'UUU' (letras maiúsculas e dígitos, quantidade variável) correspondem ao código da unidade.
+        * USUARIO - Deve estar no formato OONNNNN onde 
+          - 'OO' (apenas letras maiúsculas, quantidade variável) corresponde ao código do órgão propriamente dito.
+          - 'NNNN' (apenas dígitos, quantidade variável) à sua respectiva matrícula nesse órgão.
+        * EXTERNO - Código do Órgão Externo ao São Paulo Sem Papel (Deve ter até 10 letras maiúsculas).
     required: true
     type: string
   observacao:
@@ -208,10 +220,10 @@ parameters:
   dataDevolucao:
     name: dataDevolucao
     in: formData
-    description: Data de Devolução do documento (por exemplo, `2020-12-02T10:57:23.000-03:00`)
+    description: Data de Devolução do documento (por exemplo, `2020-12-02`). Deve ser igual ou maior que o dia corrente!
     required: false
     type: string
-    format: date
+    pattern: ^\d{4}-(0\d|1[012])-([012]\d|3[01])
 
 ################################################################################
 #                                           Paths                              #

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -44,6 +44,12 @@ parameters:
     description: Sigla do mobil
     type: string
     required: true
+  siglapai:
+    name: siglapai
+    in: query
+    description: Sigla do mobil do documento pai
+    type: string
+    required: true
   completo:
     name: completo
     in: query
@@ -512,6 +518,36 @@ paths:
             $ref: "#/definitions/Error"
         500:
           description: Erro na Tramitação
+          schema:
+            $ref: "#/definitions/Error"
+
+
+  /doc/{sigla}/juntar:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/siglapai"
+      description: Junta a via de um documento com outro informado em siglapai
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+        403:
+          description: Acesso ao documento não permitido
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+          description: Via ou volume não encontrado
+          schema:
+            $ref: "#/definitions/Error"                
+        500:
+          description: Error ocurred
           schema:
             $ref: "#/definitions/Error"
 

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -15,6 +15,16 @@ tags:
     description: Autenticação
   - name: download
     description: Download
+  - name: mesa
+    description: Mesa Virtual
+  - name: consulta
+    description: Consulta a Documentos
+  - name: acao
+    description: Ações em Documentos
+  - name: cadastro
+    description: Consulta nos Cadastros
+  - name: utils
+    description: Utilitários
     
 securityDefinitions:
   Basic:
@@ -52,6 +62,12 @@ parameters:
     description: Informar true se deseja receber uma compilação com todos os volumes de um processo
     required: false
     type: boolean
+  exibirReordenacao:
+    name: exibirReordenacao
+    in: query
+    description: Informar true se deseja habilitar a reordenação dos documentos
+    required: false
+    type: boolean    
   pdf:
     name: pdf
     in: path
@@ -88,6 +104,74 @@ parameters:
     description: Chave que referencia um processo assíncrono
     required: true
     type: string
+  nome:
+    name: nome
+    in: formData
+    description: Nome do usuário
+    type: string
+    required: false
+  email:
+    name: email
+    in: formData
+    description: Email do usuário
+    type: string
+    required: false
+  mensagem:
+    name: mensagem
+    in: formData
+    description: Sugestão
+    type: string
+    required: true
+  username:
+    name: username
+    in: formData
+    description: Identificador do usuário
+    type: string
+    required: true
+  password:
+    name: password
+    in: formData
+    description: Senha do usuário
+    type: string
+    required: true
+  id:
+    name: id
+    in: path
+    description: Identificador da movimentação
+    required: true
+    type: string
+  lotacao:
+    name: lotacao
+    in: formData
+    description: Sigla completa da lotação
+    required: false
+    type: string
+  matricula:
+    name: matricula
+    in: formData
+    description: Sigla completa da matrícula
+    required: false
+    type: string
+  matriculaQuery:
+    name: matricula
+    in: query
+    description: Sigla completa da matrícula
+    required: false
+    type: string
+  anotacao:
+    name: anotacao
+    in: path
+    description: Texto da anotação
+    required: true
+    type: string
+  texto:
+    name: texto
+    in: path
+    description: Texto a ser pesquisado
+    required: true
+    type: string    
+    
+    
 
 
 ################################################################################
@@ -126,6 +210,7 @@ paths:
         - $ref: "#/parameters/estampa"
         - $ref: "#/parameters/completo"
         - $ref: "#/parameters/volumes"
+        - $ref: "#/parameters/exibirReordenacao"
       responses:
         200:
           description: Successful response
@@ -202,7 +287,303 @@ paths:
           description: Error ocurred
           schema:
             $ref: "#/definitions/Error"
+  /mesa:
+    get:
+      description: Listar as mesas virtuais disponíveis
+      tags: [mesa]
+      security:
+        - Bearer: []      
+      parameters: []
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/MesaItem"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+  /doc/{sigla}:
+    get:
+      description: Exibir um documento
+      tags: [consulta]
+      parameters:
+        - $ref: "#/parameters/sigla"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: file
+          headers:
+            Content-Type:
+              type: string
+              description: application/pdf
+            Content-Disposition:
+              type: string
+              description: attachment
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
+  /doc/{sigla}/pdf:
+    get:
+      description: Obter o PDF de um documento para visualização
+      tags: [consulta]
+      parameters:
+        - $ref: "#/parameters/sigla"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              jwt:
+                type: string
+                description: JWT com as informações para download do PDF
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
 
+  /doc/{sigla}/pdf-completo:
+    get:
+      description: Obter o PDF completo de um documento para visualização
+      tags: [consulta]
+      parameters:
+        - $ref: "#/parameters/sigla"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              jwt:
+                type: string
+                description: JWT com as informações para download do PDF
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
+  /doc/{sigla}/mov/{id}/pdf:
+    get:
+      description: Obter o PDF de uma movimentação para visualização
+      tags: [consulta]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/id"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              jwt:
+                type: string
+                description: JWT com as informações para download do PDF
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+  /doc/{sigla}/assinar-com-senha:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/username"
+        - $ref: "#/parameters/password"
+      description: Assinar documento com senha
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
+  /doc/{sigla}/tramitar:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/lotacao"
+        - $ref: "#/parameters/matricula"
+      description: Tramitar documento
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
+  /doc/{sigla}/anotar:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/anotacao"
+      description: Anotar documento
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
+  /doc/{sigla}/pesquisar-sigla:
+    get:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/matriculaQuery"
+      description: Tramitar documento
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              codigo:
+                type: string
+              sigla:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+  /sugestao:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [utils]
+      parameters:
+        - $ref: "#/parameters/nome"
+        - $ref: "#/parameters/email"
+        - $ref: "#/parameters/mensagem"
+      description: Enviar sugestões
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"         
+  /token/criar:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [utils]
+      parameters:
+        - $ref: "#/parameters/username"
+        - $ref: "#/parameters/password"
+      description: Autenticar usuário
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              id_token:
+                type: string
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
+  /acessos:
+    get:
+      description: Listar os últimos acessos
+      tags: [utils]
+      parameters: []
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/AcessoItem"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
+
+            
+  /pessoa/{texto}/pesquisar:
+    get:
+      description: Retornar uma lista de pessoas
+      tags: [cadastro]
+      parameters:
+        - $ref: "#/parameters/texto"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/ResultadoDePesquisa"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
+  /lotacao/{texto}/pesquisar:
+    get:
+      description: Retornar uma lista de lotações
+      tags: [cadastro]
+      parameters:
+        - $ref: "#/parameters/texto"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/ResultadoDePesquisa"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"            
+                           
 
 ################################################################################
 #                                     Definitions                              #
@@ -235,3 +616,118 @@ definitions:
     properties:
       errormsg:
         type: string
+  MesaItem:
+    description: Lista documentos na mesa
+    type: object
+    properties:
+      tipo:
+        type: string
+      datahora:
+        type: string
+        format: date-time
+      tempoRelativo:
+        type: string
+      codigo:
+        type: string
+      sigla:
+        type: string
+      descr:
+        type: string
+      origem:
+        type: string
+      grupo:
+        type: string
+      grupoNome:
+        type: string
+      grupoOrdem:
+        type: string
+      podeAnotar:
+        type: boolean
+      podeAssinar:
+        type: boolean
+      podeAssinarEmLote:
+        type: boolean
+      podeTramitar:
+        type: boolean
+      list:
+        type: array
+        items:
+          $ref: "#/definitions/Marca"      
+  AcessoItem:
+    description: Acessos recentes
+    type: object
+    properties:
+      datahora:
+        type: string
+        format: date-time
+      ip:
+        type: string
+
+  Marca:
+    description: Etiquetas relacionadas a um documento
+    type: object
+    properties:
+      pessoa:
+        type: string
+      lotacao:
+        type: string
+      nome:
+        type: string
+      icone:
+        type: string
+      titulo:
+        type: string
+      inicio:
+        type: string
+        format: date-time
+      termino:
+        type: string
+        format: date-time
+      daPessoa:
+        type: boolean
+      deOutraPessoa:
+        type: boolean
+      daLotacao:
+        type: boolean
+
+  Acao:
+    description: Ação que pode ser realizada a um documento
+    type: object
+    properties:
+      nome:
+        type: string
+      icone:
+        type: string
+      ativa:
+        type: boolean
+
+  Documento:
+    description: Dados de um documento
+    type: object
+    properties:
+      sigla:
+        type: string
+      html:
+        type: string
+      data:
+        type: string
+      descr:
+        type: string
+      marca:
+        type: array
+        items:
+          $ref: "#/definitions/Marca"
+      acao:
+        type: array
+        items:
+          $ref: "#/definitions/Acao"
+
+  ResultadoDePesquisa:
+    description: Dados de um item
+    type: object
+    properties:
+      sigla:
+        type: string
+      nome:
+        type: string
+        

--- a/sigaex/src/main/webapp/WEB-INF/web.xml
+++ b/sigaex/src/main/webapp/WEB-INF/web.xml
@@ -112,6 +112,7 @@
 		<url-pattern>/webdav/*</url-pattern>
 		<url-pattern>/servicos/*</url-pattern>
 		<url-pattern>/apis/*</url-pattern>
+		<url-pattern>/api/*</url-pattern>
 	</filter-mapping>
 
 	<filter-mapping>


### PR DESCRIPTION
- Convertida a API do SIGA-LE para o SIGA-EX
- Trazido os VOs do SIGA-LE para manter compatibilidade (necessária validação dos dados)
- Implementado os filtos do SigaThread e ExThread para manter persistência centralizada. Com isso, foi descontinuado o API Context que estava implementado

![image](https://user-images.githubusercontent.com/20362170/93612406-d794e180-f9a5-11ea-87ac-db633f1d95a7.png)
