### PR TITLE
Develop govsp 1630 preenchimento obrigatorio ciencia

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -218,5 +218,8 @@ public class Prop {
 		
 		/* Tipos de possíveis responsáveis */
 		provider.addPublicProperty("/siga.substituto.tipos", "MATRICULA,LOTACAO");
+		
+		/* Obriga o preenchimento da descrição da ciência */
+		provider.addPublicProperty("/siga.ciencia.preenchimento.obrigatorio", "true");
 	}
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4936,6 +4936,10 @@ public class ExMovimentacaoController extends ExController {
 	public void ciencia_gravar(final Integer postback, final String sigla, final String descrMov) {					
 		this.setPostback(postback);
 		
+		if (descrMov == null || descrMov.trim().length() == 0) {
+			throw new AplicacaoException("Necessário o preenchimento do campo para dar Ciência.");
+		}
+		
 		final ExMovimentacaoBuilder builder = ExMovimentacaoBuilder
 				.novaInstancia();
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4934,7 +4934,7 @@ public class ExMovimentacaoController extends ExController {
 	public void ciencia_gravar(final Integer postback, final String sigla, final String descrMov) {					
 		this.setPostback(postback);
 		
-		if (descrMov == null || descrMov.trim().length() == 0) {
+		if (Prop.getBool("/siga.ciencia.preenchimento.obrigatorio") && (descrMov == null || descrMov.trim().length() == 0)) {
 			throw new AplicacaoException("Necessário o preenchimento do campo para dar Ciência.");
 		}
 		


### PR DESCRIPTION
Criou o parâmetro siga.ciencia.preenchimento.obrigatorio para indicar se o preenchimento do campo ciência deve ser obrigatório.
Aplicou o teste em ExMovimentacaoController.ciencia_gravar