### PR TITLE
GOVSP1820 - Restrição da pesquisa avançada por range de datas e pesquisa por texto

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/FuncoesEL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/FuncoesEL.java
@@ -25,6 +25,8 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -1146,4 +1148,10 @@ public class FuncoesEL {
 				.podeDisponibilizarNoAcompanhamentoDoProtocolo(titular, lotaTitular, doc);
 	}
 
+	public static String calculaDiasAPartirDeHoje(Long qtdDias) {
+		final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		LocalDate dt = LocalDate.now().plusDays(qtdDias);
+		return formatter.format(dt);
+	}
+	
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -28,10 +28,12 @@ import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,7 @@ import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.base.TipoResponsavelEnum;
+import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.model.CpOrgaoSelecao;
 import br.gov.jfrj.siga.cp.model.DpLotacaoSelecao;
 import br.gov.jfrj.siga.cp.model.DpPessoaSelecao;
@@ -76,6 +79,7 @@ import br.gov.jfrj.siga.ex.ExTipoDocumento;
 import br.gov.jfrj.siga.ex.ExTipoFormaDoc;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.ExBL;
+import br.gov.jfrj.siga.ex.util.FuncoesEL;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.model.GenericoSelecao;
 import br.gov.jfrj.siga.model.Selecionavel;
@@ -86,7 +90,9 @@ import br.gov.jfrj.siga.vraptor.builder.ExMobilBuilder;
 public class ExMobilController extends
 		ExSelecionavelController<ExMobil, ExMobilDaoFiltro> {
 	private static final String SIGA_DOC_FE_LD = "FE:Ferramentas;LD:Listar Documentos";
-	
+	private static final String SIGA_DOC_PESQ_PESQDESCR = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;PESQDESCR:Pesquisar descrição";
+	private static final String SIGA_DOC_PESQ_DTLIMITADA = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;DTLIMITADA:Pesquisar somente com data limitada";
+	final static public Long MAXIMO_DIAS_PESQUISA = 30L;	
 	/**
 	 * @deprecated CDI eyes only
 	 */
@@ -158,18 +164,18 @@ public class ExMobilController extends
 
 		builder.processar(getLotaTitular());
 
+		String dtDoc = dtDocString;
+
 		if ((SigaMessages.isSigaSP() && offset != null) || (!SigaMessages.isSigaSP() && (primeiraVez == null || !primeiraVez.equals("sim")))) {
-			final ExMobilDaoFiltro flt = createDaoFiltro();
-			final long tempoIni = System.currentTimeMillis();
-			setTamanho(dao().consultarQuantidadePorFiltroOtimizado(flt,
-					getTitular(), getLotaTitular()));
-
-//			System.out.println("Consulta dos por filtro: "
-//					+ (System.currentTimeMillis() - tempoIni));
-
-			setItens(dao().consultarPorFiltroOtimizado(flt,
-					builder.getOffset(), getItemPagina(), getTitular(),
-					getLotaTitular()));
+			dtDoc = listarItensPesquisa(dtDocString, dtDocFinalString, builder, dtDoc);
+		} else {
+			if( Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(getTitular(), getLotaTitular(),
+					SIGA_DOC_PESQ_DTLIMITADA )) {
+				dtDoc = FuncoesEL.calculaDiasAPartirDeHoje(-MAXIMO_DIAS_PESQUISA);
+        		result.include("msgCabecClass", "alert-warning");
+        		result.include("mensagemCabec", "ATENÇÃO: A pesquisa deve ser limitada com uma range de datas de no máximo "
+        				+ MAXIMO_DIAS_PESQUISA.toString() + " dias. Será assumida uma data inicial 30 dias anterior à hoje no campo Data Inicial.");
+			}
 		}
 
 		result.include("primeiraVez", primeiraVez);
@@ -187,7 +193,7 @@ public class ExMobilController extends
 		result.include("orgaosUsu", this.getOrgaosUsu());
 		result.include("tiposDocumento", this.getTiposDocumentoParaConsulta());
 		result.include("idTpDoc", builder.getIdTpDoc());
-		result.include("dtDocString", dtDocString);
+		result.include("dtDocString", dtDoc);
 		result.include("dtDocFinalString", dtDocFinalString);
 		result.include("tiposFormaDoc", this.getTiposFormaDoc());
 		result.include("anoEmissaoString", anoEmissaoString);
@@ -422,7 +428,7 @@ public class ExMobilController extends
 			final String nmDestinatario, final ExClassificacaoSelecao classificacaoSel, final String descrDocumento, final String fullText,
 			final Long ultMovEstadoDoc, final Integer paramoffset) {
 		assertAcesso("");
-		
+
 		getP().setOffset(paramoffset);
 		this.setPostback(postback);
 
@@ -444,17 +450,18 @@ public class ExMobilController extends
 
 		builder.processar(getLotaTitular());
 
+		String dtDoc = dtDocString;
+	
 		if (primeiraVez == null || !primeiraVez.equals("sim")) {
-			final ExMobilDaoFiltro flt = createDaoFiltro();
-			long tempoIni = System.currentTimeMillis();
-			setTamanho(dao().consultarQuantidadePorFiltroOtimizado(flt,
-					getTitular(), getLotaTitular()));
-
-//			System.out.println("Consulta dos por filtro: "
-//					+ (System.currentTimeMillis() - tempoIni));
-			setItens(dao().consultarPorFiltroOtimizado(flt,
-					builder.getOffset(), getItemPagina(), getTitular(),
-					getLotaTitular()));
+			dtDoc = listarItensPesquisa(dtDocString, dtDocFinalString, builder, dtDoc);
+		} else {
+			if( Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(getTitular(), getLotaTitular(),
+					SIGA_DOC_PESQ_DTLIMITADA )) {
+				dtDoc = FuncoesEL.calculaDiasAPartirDeHoje(-MAXIMO_DIAS_PESQUISA);
+        		result.include("msgCabecClass", "alert-warning");
+        		result.include("mensagemCabec", "ATENÇÃO: A pesquisa deve ser limitada com uma range de datas de no máximo "
+        				+ MAXIMO_DIAS_PESQUISA.toString() + " dias. Será assumida uma data inicial 30 dias anterior à hoje no campo Data Inicial.");
+			}
 		}
 
 		result.include("primeiraVez", primeiraVez);
@@ -472,7 +479,7 @@ public class ExMobilController extends
 		result.include("orgaosUsu", this.getOrgaosUsu());
 		result.include("tiposDocumento", this.getTiposDocumentoParaConsulta());
 		result.include("idTpDoc", builder.getIdTpDoc());
-		result.include("dtDocString", dtDocString);
+		result.include("dtDocString", dtDoc);
 		result.include("dtDocFinalString", dtDocFinalString);
 		result.include("tiposFormaDoc", this.getTiposFormaDoc());
 		result.include("anoEmissaoString", anoEmissaoString);
@@ -521,6 +528,79 @@ public class ExMobilController extends
 			result.include("campos", campos);
 		}
 
+	}
+
+	private String listarItensPesquisa(final String dtDocString, final String dtDocFinalString,
+			final ExMobilBuilder builder, String dtDoc) {
+		final ExMobilDaoFiltro flt = createDaoFiltro();
+		if (flt.getDescrDocumento() != null 
+				&& !"".equals(flt.getDescrDocumento()) && !(Cp.getInstance().getConf()
+				.podeUtilizarServicoPorConfiguracao(getTitular(), getLotaTitular(), SIGA_DOC_PESQ_PESQDESCR)))
+			result.include(SigaModal.ALERTA, SigaModal.mensagem("Usuário não autorizado a pesquisar pela descrição do documento."));
+		
+		LocalDate dt = null;
+		if (param("dtDocString") == null) {
+			result.include("msgCabecClass", "alert-warning");
+			result.include("mensagemCabec", "ATENÇÃO: A pesquisa deve ser limitada com uma range de datas de no máximo "
+					+ MAXIMO_DIAS_PESQUISA.toString() + " dias. Foi assumida uma data inicial 30 dias anterior à hoje.");
+			dt = LocalDate.now().plusDays(-MAXIMO_DIAS_PESQUISA);
+			flt.setDtDoc(Date.from(dt.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+			dtDoc = FuncoesEL.calculaDiasAPartirDeHoje(-MAXIMO_DIAS_PESQUISA);
+		}
+
+		try {
+			if(Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(getTitular(), 
+					getLotaTitular(), SIGA_DOC_PESQ_DTLIMITADA ) && dt == null) 
+				validarLimiteDeDatas(dtDocString, dtDocFinalString);
+//					long tempoIni = System.currentTimeMillis();
+			setTamanho(dao().consultarQuantidadePorFiltroOtimizado(flt,
+					getTitular(), getLotaTitular()));
+
+//					System.out.println("Consulta dos por filtro: "
+//							+ (System.currentTimeMillis() - tempoIni));
+			setItens(dao().consultarPorFiltroOtimizado(flt,
+					builder.getOffset(), getItemPagina(), getTitular(),
+					getLotaTitular()));
+		} catch (RegraNegocioException e) {
+			result.include("msgCabecClass", "alert-danger");
+			result.include("mensagemCabec", e.getMessage());
+		}
+		return dtDoc;
+	}
+
+	private void validarLimiteDeDatas(final String dtDocString, final String dtDocFinalString) {
+		final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		LocalDate dtIni = null;
+		LocalDate dtFinal = null;
+		LocalDate dataAtual = LocalDate.now();
+		
+		if (dtDocString != null && !"".equals(dtDocString)) {
+			if (Data.validaDDMMYYYY(dtDocString)) {
+				dtIni = LocalDate.parse(dtDocString, formatter);
+			} else {
+				throw new RegraNegocioException("Data Inicial inválida.");
+			}
+		} else {
+			throw new RegraNegocioException("Data Inicial não informada. Para grandes volumes, período para pesquisa não deve ser superior à "
+					+ MAXIMO_DIAS_PESQUISA.toString() + " dias.");
+		}
+		
+		if (dtDocFinalString != null && !"".equals(dtDocFinalString)) {
+			if (Data.validaDDMMYYYY(dtDocFinalString)) {
+				dtFinal = LocalDate.parse(dtDocFinalString, formatter);
+				if (ChronoUnit.DAYS.between(dtIni, dtFinal) > MAXIMO_DIAS_PESQUISA) {
+					throw new RegraNegocioException("Para grandes volumes, período para pesquisa não deve ser superior a "
+							+ MAXIMO_DIAS_PESQUISA.toString() + " dias. Informe a Data Inicial e/ou Final.");
+				}	
+			} else {
+				throw new RegraNegocioException("Data Final inválida.");
+			}
+		} else {
+			if (ChronoUnit.DAYS.between(dtIni, dataAtual) > MAXIMO_DIAS_PESQUISA) {
+				throw new RegraNegocioException("Para grandes volumes, período para exportação não deve ser superior a "
+						+ MAXIMO_DIAS_PESQUISA.toString() + " dias. Informe a Data Inicial e/ou Final.");
+			}	
+		}
 	}
 
 	final static Pattern preprocessadorPatternSelecao = Pattern

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
@@ -407,6 +407,16 @@ function limpaCampos()
 <siga:pagina titulo="Lista de Expedientes" popup="${popup}">
 	<!-- main content bootstrap -->
 	<div class="container-fluid">
+		<div class="row ${mensagemCabec==null?'d-none':''}" id="mensagemCabecId" >
+			<div class="col" >
+				<div class="alert ${msgCabecClass} fade show" id="mensagemCabec" role="alert">
+					${mensagemCabec}
+					<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+				</div>			
+			</div>
+		</div>
 		<div class="card bg-light mb-3">
 			<div class="card-header">
 				<h5>Pesquisa de Documentos</h5>
@@ -733,7 +743,7 @@ function limpaCampos()
 						<div class="form-group col-md-3">
 							<label for="dtDocFinalString">Data Final</label> <input
 								class="form-control" type="text" name="dtDocFinalString"
-								id="dtDocFinalString" value="${dtDocString}"
+								id="dtDocFinalString" value="${dtDocFinalString}"
 								onblur="javascript:verifica_data(this,0);" />
 						</div>
 					</div>
@@ -987,10 +997,14 @@ function limpaCampos()
 								</div>	
 								
 								<div class="row">
-									<div class="col-sm-4">
+									<div class="col-sm-6">
 										<div class="form-group">	
 											<label>Descrição</label>
-											<input type="text" name="descrDocumento" id="descrDocumento" value="${descrDocumento}" size="80" class="form-control" />
+											<input type="text" name="descrDocumento" id="descrDocumento" value="${descrDocumento}" size="80" class="form-control"
+												<c:if test="${!(f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;PESQDESCR:Pesquisar descrição'))}">
+													readonly placeholder="Não é possível realizar a pesquisa pela descrição"
+												</c:if>
+											/>
 										</div>
 									</div>
 								</div>	

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -406,7 +406,11 @@
 							<div class="form-group col-md-6">
 								<label for="classificacao"><fmt:message key="documento.descricao"/></label> <input
 									class="form-control" type="text" name="descrDocumento" id="descrDocumento"
-									value="${descrDocumento}" size="80" />
+									value="${descrDocumento}" size="80"
+									<c:if test="${!(f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;PESQDESCR:Pesquisar descrição'))}">
+										readonly placeholder="Não é possível realizar a pesquisa pela descrição"
+									</c:if>
+									/>
 							</div>
 						</div>
 					</c:if>

--- a/sigaex/src/main/webapp/WEB-INF/tld/func.tld
+++ b/sigaex/src/main/webapp/WEB-INF/tld/func.tld
@@ -437,4 +437,9 @@
   <function-class>br.gov.jfrj.siga.ex.util.FuncoesEL</function-class>
   <function-signature>java.lang.Boolean podeDisponibilizarNoAcompanhamentoDoProtocolo(br.gov.jfrj.siga.dp.DpPessoa, br.gov.jfrj.siga.dp.DpLotacao, br.gov.jfrj.siga.ex.ExDocumento)</function-signature>
  </function> 
+ <function>
+  <name>calculaDiasAPartirDeHoje</name>
+  <function-class>br.gov.jfrj.siga.jee.SigaLibsEL</function-class>
+  <function-signature>java.lang.String calculaDiasAPartirDeHoje( java.lang.Long )</function-signature>
+ </function>
 </taglib>


### PR DESCRIPTION
Criadas configurações de serviços para:

- Bloquear pesquisa por texto (só em SP) 
- Obrigar preenchimento de um range de datas menor que 30 dias na pesquisa de documentos

![image](https://user-images.githubusercontent.com/49542320/108532402-94bd9980-72b6-11eb-8cab-af57656fa91f.png)

Caso o usuário tenha a permissão PESQ-DTLIMITADA setada, ao entrar na página de pesquisa, a data inicial é preenchida automaticamente com uma data de 30 dias atrás e é emitido um aviso informando o usuário no topo da tela sobre isso:

![image](https://user-images.githubusercontent.com/49542320/108532771-f4b44000-72b6-11eb-87b9-1cdbe44d25aa.png)

Isso acontecerá inclusive quando é redirecionada a partir do quadro quantitativo.

Futuramente, será implementada a tela reativa da pesquisa avançada em vue.js. Ao invés de paginar a tela carregará mais documentos na tela sem perder os já carregados. Isto irá evitar um count no banco para gerar os indices de navegação das páginas.

