### PR TITLE
GOVSP1635 - Adequar Mensagem apresentada ao Cancelar Documento Juntado ou Incluso

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -1427,7 +1427,7 @@
 		tituloADireita="<i class='fas fa-exclamation-circle' style='font-size: 1.5em; color: #ffc107;'></i> <label style='font-size: 1.1em;vertical-align: middle;'><b>Atenção</b></label>"
 		descricaoBotaoFechaModalDoRodape="Ok">
 		<div class="modal-body">
-       		Favor desentranhar documento antes de cancelar
+       		É necessário desentranhar o documento para realizar o seu cancelamento.
      	</div>	     	
 	</siga:siga-modal>	
 			


### PR DESCRIPTION
Foi alterada a mensagem apresentada de “Favor desentranhar documentos antes de cancelar” 
para “É necessário desentranhar o documento para realizar o seu cancelamento”. 