### PR TITLE
GOVSP1774* - Adequação do uso do CURRENT_TIMESTAMP

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
@@ -50,8 +50,8 @@ import br.gov.jfrj.siga.model.Historico;
 @NamedQueries({ 
 	@NamedQuery(name = "quantidadeDocumentos", query = "SELECT count(1)"
 			+ "		FROM CpMarca marca"
-			+ "	WHERE (marca.dtIniMarca IS NULL OR marca.dtIniMarca < CURRENT_TIMESTAMP)"
-			+ "		AND (marca.dtFimMarca IS NULL OR marca.dtFimMarca > CURRENT_TIMESTAMP)"
+			+ "	WHERE (marca.dtIniMarca IS NULL OR marca.dtIniMarca < :dbDatetime)"
+			+ "		AND (marca.dtFimMarca IS NULL OR marca.dtFimMarca > :dbDatetime)"
 			+ "		AND marca.dpPessoaIni.idPessoa = :idPessoaIni"
 			+ "     AND marca.cpTipoMarca.idTpMarca = 1 "
 			+ "	    AND marca.cpMarcador.idMarcador not in (9,8,10,11,12 ,13,16, 18, 20 , 21, 22, 24 ,26, 32, 62, 63, 64, 7, 50, 51)") })

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
@@ -48,7 +48,6 @@ import br.gov.jfrj.siga.cp.model.HistoricoAuditavel;
 import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 
 @MappedSuperclass
-@NamedNativeQuery(name = "consultarDataEHoraDoServidor", query = "select CURRENT_TIMESTAMP from CpOrgaoUsuario", resultSetMapping = "scalar")
 @NamedQueries({
 		@NamedQuery(name = "consultarPorIdDpPessoa", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoa"),
 		@NamedQuery(name = "consultarPorIdInicialDpPessoa", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoaIni and pes.dataFimPessoa = null"),

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpSubstituicao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpSubstituicao.java
@@ -45,8 +45,8 @@ import br.gov.jfrj.siga.model.Objeto;
 @MappedSuperclass
 @NamedQueries({
 		@NamedQuery(name = "consultarSubstituicoesPermitidas", query = "from DpSubstituicao dps "
-				+ " where (dps.dtIniSubst < CURRENT_TIMESTAMP or dps.dtIniSubst = null) "
-				+ " and (dps.dtFimSubst > CURRENT_TIMESTAMP or dps.dtFimSubst = null) "
+				+ " where (dps.dtIniSubst < :dbDatetime or dps.dtIniSubst = null) "
+				+ " and (dps.dtFimSubst > :dbDatetime or dps.dtFimSubst = null) "
 				+ " and ((dps.substituto = null and dps.lotaSubstituto.idLotacao in (select lot.idLotacao from DpLotacao as lot where lot.idLotacaoIni = :idLotaSubstitutoIni)) or "
 				+ " dps.substituto.idPessoa in (select pes.idPessoa from DpPessoa as pes where pes.idPessoaIni = :idSubstitutoIni)) "
 				+ " and dps.dtFimRegistro = null"),
@@ -56,8 +56,8 @@ import br.gov.jfrj.siga.model.Objeto;
 				+ " and dps.dtFimRegistro = null "
 				+ " order by dps.dtIniSubst, dps.dtFimSubst "),
 		@NamedQuery(name = "qtdeSubstituicoesAtivasPorTitular", query = "select count(1) from DpSubstituicao as dps "
-				+ " where (dps.dtIniSubst < CURRENT_TIMESTAMP or dps.dtIniSubst = null) " 
-				+ " and (dps.dtFimSubst > CURRENT_TIMESTAMP or dps.dtFimSubst = null)"
+				+ " where (dps.dtIniSubst < :dbDatetime or dps.dtIniSubst = null) " 
+				+ " and (dps.dtFimSubst > :dbDatetime or dps.dtFimSubst = null)"
 				+ " and ((dps.titular = null and dps.lotaTitular.idLotacao in (select lot.idLotacao from DpLotacao as lot where lot.idLotacaoIni = :idLotaTitularIni)) or "
 				+ " dps.titular.idPessoa in (select pes.idPessoa from DpPessoa as pes where pes.idPessoaIni = :idTitularIni)) "
 				+ " and dps.dtFimRegistro = null ")

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpVisualizacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpVisualizacao.java
@@ -43,8 +43,8 @@ import br.gov.jfrj.siga.model.Objeto;
 @MappedSuperclass
 @NamedQueries({
 		@NamedQuery(name = "consultarVisualizacoesPermitidas", query = "from DpVisualizacao as dps "
-				+ " where (dps.dtIniDeleg < CURRENT_TIMESTAMP or dps.dtIniDeleg is null) "
-				+ " and (dps.dtFimDeleg > CURRENT_TIMESTAMP or dps.dtFimDeleg is null) "
+				+ " where (dps.dtIniDeleg < :dbDatetime or dps.dtIniDeleg is null) "
+				+ " and (dps.dtFimDeleg > :dbDatetime or dps.dtFimDeleg is null) "
 				+ " and dps.delegado.idPessoa in (select pes.idPessoa from DpPessoa as pes where pes.idPessoaIni = :idDelegadoIni) "
 				+ " and dps.dtFimRegistro is null "),
 		@NamedQuery(name = "consultarOrdem", query = "from DpVisualizacao as dps "

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -108,7 +108,6 @@ public class CpDao extends ModeloDao {
 	public static final String CACHE_HOURS = "hours";
 	public static final String CACHE_SECONDS = "seconds";
 	
-
 	private static Map<String, CpServico> cacheServicos = null;
 
 	public static CpDao getInstance() {
@@ -1528,6 +1527,8 @@ public class CpDao extends ModeloDao {
 		query.setHint("org.hibernate.cacheable", true);
 		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
 //			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_SUBSTITUICAO);
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		return query.getResultList();
 	}
 
@@ -1548,6 +1549,8 @@ public class CpDao extends ModeloDao {
 		query = em().createNamedQuery("qtdeSubstituicoesAtivasPorTitular");
 		query.setParameter("idTitularIni", exemplo.getTitular().getIdPessoaIni());
 		query.setParameter("idLotaTitularIni", exemplo.getLotaTitular().getIdLotacaoIni());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		return ((Long)query.getSingleResult()).intValue();
 	}
 
@@ -1556,6 +1559,8 @@ public class CpDao extends ModeloDao {
 		Query query = null;
 		query = em().createNamedQuery("consultarVisualizacoesPermitidas");
 		query.setParameter("idDelegadoIni", exemplo.getDelegado().getIdPessoaIni());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		query.setHint("org.hibernate.cacheable", true);
 //			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_SUBSTITUICAO);
 		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
@@ -2552,8 +2557,8 @@ public class CpDao extends ModeloDao {
 		try {
 			String consultarQuantidadeDocumentosPorDpLotacao = "SELECT count(1) FROM DpLotacao lotacao"
 					+ " left join CpMarca marca on lotacao.idLotacao = marca.dpLotacaoIni"
-					+ " WHERE(marca.dtIniMarca IS NULL OR marca.dtIniMarca < CURRENT_TIMESTAMP)"
-					+ " AND(marca.dtFimMarca IS NULL OR marca.dtFimMarca > CURRENT_TIMESTAMP)"
+					+ " WHERE(marca.dtIniMarca IS NULL OR marca.dtIniMarca < :dbDatetime)"
+					+ " AND(marca.dtFimMarca IS NULL OR marca.dtFimMarca > :dbDatetime)"
 					+ " AND marca.cpMarcador.idMarcador not in (1,10,32)"
 					+ " AND lotacao.idLotacaoIni = :idLotacao"
 					+ " AND marca.cpTipoMarca.idTpMarca = :idTipoMarca ";
@@ -2561,6 +2566,8 @@ public class CpDao extends ModeloDao {
 	
 			query.setParameter("idLotacao", o.getId());
 			query.setParameter("idTipoMarca", CpTipoMarca.TIPO_MARCA_SIGA_EX);
+			query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+			
             final int l = ((Long) query.getSingleResult()).intValue();
             return l;
         } catch (final NullPointerException e) {
@@ -2599,8 +2606,8 @@ public class CpDao extends ModeloDao {
 					+ queryLotacao
 					+ queryUsuario
 					+ "and marcador.idMarcador = :idMarcador " 
-					+ "and (dt_ini_marca is null or dt_ini_marca < CURRENT_TIMESTAMP) " 
-					+ "and (dt_fim_marca is null or dt_fim_marca > CURRENT_TIMESTAMP) " 
+					+ "and (dt_ini_marca is null or dt_ini_marca < :dbDatetime) " 
+					+ "and (dt_fim_marca is null or dt_fim_marca > :dbDatetime) " 
 				;
 
 		Query query = em().createQuery(queryTemp);
@@ -2619,7 +2626,8 @@ public class CpDao extends ModeloDao {
 		query.setParameter("dtini", dataInicial);
 		Date dtfimMaisUm = new Date(dataFinal.getTime() + 86400000L);
 		query.setParameter("dtfim", dtfimMaisUm);
-
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		List<CpOrgaoUsuario> l = query.getResultList();
 
 		if (l.size() == 0) {
@@ -2650,7 +2658,8 @@ public class CpDao extends ModeloDao {
 			Query sql = em().createNamedQuery("quantidadeDocumentos");
 
 			sql.setParameter("idPessoaIni", pes.getIdPessoaIni());
-			return ((BigDecimal) sql.getSingleResult()).intValue();
+			sql.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+			return ((Long) sql.getSingleResult()).intValue();
 		} catch (final NullPointerException e) {
 			return null;
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
@@ -93,42 +93,42 @@ import br.gov.jfrj.siga.dp.DpPessoa;
 		@NamedQuery(name = "consultarParaArquivarIntermediarioEmLote", query = "select mob, mar from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where mar.cpMarcador.idMarcador=51              "
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"
 				+ "                order by mob.exDocumento.dtDoc asc"),
 
 		@NamedQuery(name = "consultarQuantidadeParaArquivarIntermediarioEmLote", query = "select count(*) from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where mar.cpMarcador.idMarcador=51              "
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"),
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"),
 		// Somente os "a recolher para arquivo permanente"
 		@NamedQuery(name = "consultarParaArquivarPermanenteEmLote", query = "select mob, mar from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where mar.cpMarcador.idMarcador=50      "
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"
 				+ "                order by mob.exDocumento.dtDoc asc"),
 		@NamedQuery(name = "consultarQuantidadeParaArquivarPermanenteEmLote", query = "select count(*) from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where mar.cpMarcador.idMarcador=50              "
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"),
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"),
 		// Somente os "a eliminar"
 		@NamedQuery(name = "consultarAEliminar", query = "select mob, mar from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where (mar.cpMarcador.idMarcador=7)"
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
 				+ "                and (:dtIni is null or mob.exDocumento.dtDoc >= :dtIni)"
 				+ "                and (:dtFim is null or mob.exDocumento.dtDoc <= :dtFim)"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"),
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"),
 		@NamedQuery(name = "consultarQuantidadeAEliminar", query = "select count(*) from ExMobil mob join mob.exMarcaSet mar"
 				+ "                where mar.cpMarcador.idMarcador=7              "
 				+ "                and mar.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu"
 				+ "                and (:dtIni is null or mob.exDocumento.dtDoc >= :dtIni)"
 				+ "                and (:dtFim is null or mob.exDocumento.dtDoc <= :dtFim)"
-				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > CURRENT_TIMESTAMP)"),
+				+ "                and (mar.dtIniMarca is null or mar.dtIniMarca < :dbDatetime)"
+				+ "                and (mar.dtFimMarca is null or mar.dtFimMarca > :dbDatetime)"),
 		// Somente os "em edital de eliminação"
 		@NamedQuery(name = "consultarEmEditalEliminacao", query = "select mob, mar" + "                from ExMobil mob"
 				+ "                join mob.exMarcaSet mar" + "                join mob.exDocumento doc"

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -678,6 +678,8 @@ public class ExDao extends CpDao {
 					ExModelo.class, false);
 			query.setParameter("hisIdIni", mod.getHisIdIni());
 		}
+		
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
 	}
 
 	public List consultarPorFiltroOtimizado(final ExMobilDaoFiltro flt,
@@ -1212,6 +1214,8 @@ public class ExDao extends CpDao {
 		final Query query = em().createNamedQuery(
 				"consultarParaArquivarIntermediarioEmLote");
 		query.setParameter("idOrgaoUsu", lot.getOrgaoUsuario().getIdOrgaoUsu());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		query.setFirstResult(offset);
 		query.setMaxResults(100);
 		List<Object[]> results = query.getResultList();
@@ -1226,6 +1230,8 @@ public class ExDao extends CpDao {
 		final Query query = em().createNamedQuery(
 				"consultarQuantidadeParaArquivarIntermediarioEmLote");
 		query.setParameter("idOrgaoUsu", lot.getOrgaoUsuario().getIdOrgaoUsu());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		return ((Long) query.getSingleResult()).intValue();
 	}
 
@@ -1234,6 +1240,8 @@ public class ExDao extends CpDao {
 		final Query query = em().createNamedQuery(
 				"consultarParaArquivarPermanenteEmLote");
 		query.setParameter("idOrgaoUsu", lot.getOrgaoUsuario().getIdOrgaoUsu());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		query.setFirstResult(offset);
 		query.setMaxResults(100);
 		List<Object[]> results = query.getResultList();
@@ -1248,6 +1256,8 @@ public class ExDao extends CpDao {
 		final Query query = em().createNamedQuery(
 				"consultarQuantidadeParaArquivarPermanenteEmLote");
 		query.setParameter("idOrgaoUsu", lot.getOrgaoUsuario().getIdOrgaoUsu());
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		return ((Long) query.getSingleResult()).intValue();
 	}
 
@@ -1282,6 +1292,8 @@ public class ExDao extends CpDao {
 		query.setParameter("idOrgaoUsu", orgaoUsu.getIdOrgaoUsu());
 		query.setParameter("dtIni", dtIni);
 		query.setParameter("dtFim", dtFim);
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		long ini = System.currentTimeMillis();
 		List<Object[]> results = query.getResultList();
 		List<ExItemDestinacao> listaFinal = new ArrayList<ExItemDestinacao>();
@@ -1299,6 +1311,8 @@ public class ExDao extends CpDao {
 		query.setParameter("idOrgaoUsu", orgaoUsu.getIdOrgaoUsu());
 		query.setParameter("dtIni", dtIni);
 		query.setParameter("dtFim", dtFim);
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		return ((Long) query.getSingleResult()).intValue();
 	}
 
@@ -1723,8 +1737,8 @@ public class ExDao extends CpDao {
 		String q = "select marca, marcador, mobil from ExMarca marca"
 				+ " inner join marca.cpMarcador marcador"
 				+ " inner join marca.exMobil mobil"
-				+ " where (marca.dtIniMarca is null or marca.dtIniMarca < CURRENT_TIMESTAMP)"
-				+ " and (marca.dtFimMarca is null or marca.dtFimMarca > CURRENT_TIMESTAMP)"
+				+ " where (marca.dtIniMarca is null or marca.dtIniMarca < :dbDatetime)"
+				+ " and (marca.dtFimMarca is null or marca.dtFimMarca > :dbDatetime)"
 				+ " and (marca.dpPessoaIni.idPessoa = :titular or "
 				+ " (marca.dpPessoaIni.idPessoa = null and marca.dpLotacaoIni.idLotacao = :lotaTitular))";
 		if(Prop.isGovSP()) {
@@ -1745,6 +1759,8 @@ public class ExDao extends CpDao {
 		else
 			query.setParameter("lotaTitular", null);
 
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		List l = query.getResultList();
  		long tempoTotal = System.nanoTime() - tempoIni;
 		// System.out.println("consultarPorFiltroOtimizado: " + tempoTotal
@@ -1787,8 +1803,8 @@ public class ExDao extends CpDao {
 						"select marca, marcador, mobil from ExMarca marca"
 								+ " inner join marca.cpMarcador marcador"
 								+ " inner join marca.exMobil mobil"
-								+ " where (marca.dtIniMarca is null or marca.dtIniMarca < CURRENT_TIMESTAMP)"
-								+ " and (marca.dtFimMarca is null or marca.dtFimMarca > CURRENT_TIMESTAMP)"
+								+ " where (marca.dtIniMarca is null or marca.dtIniMarca < :dbDatetime)"
+								+ " and (marca.dtFimMarca is null or marca.dtFimMarca > :dbDatetime)"
 								+ " and (marca.cpMarcador.idMarcador = 14L)"
 								+ (titular != null ? " and (marca.dpPessoaIni.idPessoaIni = :titular)"
 										: " and (marca.dpLotacaoIni.idLotacaoIni = :lotaTitular)"));
@@ -1797,6 +1813,8 @@ public class ExDao extends CpDao {
 		else if (lotaTitular != null)
 			query.setParameter("lotaTitular", lotaTitular.getIdLotacaoIni());
         
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		List l = query.getResultList();
  		long tempoTotal = System.nanoTime() - tempoIni;
 		// System.out.println("consultarPorFiltroOtimizado: " + tempoTotal
@@ -1826,6 +1844,7 @@ public class ExDao extends CpDao {
 			String queryMarcasAIgnorar = marcasAIgnorar.toString().replaceAll("\\[|\\]", "");
 			String queryMarcasAIgnorarFinal = "";
 			int i = 0;
+			
 			// Para cada grupo solicitado, gera a query para contagem
 			for (GrupoItem grupoItem : grupos) {
 				i++;
@@ -1852,8 +1871,8 @@ public class ExDao extends CpDao {
 						 + " INNER JOIN corporativo.cp_marcador marcador ON marca.id_marcador = marcador.id_marcador"
 						 + " LEFT OUTER JOIN corporativo.cp_marca marca2 ON "
 						  + " marca2.id_ref = marca.id_ref "
-						  + " AND (marca2.dt_ini_marca IS NULL OR marca2.dt_ini_marca < CURRENT_TIMESTAMP)"
-						  + " AND (marca2.dt_fim_marca IS NULL OR marca2.dt_fim_marca > CURRENT_TIMESTAMP)"
+						  + " AND (marca2.dt_ini_marca IS NULL OR marca2.dt_ini_marca < :dbDatetime)"
+						  + " AND (marca2.dt_fim_marca IS NULL OR marca2.dt_fim_marca > :dbDatetime)"
 						  + " AND ((marcador.GRUPO_MARCADOR <> " + String.valueOf(Mesa2.GrupoDeMarcadorEnum.EM_ELABORACAO.getId()) 
 						  	+ " AND MARCA2.ID_MARCADOR = " + String.valueOf(CpMarcador.MARCADOR_EM_ELABORACAO) + ") "
 						  	+ ( "".equals(queryMarcasAIgnorarFinal) ? ")" : 
@@ -1862,8 +1881,8 @@ public class ExDao extends CpDao {
 						  		+ " AND marca2.id_marcador in (" + queryMarcasAIgnorarFinal + ")))" )
 //  						  + (!grupoItem.grupoNome.equals(Mesa2.GrupoDeMarcadorEnum.EM_ELABORACAO.getNome())?
 //  								  " OR marca2.id_marcador = " + String.valueOf(CpMarcador.MARCADOR_EM_ELABORACAO) + ")" : ")")
-						 + " WHERE (marca.dt_ini_marca IS NULL OR marca.dt_ini_marca < CURRENT_TIMESTAMP)"
-						  + " AND (marca.dt_fim_marca IS NULL OR marca.dt_fim_marca > CURRENT_TIMESTAMP)"
+						 + " WHERE (marca.dt_ini_marca IS NULL OR marca.dt_ini_marca < :dbDatetime)"
+						  + " AND (marca.dt_fim_marca IS NULL OR marca.dt_fim_marca > :dbDatetime)"
 						  + " AND ((marca.id_pessoa_ini = :idPessoaIni) OR (marca.id_lotacao_ini = :idLotacaoIni))"
 						  + " AND marca.id_tp_marca = 1"
 						  + " AND marcador.grupo_marcador = " + grupoItem.grupoOrdem 
@@ -1884,7 +1903,8 @@ public class ExDao extends CpDao {
 				sql.setParameter("idLotacaoIni", lot.getIdLotacaoIni());
 				sql.setParameter("marcaAssinSenha", CpMarcador.MARCADOR_DOCUMENTO_ASSINADO_COM_SENHA);
 				sql.setParameter("marcaMovAssinSenha", CpMarcador.MARCADOR_MOVIMENTACAO_ASSINADA_COM_SENHA);
-	
+				sql.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+				
 				result = sql.getResultList();
 			}
 
@@ -1924,8 +1944,8 @@ public class ExDao extends CpDao {
 					+ " inner join mobil.exDocumento doc"
 					+ " left join marca.exMovimentacao mov"
 					+ queryMarcasAIgnorar
-					+ " where (marca.dtIniMarca is null or marca.dtIniMarca < CURRENT_TIMESTAMP)"
-					+ " and (marca.dtFimMarca is null or marca.dtFimMarca > CURRENT_TIMESTAMP)"
+					+ " where (marca.dtIniMarca is null or marca.dtIniMarca < :dbDatetime)"
+					+ " and (marca.dtFimMarca is null or marca.dtFimMarca > :dbDatetime)"
 					+ (!exibeLotacao && titular != null ? " and (marca.dpPessoaIni.idPessoaIni = :titular)" : "") 
 					+ (exibeLotacao && lotaTitular != null ? " and (marca.dpLotacaoIni.idLotacaoIni = :lotaTitular)" : "")
 					+ queryMarcasAIgnorarWhere
@@ -1943,7 +1963,8 @@ public class ExDao extends CpDao {
 
 		query.setParameter("marcaAssinSenha", CpMarcador.MARCADOR_DOCUMENTO_ASSINADO_COM_SENHA);
 		query.setParameter("marcaMovAssinSenha", CpMarcador.MARCADOR_MOVIMENTACAO_ASSINADA_COM_SENHA);
-
+		query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
+		
 		l = query.getResultList();
 //		long tempoTotal = System.nanoTime() - tempoIni;
 //		System.out.println("listarMobilsPorMarcas: " + tempoTotal

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -40,8 +40,8 @@ public class MontadorQuery implements IMontadorQuery {
 		if (flt.getUltMovIdEstadoDoc() != null
 				&& flt.getUltMovIdEstadoDoc() != 0) {
 			sbf.append(" and label.cpMarcador.hisIdIni = :idMarcadorIni");
-			sbf.append(" and (dt_ini_marca is null or dt_ini_marca < CURRENT_TIMESTAMP)");
-			sbf.append(" and (dt_fim_marca is null or dt_fim_marca > CURRENT_TIMESTAMP)");
+			sbf.append(" and (dt_ini_marca is null or dt_ini_marca < :dbDatetime)");
+			sbf.append(" and (dt_fim_marca is null or dt_fim_marca > :dbDatetime)");
 		} else {
 			sbf.append(" and not (label.cpMarcador.idMarcador = :id1 or label.cpMarcador.idMarcador = :id2 or label.cpMarcador.idMarcador = :id3)");
 		}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/relatorio/dinamico/relatorios/RelDocsOrgaoInteressado.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/relatorio/dinamico/relatorios/RelDocsOrgaoInteressado.java
@@ -30,6 +30,7 @@ import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExDocumento;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.model.ContextoPersistencia;
 import br.gov.jfrj.siga.model.dao.HibernateUtil;
 
@@ -131,8 +132,8 @@ import br.gov.jfrj.siga.model.dao.HibernateUtil;
 						+ "			where label.cpMarcador.idMarcador = :idMarcador "
 						+ "			and (label.dpLotacaoIni.orgaoUsuario.idOrgaoUsu = :orgaoPesqId "
 						+ "			or label.dpPessoaIni.orgaoUsuario.idOrgaoUsu = :orgaoPesqId) "
-						+ "			and (label.dtIniMarca is null or label.dtIniMarca < CURRENT_TIMESTAMP) " 
-						+ "			and (label.dtFimMarca is null or label.dtFimMarca > CURRENT_TIMESTAMP)) "
+						+ "			and (label.dtIniMarca is null or label.dtIniMarca < :dbDatetime) " 
+						+ "			and (label.dtFimMarca is null or label.dtFimMarca > :dbDatetime)) "
 						+ "		and doc.dtDoc >= :dtini and doc.dtDoc < :dtfim "
 						+ "		and doc.dtFinalizacao is not null "
 						+ queryOrgao
@@ -175,6 +176,8 @@ import br.gov.jfrj.siga.model.dao.HibernateUtil;
 			Date dtfim = formatter.parse((String) parametros.get("dataFinal"));
 			Date dtfimMaisUm = new Date( dtfim.getTime() + 86400000L );
 			query.setParameter("dtfim", dtfimMaisUm);
+			
+			query.setParameter("dbDatetime", ExDao.getInstance().consultarDataEHoraDoServidor());
 			
 			Iterator it = query.getResultList().iterator();
 


### PR DESCRIPTION
### Adequação do uso da Data/Hora do Banco de Dados
Devido a BUG do CURRENT_TIMESTAMP com o Oracle, está sendo utilizada a query consultarDataEHoraDoServidor para ir ao banco de forma Nativa e obter a data/hora do banco de dados. Valor é passado para as queries que utilizavam SYSDATE/CURRENT_TIMESTAMP por Parâmetro :dbDatetime.

Observar comportamento, pois é uma ida e volta a mais no banco de dados, porém com um custo baixíssimo de processamento.