### PR TITLE
GOVSP1880* - Exibir Documento Pai no Acompanhamento do Protocolo

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
@@ -2,10 +2,13 @@ package br.gov.jfrj.siga.base.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import br.gov.jfrj.siga.base.Texto;
@@ -55,5 +58,17 @@ public class Utils {
 	    return scheme + serverName + serverPort + contextPath;
 	  }
 	
-
+	/*
+	* Devolve o valor do cookie com o nome correspondente
+	*/
+	public static String getCookieValue(HttpServletRequest request, String name) {
+		final Cookie[] cookies = request.getCookies();
+		if(cookies == null) return null;
+		return Arrays.stream(cookies)
+		             .filter(e -> name.equals(e.getName()))
+		             .findAny()
+		             .map(Cookie::getValue)
+		             .orElse(null);		
+	} 
+	
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
@@ -2915,5 +2915,31 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 		return this.idDocPrincipal;
 	}
 
+	/**
+	 * Verifica se o documento contém um determinado mobil 
+	 */
+	public boolean contemMobil(ExMobil mob) {
+		for (ExMobil m : getExMobilSet()) {
+			if (m.equals(mob))
+				return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Retorna se o móbil possui acompanhamento de protocolo gerado.
+	 * 
+	 * @return
+	 */
+	public boolean temAcompanhamentoDeProtocolo() {
+		boolean b = false;
+		for (ExMovimentacao movRef : getExMovimentacaoSet()) {
+			if (!movRef.isCancelada()
+				&& movRef.getExTipoMovimentacao().getId() == ExTipoMovimentacao.TIPO_MOVIMENTACAO_GERAR_PROTOCOLO)
+					b = true;
+		}
+		return b;
+	}
+
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -415,18 +415,13 @@ public class ExDao extends CpDao {
 			Expression<Long> mobilRef = root.get("exMobilRef");																		
 			Join<ExMovimentacao, ExTipoMovimentacao> joinTipoMovimentacao = root.join("exTipoMovimentacao");
 			
-			predicateMobilIgnorandoMovimentacaoDeJuntada = builder.and(mobil.in(mobils), 
-					builder.notEqual(joinTipoMovimentacao.get("idTpMov"), ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA),
-					builder.notEqual(joinTipoMovimentacao.get("idTpMov"), ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA),
-					builder.notEqual(joinTipoMovimentacao.get("idTpMov"), ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_DE_MOVIMENTACAO));
-																
 			predicateMobilRefComoMovimentacaoDeJuntadaEDesentranhamento = builder.and(mobilRef.in(mobils),
 					builder.or(builder.equal(root.get("exTipoMovimentacao"), ExTipoMovimentacao.TIPO_MOVIMENTACAO_JUNTADA),
 							builder.equal(root.get("exTipoMovimentacao"), ExTipoMovimentacao.TIPO_MOVIMENTACAO_CANCELAMENTO_JUNTADA)),
 					builder.isNull(root.get("exMovimentacaoCanceladora"))
 					);
 			
-			predicate = builder.or(predicateMobilIgnorandoMovimentacaoDeJuntada, predicateMobilRefComoMovimentacaoDeJuntadaEDesentranhamento);
+			predicate = builder.or(mobil.in(mobils), predicateMobilRefComoMovimentacaoDeJuntadaEDesentranhamento);
 			
 			query.where(predicate)
 				.orderBy(builder.desc(root.get("dtTimestamp")));

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -1123,6 +1123,12 @@ public class ExMovimentacaoController extends ExController {
 		result.include("doc", doc);
 		result.include("subscritorSel", new DpPessoaSelecao());
 		result.include("documentoRefSel", documentoRefSel);
+		if (doc.temAcompanhamentoDeProtocolo()) {
+    		result.include("msgCabecClass", "alert-warning");
+			result.include("mensagemCabec", "Este documento possui acompanhamento do protocolo, portanto "
+					+ "o histórico do documento juntado também será visível no acompanhamento do protocolo.");
+		}
+		
 	}
 
 	@Transacional

--- a/sigaex/src/main/webapp/WEB-INF/page/exProcessoAutenticacao/processoArquivoAutenticado.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exProcessoAutenticacao/processoArquivoAutenticado.jsp
@@ -130,16 +130,25 @@
 											<td align="left">${dt}</td>
 											<td align="left">${mov.descrTipoMovimentacao} 
 												<c:if test="${mov.idTpMov == 12}">
-													<span style="font-size: .8rem;color: #9e9e9e;"
-														>| documento juntado ${mov.exMobil}
-														<c:if test="${m.sigla == mov.exMobil.exMobilPai.sigla 
-																&& mov.exMobil.podeExibirNoAcompanhamento()}">
-															&nbsp<a class="showConteudoDoc link-btn btn btn-sm btn-light" href="#" 
-																onclick="popitup('/sigaex/public/app/processoArquivoAutenticado_stream?jwt=${jwt}&sigla=${mov.exMobil}');"
-																rel="popover" data-title="${mov.exMobil}" 
-		    													data-content="" onmouseenter="exibeDoc(this);"
-																>Ver</a>
-	    												</c:if>
+													<span style="font-size: .8rem;color: #9e9e9e;">| documento juntado&nbsp
+														<c:choose>
+															<c:when test="${m.sigla ne mov.exMobil.sigla}">
+																${mov.exMobil}
+																<c:if test="${m.sigla == mov.exMobil.exMobilPai.sigla 
+																				&& mov.exMobil.podeExibirNoAcompanhamento()}">
+																	&nbsp<a class="showConteudoDoc link-btn btn btn-sm btn-light" href="#" 
+																		onclick="popitup('/sigaex/public/app/processoArquivoAutenticado_stream?sigla=${mov.exMobil}');"
+																		rel="popover" data-title="${mov.exMobil}" 
+				    													data-content="" onmouseenter="exibeDoc(this);"
+																		>Ver</a>
+			    												</c:if>
+															</c:when>
+															<c:otherwise>
+																<a class="link-btn btn btn-sm btn-light"  
+																	href="/sigaex/public/app/processoArquivoAutenticado?idMovJuntada=${mov.idMov}"
+																	>${mov.exMobilRef.sigla}</a>
+															</c:otherwise>
+														</c:choose>
 													</span>
 												</c:if>
 												<c:if test="${mov.idTpMov == 13}">


### PR DESCRIPTION
Passa a exibir as juntadas no acompanhamento do protocolo de documentos expedientes. 

![image](https://user-images.githubusercontent.com/49542320/111238537-0b0f9c00-85d6-11eb-9d29-9b4bf6cd38d0.png)

Ao clicar na sigla do documento juntado, exibe acompanhamento de protocolo do documento pai também.

![image](https://user-images.githubusercontent.com/49542320/111238641-372b1d00-85d6-11eb-8d3c-a8c4ea4c9d67.png)


No momento da juntada, se o documento já estiver com o acompanhamento de protocolo gerado, mostra a seguinte mensagem:

![image](https://user-images.githubusercontent.com/49542320/111238693-55911880-85d6-11eb-9ab7-7f32c2493521.png)
