### PR TITLE
GOVSP1464* - Incluir no editor de texto o recurso nota de rodapé.

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -1134,6 +1134,8 @@ public class Documento {
 				"<!-- FIM PRIMEIRO CABECALHO -->");
 		sHtml = sHtml.replace("<!-- INICIO PRIMEIRO RODAPE",
 				"<!-- INICIO PRIMEIRO RODAPE -->");
+		sHtml = sHtml.replace("<!-- div style=\"font-size:11pt;\" class=\"footnotes\"",
+				"<div style=\"font-size:11pt;\" class=\"footnotes\">");
 		sHtml = sHtml.replace("FIM PRIMEIRO RODAPE -->",
 				"<!-- FIM PRIMEIRO RODAPE-->");
 		// s = s.replace("http://localhost:8080/siga/", "/siga/");

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
@@ -49,11 +49,11 @@ public class ProcessadorHtml {
 
 	static final String asTrimElements[] = { "html", "title", "head", "body",
 			"div", "hr", "table", "caption", "colgroup", "col", "th", "tr", "td", "ol", "ul",
-			"li", "p", "br", "hr", "blockquote" };
+			"li", "p", "br", "hr", "blockquote", "section", "header", "sup" };
 
 	static final String asKnownElements[] = { "html", "title", "head", "body",
 			"div", "hr", "table", "caption", "colgroup", "col", "th", "tr", "td", "ol", "ul",
-			"li", "p", "br", "hr", "blockquote" };
+			"li", "p", "br", "hr", "blockquote", "section", "header", "sup" };
 	
 	private String htmlCompleto, htmlPersonalizado = "";
 
@@ -143,7 +143,13 @@ public class ProcessadorHtml {
 
 			add(myTags, "blockquote", null, null, true);
 			add(myTags, "br", null, null, false);
-
+			
+			add(myTags, "section", "class", null, true);
+			add(myTags, "header", "class", null, true);
+			add(myTags, "sup", "data-footnote-id", null, true);
+			add(myTags, "a", "href;id;rel", null, true);
+			add(myTags, "cite", null, null, true);
+			
 			String styleP = "background-color;width;font-family=arial,avantgarde bk bt\\, arial;font-size=6pt,7pt,8pt,9pt,10pt,11pt,12pt,13pt,14pt;font-weight=bold"
 					+ ";margin-left;text-decoration=italic;text-align=left,right,center,justify"
 					+ ";text-indent;text-decoration;font-size-no-fix=yes;float=none;clear=both";
@@ -161,9 +167,9 @@ public class ProcessadorHtml {
 					true);
 			add(myTags, "ol", "class", "list-style-type=roman", true);
 			add(myTags, "ul", "class", null, true);
-			add(myTags, "li", "class", null, true);
+			add(myTags, "li", "class;data-footnote-id;id", null, true);
 
-			add(myTags, "hr", "size;color", "color", false);
+			add(myTags, "hr", "class", null, false);
 
 			final String sWidth = "width="
 					+ "1%,2%,3%,4%,5%,6%,7%,8%,9%,10%,11%,12%,13%,14%,15%,16%,17%,18%,19%,20%"
@@ -281,6 +287,24 @@ public class ProcessadorHtml {
 		s = s.replace("FIM PRIMEIRO RODAPE -->", "<!-- FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE", "<!-- INICIO RODAPE -->");
 		s = s.replace("FIM RODAPE -->", "<!-- FIM RODAPE -->");
+		
+		
+		
+		int posIniFootnote = s.indexOf("<div style=\"font-size:11pt;\" class=\"footnotes\">");
+		
+		if (posIniFootnote > 0) {
+			int posFimFootnote = s.indexOf("<!-- FIM FOOTNOTE -->");
+			if (posFimFootnote > 0) {
+				String footnote ="";
+				posFimFootnote = posFimFootnote + 21;
+				footnote = s.substring(posIniFootnote, posFimFootnote);
+				s = s.replace("<div style=\"font-size:11pt;\" class=\"footnotes\">", "<!-- div style=\"font-size:11pt;\" class=\"footnotes\"");
+				s = s.replace("<!-- FIM FOOTNOTE -->", "FIM FOOTNOTE -->");
+				s = s.replace("<!-- INICIO RODAPE -->", footnote +"<!-- INICIO RODAPE -->");
+			}
+		}
+
+		
 
 		// Resolve o problema do namespace colado do word. Outra opcao seria
 		// alterar o jtidy conforme abaixo:
@@ -368,6 +392,9 @@ public class ProcessadorHtml {
 
 		if (fBodyOnly) {
 			String sBody = bodyOnly(s);
+			
+			sBody = sBody.replace("FIM FOOTNOTE -->", "<!-- FIM FOOTNOTE -->");
+			sBody = sBody.replace("<!-- div style=\"font-size:11pt;\" class=\"footnotes\"", "<div style=\"font-size:11pt;\" class=\"footnotes\">");
 			if (sBody != null)
 				return sBody;
 		}

--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -918,6 +918,16 @@ LINHA  VARIÁVEL / CONTEÚDO
                         margin-top: ${margemSuperior};
                         margin-bottom: ${margemInferior};
                     }
+                    .footnotes {
+                    	font-size:8pt !important;
+                    	margin-top: 25pt !important;
+                    }
+                    .footnotes hr {
+					   width: 25% !important;
+					   border-top: 1px solid #000 !important;
+					   text-align: left !important;
+					   margin-left: 0 !important;
+                    }
                 </style>
             </head>
             <body>
@@ -1330,15 +1340,14 @@ CKEDITOR.replace( '${var}',
         [/#if]
 
         [#if !gerar_formulario!false]
-
             <input type="hidden" name="vars" value="${var}" />
             <input type="hidden" id="desconsiderarExtensao" name="desconsiderarExtensao" value="${desconsiderarExtensao!'false'}" />
 
                         [#if ( (func.podeUtilizarExtensaoEditor(lotaCadastrante, doc.exModelo.idMod?number)!false)
                            && (!((desconsiderarExtensao == 'true')!false)) )]
-[#else]
-<textarea id="${var}" name="${var}" class="editor"> ${default!}${v?html}</textarea>
-[/#if]
+		[#else]
+		<textarea id="${var}" name="${var}" class="editor"> ${default!}${v?html}</textarea>
+		[/#if]
             <table class="entrevista" width="100%">
                 <tr>
                     <td></td>
@@ -1351,63 +1360,89 @@ CKEDITOR.replace( '${var}',
                              <input type="hidden" id="${var}" name="${var}" value="${v?html}">
                             [@extensaoEditor nomeExtensao=var conteudoExtensao=v/]
                         [#else]
-                            
                             <script type="text/javascript">
 
-CKEDITOR.config.disableNativeSpellChecker = false;
-CKEDITOR.config.scayt_autoStartup = false;
-CKEDITOR.config.scayt_sLang = 'pt_BR';
-CKEDITOR.config.stylesSet = 'siga_ckeditor_styles';
-
-
-
-CKEDITOR.stylesSet.add('siga_ckeditor_styles',[
-                                               {
-                                            	   name:'Título',
-                                            	   element:'h1',
-                                            	   styles:{
-                                            		   'text-align':'justify',
-                                            		   'text-indent':'2cm'
-                                            			   }
-                                               },
-                                               {
-                                            	   name:'Subtítulo',
-                                            	   element:'h2',
-                                            	   styles:{
-                                            		   'text-align':'justify',
-                                            		   'text-indent':'2cm'
-                                            			   }
-                                               },
-                                               {
-                                            	   name:'Com recuo',
-                                            	   element:'p',
-                                            	   styles:{
-                                            		   'text-align':'justify',
-                                            		   'text-indent':'2cm'
-                                            			   }
-                                               }]);
-	CKEDITOR.config.toolbar = 'SigaToolbar';
- 
-	CKEDITOR.config.toolbar_SigaToolbar =
-	[
-		{ name: 'styles', items : [ 'Styles' ] },
-		{ name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] },
-		{ name: 'editing', items : [ 'Find','Replace','-','SelectAll' ] },
-		'/',
-		{ name: 'basicstyles', items : [ 'Bold','Italic','Subscript','Underline','Strike','-','RemoveFormat' ] },
-		{ name: 'paragraph', items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','JustifyLeft','JustifyCenter','JustifyBlock','JustifyRight' ] },
-		{ name: 'insert', items : [ 'Table','-','SpecialChar','-','PageBreak' ] },
-		{ name: 'document', items : [ 'Source' ] }
-	];
-
-window.onload = function(){
-     $( "textarea.editor" ).each(function( index ) {
-        CKEDITOR.replace( this,
-	{
-	   toolbar : 'SigaToolbar'
-	});
-     });
-}
+								CKEDITOR.config.disableNativeSpellChecker = false;
+								CKEDITOR.config.scayt_autoStartup = false;
+								CKEDITOR.config.scayt_sLang = 'pt_BR';
+								CKEDITOR.config.stylesSet = 'siga_ckeditor_styles';
+								
+								CKEDITOR.stylesSet.add('siga_ckeditor_styles', [{
+								        name: 'Título',
+								        element: 'h1',
+								        styles: {
+								            'text-align': 'justify',
+								            'text-indent': '2cm'
+								        }
+								    },
+								    {
+								        name: 'Subtítulo',
+								        element: 'h2',
+								        styles: {
+								            'text-align': 'justify',
+								            'text-indent': '2cm'
+								        }
+								    },
+								    {
+								        name: 'Com recuo',
+								        element: 'p',
+								        styles: {
+								            'text-align': 'justify',
+								            'text-indent': '2cm'
+								        }
+								    },
+								    {
+								        name: 'Marcador',
+								        element: 'span',
+								        styles: {
+								        	'background-color' : '#FFFF00'
+								        }
+								    },
+								    {
+								        name: 'Normal',
+								        element: 'span'
+								    }
+								]);
+								CKEDITOR.config.toolbar = 'SigaToolbar';
+								
+								CKEDITOR.config.toolbar_SigaToolbar = [{
+								        name: 'styles',
+								        items: ['Styles']
+								    },
+								    {
+								        name: 'clipboard',
+								        items: ['Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo']
+								    },
+								    {
+								        name: 'editing',
+								        items: ['Find', 'Replace', '-', 'SelectAll']
+								    },
+								    '/',
+								    {
+								        name: 'basicstyles',
+								        items: ['Bold', 'Italic', 'Subscript', 'Underline', 'Strike', '-', 'RemoveFormat']
+								    },
+								    {
+								        name: 'paragraph',
+								        items: ['NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyBlock', 'JustifyRight']
+								    },
+								    {
+								        name: 'insert',
+								        items: ['Table' , 'Footnotes', '-', 'SpecialChar', '-', 'PageBreak']
+								    },
+								    {
+								        name: 'document',
+								        items: ['Source']
+								    }
+								];
+								CKEDITOR.config.extraPlugins = 'footnotes';
+								window.onload = function() {
+								    $("textarea.editor").each(function(index) {
+								        CKEDITOR.replace(this, {
+								            toolbar: 'SigaToolbar'
+								        });
+								    });
+								}
 
                             </script>
                             


### PR DESCRIPTION
Adicionado suporte ao Add-On Footnotes do CKEditor 

![image](https://user-images.githubusercontent.com/20362170/97030974-f4d54680-1535-11eb-9b34-8c9212fbfbd0.png)

![image](https://user-images.githubusercontent.com/20362170/97030989-fa329100-1535-11eb-9ff5-4b446c02406f.png)

![image](https://user-images.githubusercontent.com/20362170/97030999-fdc61800-1535-11eb-8957-8c0fb6cf663f.png)

![image](https://user-images.githubusercontent.com/20362170/97031009-01599f00-1536-11eb-9735-2502cbcedd03.png)

E criado dois estilos novos para permitir a criação de highlights no texto

![image](https://user-images.githubusercontent.com/20362170/97031328-7e851400-1536-11eb-84d2-2cb53fa93dde.png)

![image](https://user-images.githubusercontent.com/20362170/97031397-96f52e80-1536-11eb-85cc-1c9247606f88.png)

![image](https://user-images.githubusercontent.com/20362170/97031432-a5dbe100-1536-11eb-9e5b-da74d40745cf.png)

![image](https://user-images.githubusercontent.com/20362170/97031459-b55b2a00-1536-11eb-9059-28056a845f05.png)


Anexo tem o novo CKEditor.war, porém ainda vou verificar a minificação para deixar o load da DOM mais leve, seguindo as boas práticas do CKEditor