### PR TITLE
GOVSP1864* - Correções em webservices

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExDocumentoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExDocumentoApiVO.java
@@ -269,7 +269,7 @@ public class ExDocumentoApiVO extends ExApiVO {
 
 			for (ExMovimentacaoApiVO exMovVO : mobVO.getMovs()) {
 				if (!exMovVO.isCancelada() && movimentacoesPermitidas.contains(exMovVO.getIdTpMov())) {
-
+					exMovVO.podeExibirNoSigale = true;
 					// Desabilitado temporariamente
 					// if (exMovVO.getIdTpMov() ==
 					// ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA)
@@ -283,8 +283,10 @@ public class ExDocumentoApiVO extends ExApiVO {
 					// }
 					if (!juntadasRevertidas.contains(exMovVO))
 						movimentacoesFinais.add(exMovVO);
+				} else {
+					exMovVO.podeExibirNoSigale = false;
+					movimentacoesFinais.add(exMovVO);
 				}
-
 			}
 
 			mobVO.setMovs(movimentacoesFinais);

--- a/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMovimentacaoApiVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/sigale/ex/vo/ExMovimentacaoApiVO.java
@@ -86,6 +86,7 @@ public class ExMovimentacaoApiVO extends ExApiVO {
 	String lotaCadastranteSigla;
 	String exTipoMovimentacaoSigla;
 	String tempoRelativo;
+	boolean podeExibirNoSigale;
 
 	public ExMovimentacaoApiVO(ExMobilApiVO mobVO, ExMovimentacao mov,
 			DpPessoa cadastrante, DpPessoa titular, DpLotacao lotaTitular) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoGet.java
@@ -51,7 +51,7 @@ public class DocumentosSiglaArquivoGet implements IDocumentosSiglaArquivoGet {
 						"Acesso ao documento " + mob.getSigla() + " permitido somente a usuários autorizados. ("
 								+ so.getTitular().getSigla() + "/" + so.getLotaTitular().getSiglaCompleta() + ")");
 
-			String filename = "text/html".equals(req.contenttype)
+			String filename = "application/pdf".equals(req.contenttype)
 					? (req.volumes != null && req.volumes ? mob.doc().getReferenciaPDF() : mob.getReferenciaPDF())
 					: (req.volumes != null && req.volumes ? mob.doc().getReferenciaHtml() : mob.getReferenciaHtml());
 			final String servernameport = request.getServerName() + ":" + request.getServerPort();

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -60,7 +60,7 @@ parameters:
   estampa:
     name: estampa
     in: query
-    description: Informar true se deseja receber o PDF sem estampas
+    description: Informar false se deseja receber o PDF sem estampas
     required: false
     default: false
     type: boolean


### PR DESCRIPTION
Alterações realizadas:

- Exibição de todos as movimentações no DocumentosSiglaGet, com indicação se pode ser exibido no SIGA-LE (cada movimentação tem um flag chamado podeExibirNoSigale. Os que estiverem como true eram os que eram mostrados anteriormente)
- Inversão do tipo de arquivo (pdf/html) no DocumentosSiglaArquivoGet - parâmetro contenttype
- DocumentosSiglaArquivoGet: correção na documentação do swagger, inversão do true/false do parâmetro estampa