### PR TITLE
Correção na troca do modo de gravação do arquivo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -1117,7 +1117,7 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 
 	public void setConteudoBlobDoc(byte[] createBlob) {
 		cacheConteudoBlobDoc = createBlob;
-		if (conteudoBlobDoc!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
+		if (this.cpArquivo==null && (conteudoBlobDoc!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))) {
 			conteudoBlobDoc = createBlob;
 		} else if(cacheConteudoBlobDoc != null){
 			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobDoc);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExModelo.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExModelo.java
@@ -442,7 +442,7 @@ public abstract class AbstractExModelo extends HistoricoAuditavelSuporte
 
 	public void setConteudoBlobMod(byte[] createBlob) {
 		cacheConteudoBlobMod = createBlob;
-		if (this.conteudoBlobMod!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
+		if (this.cpArquivo==null && (this.conteudoBlobMod!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))) {
 			this.conteudoBlobMod = createBlob;
 		} else if(cacheConteudoBlobMod != null){
 			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMod);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
@@ -863,7 +863,7 @@ public abstract class AbstractExMovimentacao extends ExArquivo implements Serial
 
 	public void setConteudoBlobMov(byte[] createBlob) {
 		cacheConteudoBlobMov = createBlob;
-		if (this.conteudoBlobMov!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
+		if (this.cpArquivo==null && (this.conteudoBlobMov!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))) {
 			this.conteudoBlobMov = createBlob;
 		} else if(cacheConteudoBlobMov != null){
 			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMov);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
@@ -190,7 +190,7 @@ public abstract class AbstractExPreenchimento extends Objeto implements
 
 	public void setPreenchimentoBlob(byte[] preenchimentoBlob) {
 		cacheConteudoBlobPre = preenchimentoBlob;
-		if (this.preenchimentoBlob!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
+		if (this.cpArquivo==null && (this.preenchimentoBlob!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))){
 			this.preenchimentoBlob = preenchimentoBlob;
 		} else if(cacheConteudoBlobPre != null){
 			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, TipoConteudo.TXT.getMimeType());


### PR DESCRIPTION
Ao entrar no modo HCP ou TABELA a gravação ocorria de forma errada ao
voltar o sistema para o modo BLOB
O correto é que um documento criado em um determinado modo se mantenha
neste modo até ser migrado.