### PR TITLE
Develop govsp retorno query assinar lote

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -218,5 +218,8 @@ public class Prop {
 		
 		/* Tipos de possíveis responsáveis */
 		provider.addPublicProperty("/siga.substituto.tipos", "MATRICULA,LOTACAO");
+		
+		/* Obriga o preenchimento da descrição da ciência */
+		provider.addPublicProperty("/siga.ciencia.preenchimento.obrigatorio", "true");
 	}
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -208,10 +208,10 @@ import br.gov.jfrj.siga.ex.BIE.ExBoletimDoc;
 				+ "			and doc.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"),
 		@NamedQuery(name = "listarDocPendenteAssinatura", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
-				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
+				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni = :idPessoaIni)) order by doc.dtDoc desc"),
 		@NamedQuery(name = "listarDocPendenteAssinaturaERevisado", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
-				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 71 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
+				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 71 and label.dpPessoaIni = :idPessoaIni)) order by doc.dtDoc desc"),
 		@NamedQuery(name = "consultarExDocumentoClassificados", query = "select doc from ExDocumento doc left join fetch doc.exClassificacao"
 				+ "		where doc.exClassificacao.codificacao like :mascara"
 				+ "		and doc.orgaoUsuario.idOrgaoUsu = :idOrgaoUsuario"

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4936,6 +4936,10 @@ public class ExMovimentacaoController extends ExController {
 	public void ciencia_gravar(final Integer postback, final String sigla, final String descrMov) {					
 		this.setPostback(postback);
 		
+		if (descrMov == null || descrMov.trim().length() == 0) {
+			throw new AplicacaoException("Necessário o preenchimento do campo para dar Ciência.");
+		}
+		
 		final ExMovimentacaoBuilder builder = ExMovimentacaoBuilder
 				.novaInstancia();
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4934,7 +4934,7 @@ public class ExMovimentacaoController extends ExController {
 	public void ciencia_gravar(final Integer postback, final String sigla, final String descrMov) {					
 		this.setPostback(postback);
 		
-		if (descrMov == null || descrMov.trim().length() == 0) {
+		if (Prop.getBool("/siga.ciencia.preenchimento.obrigatorio") && (descrMov == null || descrMov.trim().length() == 0)) {
 			throw new AplicacaoException("Necessário o preenchimento do campo para dar Ciência.");
 		}
 		


### PR DESCRIPTION
A query foi alterada para confrontar o parâmetro enviado com o ID da pessoa sendo que o parâmetro passado é o login.
Retornou a query original para resolver o problema

Branch develop-govsp-retorno-query-assinar-lote