### PR TITLE
TRF2- Acerto query nativa transformando em JPQL e fazendo trunc(CURRENT_TIMESTAMP) na query que contas as marcas

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
@@ -48,6 +48,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
+import org.jboss.logging.Logger;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 
@@ -56,6 +57,8 @@ import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.cp.arquivo.ArmazenamentoHCP;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
 import br.gov.jfrj.siga.model.ContextoPersistencia;
+import br.gov.jfrj.siga.dp.dao.CpDao;
+
 
 /**
  * A class that represents a row in the CP_ARQUIVO table. You can customize the
@@ -69,7 +72,7 @@ public class CpArquivo implements Serializable, PersistentAttributeInterceptable
 
 	private static final long serialVersionUID = 1L;
 	
-	private final static Logger log = Logger.getLogger(CpArquivo.class);
+	private final static org.jboss.logging.Logger log = Logger.getLogger(CpArquivo.class);
 
 	@Id
 	@SequenceGenerator(sequenceName = "CORPORATIVO.CP_ARQUIVO_SEQ", name = "CP_ARQUIVO_SEQ")

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
@@ -42,8 +42,14 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Immutable;
-import org.jboss.logging.Logger;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.Texto;
@@ -57,8 +63,9 @@ import br.gov.jfrj.siga.model.ContextoPersistencia;
  */
 @Entity
 @Immutable
+@Cache(region = CpDao.CACHE_CORPORATIVO, usage = CacheConcurrencyStrategy.READ_ONLY)
 @Table(name = "corporativo.cp_arquivo")
-public class CpArquivo implements Serializable {
+public class CpArquivo implements Serializable, PersistentAttributeInterceptable {
 
 	private static final long serialVersionUID = 1L;
 	
@@ -70,11 +77,12 @@ public class CpArquivo implements Serializable {
 	@Column(name = "ID_ARQ")
 	private java.lang.Long idArq;
 
+	@LazyToOne(LazyToOneOption.NO_PROXY)
 	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@PrimaryKeyJoinColumn
 	private CpArquivoBlob arquivoBlob;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ID_ORGAO_USU")
 	private CpOrgaoUsuario orgaoUsuario;
 
@@ -93,6 +101,19 @@ public class CpArquivo implements Serializable {
 
 	@Transient
 	protected byte[] cacheArquivo;
+	
+	@Transient
+    private PersistentAttributeInterceptor persistentAttributeInterceptor;
+ 
+    @Override
+    public PersistentAttributeInterceptor $$_hibernate_getInterceptor() {
+        return persistentAttributeInterceptor;
+    }
+ 
+    @Override
+    public void $$_hibernate_setInterceptor(PersistentAttributeInterceptor persistentAttributeInterceptor) {
+        this.persistentAttributeInterceptor = persistentAttributeInterceptor;
+    }
 
 	/**
 	 * Simple constructor of AbstractExDocumento instances.
@@ -256,13 +277,22 @@ public class CpArquivo implements Serializable {
 	private void setConteudoTpArq(java.lang.String conteudoTpArq) {
 		this.conteudoTpArq = conteudoTpArq;
 	}
-
-	private CpArquivoBlob getArquivoBlob() {
-		return arquivoBlob;
+	
+	public CpArquivoBlob getArquivoBlob() {
+	    if (this.persistentAttributeInterceptor != null) {
+	        return (CpArquivoBlob) this.persistentAttributeInterceptor.readObject(
+	                  this, "arquivoBlob", this.arquivoBlob);
+	    }
+	    return this.arquivoBlob;
 	}
-
-	private void setArquivoBlob(CpArquivoBlob arquivoBlob) {
-		this.arquivoBlob = arquivoBlob;
+	 
+	public void setArquivoBlob(CpArquivoBlob contaCorrente) {
+	    if (this.persistentAttributeInterceptor != null) {
+	        this.arquivoBlob = (CpArquivoBlob) persistentAttributeInterceptor.writeObject(
+	                  this, "arquivoBlob", this.arquivoBlob, contaCorrente);
+	    } else {
+	        this.arquivoBlob = contaCorrente;
+	    }
 	}
 
 	public CpArquivoTipoArmazenamentoEnum getTipoArmazenamento() {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivoBlob.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivoBlob.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
@@ -29,7 +30,14 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+import br.gov.jfrj.siga.dp.dao.CpDao;
 
 /**
  * A class that represents a row in the CP_ARQUIVO_BLOB table. You can customize
@@ -38,6 +46,7 @@ import org.hibernate.annotations.Immutable;
 @Entity
 @Immutable
 @Table(name = "corporativo.cp_arquivo_blob")
+@Cache(region = CpDao.CACHE_CORPORATIVO, usage = CacheConcurrencyStrategy.READ_ONLY)
 public class CpArquivoBlob implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -47,7 +56,7 @@ public class CpArquivoBlob implements Serializable {
 	private java.lang.Long idArqBlob;
 
 	@MapsId
-	@OneToOne(mappedBy = "arquivoBlob")
+	@OneToOne(mappedBy = "arquivoBlob", fetch = FetchType.LAZY)
 	@JoinColumn(name = "ID_ARQ_BLOB", referencedColumnName = "ID_ARQ") // same name as id @Column
 	private CpArquivo arquivo;
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMarca.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMarca.java
@@ -47,9 +47,9 @@ import javax.persistence.NamedQuery;
 		"               JOIN marca.cpMarcador mard "+
 		"               JOIN marca.exMobil.exDocumento.exFormaDocumento.exTipoFormaDoc tpForma "+
 		"        WHERE  ( marca.dtIniMarca IS NULL "+
-		"                  OR marca.dtIniMarca < CURRENT_TIMESTAMP ) "+
+		"                  OR marca.dtIniMarca < trunc(CURRENT_TIMESTAMP) ) "+
 		"               AND ( marca.dtFimMarca IS NULL "+
-		"                      OR marca.dtFimMarca > CURRENT_TIMESTAMP ) "+
+		"                      OR marca.dtFimMarca > trunc(CURRENT_TIMESTAMP) ) "+
 		"               AND ( ( marca.dpPessoaIni.idPessoa = :idPessoaIni ) "+
 		"                      OR ( marca.dpLotacaoIni.idLotacao = :idLotacaoIni ) ) "+
 		"               AND marca.cpTipoMarca.idTpMarca = 1 "+

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExModelo.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExModelo.java
@@ -22,6 +22,7 @@
 package br.gov.jfrj.siga.ex;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import javax.persistence.Entity;
@@ -88,17 +89,13 @@ public class ExModelo extends AbstractExModelo implements Sincronizavel, Selecio
 	}
 
 	public boolean isDescricaoAutomatica() {
-		try {
-			if ("template/freemarker".equals(getConteudoTpBlob())
-					&& getConteudoBlobMod2() != null
-					&& (new String(getConteudoBlobMod2(), "utf-8"))
-							.contains("@descricao"))
+		if ("template/freemarker".equals(getConteudoTpBlob())) {
+			byte[] blob = getConteudoBlobMod2();
+			if (blob == null) return false;
+			String freemarker = new String(getConteudoBlobMod2(), StandardCharsets.UTF_8);
+			if (freemarker.contains("@descricao"))
 				return true;
-		} catch (UnsupportedEncodingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
 		}
-
 		return false;
 	}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6249,7 +6249,7 @@ public class ExBL extends CpBL {
 
 	public void gravarModelo(ExModelo modNovo, ExModelo modAntigo, Date dt, CpIdentidade identidadeCadastrante)
 			throws AplicacaoException {
-		if (modNovo.getConteudoTpBlob().equals("template-file/jsp")) {
+		if ("template-file/jsp".equals(modNovo.getConteudoTpBlob())) {
 			modNovo.setCpArquivo(null);
 		}
 		if (modNovo.getExFormaDocumento() == null)

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6249,6 +6249,9 @@ public class ExBL extends CpBL {
 
 	public void gravarModelo(ExModelo modNovo, ExModelo modAntigo, Date dt, CpIdentidade identidadeCadastrante)
 			throws AplicacaoException {
+		if (modNovo.getConteudoTpBlob().equals("template-file/jsp")) {
+			modNovo.setCpArquivo(null);
+		}
 		if (modNovo.getExFormaDocumento() == null)
 			throw new AplicacaoException("não é possível salvar um modelo sem informar a forma do documento.");
 		if (modNovo.getNmMod() == null || modNovo.getNmMod().trim().length() == 0)

--- a/siga-vraptor-module/src/main/java/br/gov/jfrj/siga/vraptor/SigaTransacionalInterceptor.java
+++ b/siga-vraptor-module/src/main/java/br/gov/jfrj/siga/vraptor/SigaTransacionalInterceptor.java
@@ -63,8 +63,7 @@ public class SigaTransacionalInterceptor extends br.com.caelum.vraptor.jpa.JPATr
 
 	@Accepts
 	public boolean accepts(ControllerMethod method) {
-		this.method = method;
-		return true;
+		  return method.containsAnnotation(Transacional.class);
 	}
 
 	@AroundCall
@@ -72,13 +71,15 @@ public class SigaTransacionalInterceptor extends br.com.caelum.vraptor.jpa.JPATr
 		addRedirectListener();
 
 		try {
-			if (this.method.containsAnnotation(Transacional.class)) {
-				EntityTransaction transaction = manager.getTransaction();
-				transaction.begin();
+	/*		if (this.method.containsAnnotation(Transacional.class)) {
+				
 			} else {
 				disableAutoFlush();
-			}
+			} */
 
+			EntityTransaction transaction = manager.getTransaction();
+			transaction.begin();
+			
 //			 System.out.println("*** " + (manager.getTransaction() ==
 //					 null || !manager.getTransaction().isActive() ? "NÃO" : "") + " TRANSACIONAL" + this.method.toString() + " - ");
 

--- a/sigaex/src/main/webapp/META-INF/jboss-deployment-structure.xml
+++ b/sigaex/src/main/webapp/META-INF/jboss-deployment-structure.xml
@@ -16,9 +16,11 @@
 			<module name="org.apache.commons.logging" />
 			<module name="javax.wsdl4j.api" />
 			<module name="asm.asm" />
-
 			<module name="org.javassist" />
 			<module name="javax.api" />
+			
+			<!-- Dependencia com conversor HTML2PDF -->
+			<module name="sigadoc.ext" />
 		</dependencies>
 
 	</deployment>


### PR DESCRIPTION
TRF2- Acerto query nativa transformando em JPQL e fazendo trunc(CURRENT_TIMESTAMP) na query que contas as marcas da lotação e do atendente, correção da carga do cparquivo acidental na listagem dos modelos e da alteração de modelos jsp e correção da desformatação dos pdfs com a retomada da dependência do sigadoc/ext