### PR TITLE
GOVSP1837* Proibir juntada de vias diferentes do mesmo documento

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3980,8 +3980,7 @@ public class ExBL extends CpBL {
 				throw new RegraNegocioException("Não foi selecionado um documento para a juntada");
 
 			if (mob.getExDocumento().getIdDoc().equals(mobPai.getExDocumento().getIdDoc())
-					&& mob.getNumSequencia().equals(mobPai.getNumSequencia())
-					&& mob.getExTipoMobil().getIdTipoMobil().equals(mobPai.getExTipoMobil().getIdTipoMobil()))
+					&& mob.getNumSequencia().equals(mobPai.getNumSequencia()))
 				throw new RegraNegocioException("Não é possível juntar um documento a ele mesmo");					
 			
 			if (!mobPai.getExDocumento().isFinalizado())


### PR DESCRIPTION
Já existia uma verificação se a juntada ocorria para a mesma via, passa a bloquear também se forem vias diferentes mostrando a mensagem:

![image](https://user-images.githubusercontent.com/49542320/109146314-6f131300-7742-11eb-9d86-ad2fc489b96e.png)
