### PR TITLE
GOVSP1862* - Webservice gerar protocolo

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.HttpServletRequest;
+
 import br.gov.jfrj.siga.base.Texto;
 
 public class Utils {
@@ -45,6 +47,13 @@ public class Utils {
 	    return matcher.find();   
 	}
 	
+	public static String getBaseUrl(HttpServletRequest request) {
+	    String scheme = request.getScheme() + "://";
+	    String serverName = request.getServerName();
+	    String serverPort = (request.getServerPort() == 80) ? "" : ":" + request.getServerPort();
+	    String contextPath = request.getContextPath();
+	    return scheme + serverName + serverPort + contextPath;
+	  }
 	
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGerarProtocoloPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGerarProtocoloPost.java
@@ -1,0 +1,79 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import com.crivano.swaggerservlet.SwaggerException;
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.base.Prop;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExProtocolo;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocumentosSiglaGerarProtocoloPostRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocumentosSiglaGerarProtocoloPostResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocumentosSiglaGerarProtocoloPost;
+import br.gov.jfrj.siga.ex.bl.CurrentRequest;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExBL;
+import br.gov.jfrj.siga.ex.bl.RequestInfo;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
+import br.gov.jfrj.siga.base.util.Utils;
+
+public class DocumentosSiglaGerarProtocoloPost implements IDocumentosSiglaGerarProtocoloPost {
+
+	@Override
+	public void run(DocumentosSiglaGerarProtocoloPostRequest req, DocumentosSiglaGerarProtocoloPostResponse resp) throws Exception {
+		try (ApiContext ctx = new ApiContext(true, true)) {
+			CurrentRequest.set(
+					new RequestInfo(null, SwaggerServlet.getHttpServletRequest(), SwaggerServlet.getHttpServletResponse()));
+			ApiContext.assertAcesso("");
+			SigaObjects so = ApiContext.getSigaObjects();
+	
+			DpPessoa cadastrante = so.getCadastrante();
+			DpLotacao lotaCadastrante = cadastrante.getLotacao();
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+	
+			ExMobil mob = SwaggerHelper.buscarEValidarMobil(req.sigla, so, req, resp, "Documento a gerar protocolo");
+	
+			ApiContext.assertAcesso(mob, titular, lotaTitular);
+
+			final Ex ex = Ex.getInstance();
+			final ExBL exBL = ex.getBL();
+			
+			ExProtocolo prot = new ExProtocolo();
+			prot = exBL.obterProtocolo(mob.getDoc());
+			
+			if(prot == null) {
+				try {
+					prot = exBL.gerarProtocolo(mob.getDoc(), cadastrante, lotaCadastrante);
+				} catch (Exception e) {
+					throw new AplicacaoException("Ocorreu um erro ao gerar protocolo.");
+				}
+			}
+			DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+			Calendar c = Calendar.getInstance();
+			c.setTime(prot.getData());
+			String servidor = Prop.get("/sigaex.url");
+			String caminho = Utils.getBaseUrl(SwaggerServlet.getHttpServletRequest()) 
+					+ "/public/app/processoautenticar?n=" + prot.getCodigo();
+			resp.numeroProtocolo = prot.getCodigo();
+			resp.linkProtocolo = caminho;
+			resp.dataHoraEmissaoProtocolo = df.format(c.getTime());
+		} catch (AplicacaoException | SwaggerException e) {
+			throw e;
+		} catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw e;
+		}
+	}
+	
+	@Override
+	public String getContext() {
+		return "Gerar protocolo do documento";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -451,6 +451,20 @@ public interface IExApiV1 {
 		public void run(DocumentosSiglaMarcadoresDisponiveisGetRequest req, DocumentosSiglaMarcadoresDisponiveisGetResponse resp) throws Exception;
 	}
 
+	public class DocumentosSiglaGerarProtocoloPostRequest implements ISwaggerRequest {
+		public String sigla;
+	}
+
+	public class DocumentosSiglaGerarProtocoloPostResponse implements ISwaggerResponse {
+		public String numeroProtocolo;
+		public String linkProtocolo;
+		public String dataHoraEmissaoProtocolo;
+	}
+
+	public interface IDocumentosSiglaGerarProtocoloPost extends ISwaggerMethod {
+		public void run(DocumentosSiglaGerarProtocoloPostRequest req, DocumentosSiglaGerarProtocoloPostResponse resp) throws Exception;
+	}
+
 	public class SugestaoPostRequest implements ISwaggerRequest {
 		public String nome;
 		public String email;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -75,6 +75,7 @@ import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.RegraNegocioException;
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.SigaModal;
+import br.gov.jfrj.siga.base.util.Utils;
 import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.model.DpLotacaoSelecao;
@@ -99,6 +100,7 @@ import br.gov.jfrj.siga.ex.ExSituacaoConfiguracao;
 import br.gov.jfrj.siga.ex.ExTipoDocumento;
 import br.gov.jfrj.siga.ex.ExTipoMobil;
 import br.gov.jfrj.siga.ex.ExTipoMovimentacao;
+import br.gov.jfrj.siga.ex.api.v1.ApiContext;
 import br.gov.jfrj.siga.ex.bl.AcessoConsulta;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.ExBL;
@@ -136,7 +138,7 @@ public class ExDocumentoController extends ExController {
 			Result result, SigaObjects so, EntityManager em) {
 		super(request, response, context, result, CpDao.getInstance(), so, em);
 		
-		url = getBaseUrl(request);
+		url = Utils.getBaseUrl(request);
 	}
 
 	private ExDocumento buscarDocumento(final BuscaDocumentoBuilder builder,
@@ -2120,14 +2122,6 @@ public class ExDocumentoController extends ExController {
 		result.include("doc", exDocumentoDto.getDoc());
 	}
 	
-	public static String getBaseUrl(HttpServletRequest request) {
-	    String scheme = request.getScheme() + "://";
-	    String serverName = request.getServerName();
-	    String serverPort = (request.getServerPort() == 80) ? "" : ":" + request.getServerPort();
-	    String contextPath = request.getContextPath();
-	    return scheme + serverName + serverPort + contextPath;
-	  }
-
 	@Transacional
 	@Post("/app/expediente/doc/tornarDocumentoSemEfeitoGravar")
 	public void tornarDocumentoSemEfeitoGravar(final String sigla,

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -859,6 +859,40 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /documentos/{sigla}/gerar-protocolo:
+    post:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [acao]
+      security:
+        - Bearer: []      
+      parameters:
+        - $ref: "#/parameters/sigla"
+      description: Gera um número de protocolo e link para acompanhamento de um expediente ou processo
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              numeroProtocolo:
+                type: string
+              linkProtocolo:
+                type: string
+              dataHoraEmissaoProtocolo:
+                type: string
+        403:
+          description: Acesso ao documento não permitido
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+          description: Documento não encontrado
+          schema:
+            $ref: "#/definitions/Error"        
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
   /sugestao:
     post:
       consumes: ["application/x-www-form-urlencoded"]


### PR DESCRIPTION
Criado no siga-ex o webservice POST /documentos/{sigla}/gerar-protocolo, que faz a mesma função do botão Gerar Protocolo. O método getBaseUrl que é comum ao WS e ao controller do botão, foi passado para o Utils para não duplicar código.