### PR TITLE
PCRJ423 - Correção do erro ao acessar a Mesa v.10.0.5.3 - ( siga-docker mysql )

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1875,7 +1875,7 @@ public class ExDao extends CpDao {
 						  + " AND (marca2.dt_ini_marca IS NULL OR marca2.dt_ini_marca < :dbDatetime)"
 						  + " AND (marca2.dt_fim_marca IS NULL OR marca2.dt_fim_marca > :dbDatetime)"
 						  + " AND ((marcador.GRUPO_MARCADOR <> " + String.valueOf(CpMarcadorGrupoEnum.EM_ELABORACAO.getId()) 
-						  	+ " AND MARCA2.ID_MARCADOR = " + String.valueOf(CpMarcadorEnum.EM_ELABORACAO.getId()) + ") "
+						  	+ " AND marca2.ID_MARCADOR = " + String.valueOf(CpMarcadorEnum.EM_ELABORACAO.getId()) + ") "
 						  	+ ( "".equals(queryMarcasAIgnorarFinal) ? ")" : 
 						  		"OR (((marca2.id_pessoa_ini = :idPessoaIni) OR (marca2.id_lotacao_ini = :idLotacaoIni))"
 						  		+ " AND marca2.id_tp_marca = 1"						 


### PR DESCRIPTION
Sistema apresentou erro ao acessar a Mesa com   v.10.0.5.3 ( SIGA-DOCKER )
![Erro ao acessar a mesa 2021-3-18 10-26](https://user-images.githubusercontent.com/78379805/111649188-e8060780-87e2-11eb-911b-5c60b5d26688.png)
Verifiquei que o campo existe na tabela
![Coluna existe na tabela cp_marca 2021-3-18 11-45](https://user-images.githubusercontent.com/78379805/111649710-65317c80-87e3-11eb-9d97-6d7c7c5f1be5.png)
O  trecho do código com erro. 
Apelido da cp_marca  esta em maiúsculo.
![codigo](https://user-images.githubusercontent.com/78379805/111650655-3ff13e00-87e4-11eb-948a-e53f329cf3c4.PNG)
Creio que seja esse o motivo do erro.
Após correção 
![Acesso apos correcao 2021-3-18 11-52](https://user-images.githubusercontent.com/78379805/111651188-c279fd80-87e4-11eb-95ad-678886aa8667.png)

