### PR TITLE
Fix/develop/comprimindo json hierarquia de modelos

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/GZip.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/GZip.java
@@ -1,0 +1,47 @@
+package br.gov.jfrj.siga.base;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GZip {
+
+	public static byte[] compress(byte[] str) throws IOException {
+		if (str == null || str.length == 0) {
+			return null;
+		}
+		System.out.println("String length : " + str.length);
+		ByteArrayOutputStream obj = new ByteArrayOutputStream();
+		GZIPOutputStream gzip = new GZIPOutputStream(obj);
+		gzip.write(str);
+		gzip.close();
+		return obj.toByteArray();
+	}
+
+	public static byte[] decompress(byte[] str) throws IOException {
+		int BUFFER = 8192;
+		byte data[] = new byte[BUFFER];
+		int count;
+		byte out[];
+
+		if (str == null || str.length == 0) {
+			return null;
+		}
+		System.out.println("Input byte[] length : " + str.length);
+		GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(str));
+
+		// write the files to the disk
+		ByteArrayOutputStream fos = new ByteArrayOutputStream();
+		while ((count = gis.read(data, 0, BUFFER)) != -1) {
+			fos.write(data, 0, count);
+		}
+		fos.flush();
+		fos.close();
+		out = fos.toByteArray();
+
+		System.out.println("Output String lenght : " + out.length);
+		return out;
+	}
+}

--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/GZip.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/GZip.java
@@ -3,16 +3,16 @@ package br.gov.jfrj.siga.base;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class GZip {
-
 	public static byte[] compress(byte[] str) throws IOException {
 		if (str == null || str.length == 0) {
 			return null;
 		}
-		System.out.println("String length : " + str.length);
+//		System.out.println("String length : " + str.length);
 		ByteArrayOutputStream obj = new ByteArrayOutputStream();
 		GZIPOutputStream gzip = new GZIPOutputStream(obj);
 		gzip.write(str);
@@ -29,7 +29,7 @@ public class GZip {
 		if (str == null || str.length == 0) {
 			return null;
 		}
-		System.out.println("Input byte[] length : " + str.length);
+//		System.out.println("Input byte[] length : " + str.length);
 		GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(str));
 
 		// write the files to the disk
@@ -41,7 +41,7 @@ public class GZip {
 		fos.close();
 		out = fos.toByteArray();
 
-		System.out.println("Output String lenght : " + out.length);
+//		System.out.println("Output String lenght : " + out.length);
 		return out;
 	}
 }

--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/log/RequestExceptionLogger.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/log/RequestExceptionLogger.java
@@ -85,8 +85,12 @@ public class RequestExceptionLogger {
 				if (name.toLowerCase().contains("senha") || name.toLowerCase().contains("password")
 					|| name.toLowerCase().contains("pwd"))
 					requestInfo.append("[parâmetro suprimido]");
-				else
-					requestInfo.append(httpReq.getParameter(name));
+				else {
+					String p = httpReq.getParameter(name);
+					if (p != null && p.length() > 200)
+						p = "[parâmetro encurtado] " + p.substring(0, 200) + "...";
+					requestInfo.append(p);
+				}
 				requestInfo.append("\n");
 			}
 
@@ -100,7 +104,10 @@ public class RequestExceptionLogger {
 				requestInfo.append(name);
 				requestInfo.append(" : ");
 				try {
-					requestInfo.append(httpReq.getAttribute(name));
+					String a = httpReq.getAttribute(name).toString();
+					if (a != null && a.length() > 200)
+						a = "[atributo encurtado] " + a.substring(0, 200) + "...";
+					requestInfo.append(a);
 				} catch (Exception e) {
 					requestInfo.append("não foi possível determinar: ");
 					requestInfo.append(e.getMessage());


### PR DESCRIPTION
Alterei o encoding do parâmetro jsonHierarquiaDeModelos, que antes era um json html encoded, e agora é um base64, gzipped, json. Fiz isso porque esse parâmetro estava ficando grande demais, e inclusive atrapalhava nossa infra, gerando HTTP-POSTs por vezes com mais de 200KB.

Outro problema era da hora de logar esse parâmetro muito grande, quando havia um erro qualquer. O log ficava enorme e também gerava problemas de infra.