### PR TITLE
TRF2 - Corrige erro na busca quando a sigla da lotação possui underscore 

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/MatriculaUtils.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/MatriculaUtils.java
@@ -49,7 +49,7 @@ public abstract class MatriculaUtils {
 
 		final Pattern p1 = Pattern.compile("^(?<orgao>" + acronimos
 				+ "){0,1}-?(?<complemento>[0-9"
-				+ (!complementoNumerico ? "A-Za-z\\-\\/\\º\\ª\\ " : "") + "]{1,13})$");
+				+ (!complementoNumerico ? "A-Za-z\\-\\/\\º\\ª\\_\\ " : "") + "]{1,13})$");
 		final Matcher m1 = p1.matcher(junto);
 
 		if (m1.find()) {


### PR DESCRIPTION
TRF2 - Corrige erro na busca quando a sigla da lotação possui underscore .