### PR TITLE
Script V64_0__Configuracoes_para_permitir_exportar_dados.sql não foi encontrado na migration mysql

### DIFF
--- a/siga-cp/src/main/resources/db/mysql/sigacp/V64_0__Configuracoes_para_permitir_exportar_dados.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V64_0__Configuracoes_para_permitir_exportar_dados.sql
@@ -1,0 +1,25 @@
+/* Permissões para botão de exportar dados para CSV */
+
+-- Cadastro de Pessoa
+INSERT INTO corporativo.cp_servico ( SIGLA_SERVICO, DESC_SERVICO, ID_SERVICO_PAI, ID_TP_SERVICO) 
+    SELECT 'SIGA-GI-CAD_PESSOA-EXP_DADOS', 'Exportar Dados',  max(id_servico) , '2'  
+    FROM corporativo.cp_servico
+    WHERE SIGLA_SERVICO = 'SIGA-GI-CAD_PESSOA' ;
+    
+-- Cadastro de Cargo
+INSERT INTO corporativo.cp_servico (SIGLA_SERVICO, DESC_SERVICO, ID_SERVICO_PAI, ID_TP_SERVICO) 
+    SELECT  'SIGA-GI-CAD_CARGO-EXP_DADOS', 'Exportar Dados', max(id_servico), '2'
+    FROM corporativo.cp_servico 
+    WHERE SIGLA_SERVICO = 'SIGA-GI-CAD_CARGO';
+    
+-- Cadastro de Função de Confiança    
+INSERT INTO corporativo.cp_servico (  SIGLA_SERVICO, DESC_SERVICO, ID_SERVICO_PAI, ID_TP_SERVICO) 
+    SELECT  'SIGA-GI-CAD_FUNCAO-EXP_DADOS', 'Exportar Dados',  max(id_servico) , '2'
+    FROM corporativo.cp_servico 
+    WHERE SIGLA_SERVICO = 'SIGA-GI-CAD_FUNCAO';    
+    
+-- Cadastro de Lotação   
+INSERT INTO corporativo.cp_servico ( SIGLA_SERVICO, DESC_SERVICO, ID_SERVICO_PAI, ID_TP_SERVICO) 
+   SELECT  'SIGA-GI-CAD_LOTACAO-EXP_DADOS', 'Exportar Dados',  max(id_servico) , '2'
+   FROM corporativo.cp_servico 
+   WHERE SIGLA_SERVICO = 'SIGA-GI-CAD_LOTACAO';    


### PR DESCRIPTION
Fixes #1743 