### PR TITLE
GOVSP1747* - Coluna indicando a posse do documento na mesa virtual 2

### DIFF
--- a/siga/src/main/webapp/css/style_siga.css
+++ b/siga/src/main/webapp/css/style_siga.css
@@ -163,8 +163,8 @@ p.gt-table-action-list a.link-tag {
 }
 .mesa-config {
     position: fixed;
-    right: -220px;
-    width: 250px;
+    right: -320px;
+    width: 350px;
     top: 180px;
     z-index: 100;	
 }
@@ -181,17 +181,17 @@ p.gt-table-action-list a.link-tag {
     position: absolute;
     right: 0;
     top: 0;	
-	width: 220px;
+	width: 320px;
 	background-color: #f1f2f2 ;
 	color: #333;
 }
 .show-config {
-    transition: 1s;
+    transition: 0.3s;
     right: 0;
 }
 .hide-config {
-    transition: 1s;
-    right: -220px;
+    transition: 0.3s;
+    right: -320px;
 }
 .badge-mesa {
 	font-size: 0.8em;

--- a/siga/src/main/webapp/javascript/mesa2.js
+++ b/siga/src/main/webapp/javascript/mesa2.js
@@ -41,7 +41,8 @@ var appMesa = new Vue({
 			trazerComposto: false,
 			trazerArquivados: false,
 			trazerCancelados: false,
-			ordemCrescenteData: false
+			ordemCrescenteData: false,
+			usuarioPosse: false
 		};
 	},
 	computed: {
@@ -113,6 +114,10 @@ var appMesa = new Vue({
 		ordemCrescenteData: function() {
 			setParmUser('ordemCrescenteData', this.ordemCrescenteData);
 			this.recarregarMesa();
+		},
+		usuarioPosse: function() {
+			setParmUser('usuarioPosse', this.usuarioPosse);
+			this.recarregarMesa();
 		}
 	},
 	methods: {
@@ -123,6 +128,7 @@ var appMesa = new Vue({
 			this.trazerArquivados = (getParmUser('trazerArquivados') == null ? false : getParmUser('trazerArquivados'));
 			this.trazerCancelados = (getParmUser('trazerCancelados') == null ? false : getParmUser('trazerCancelados'));
 			this.ordemCrescenteData = (getParmUser('ordemCrescenteData') == null ? false : getParmUser('ordemCrescenteData'));
+			this.usuarioPosse = (getParmUser('usuarioPosse') == null ? false : getParmUser('usuarioPosse'));
 			setValueGrupo('Aguardando Ação de Temporalidade', 'hide', !this.trazerArquivados);
 			
 
@@ -179,6 +185,7 @@ var appMesa = new Vue({
 					trazerArquivados: this.trazerArquivados,
 					trazerCancelados: this.trazerCancelados,
 					ordemCrescenteData: this.ordemCrescenteData,
+					usuarioPosse: this.usuarioPosse,
 					idVisualizacao: ID_VISUALIZACAO
 				},
 				complete: function(response, status, request) {
@@ -234,6 +241,7 @@ var appMesa = new Vue({
 			localStorage.removeItem('trazerArquivados' + getUser());
 			localStorage.removeItem('trazerCancelados' + getUser());
 			localStorage.removeItem('ordemCrescenteData' + getUser());
+			localStorage.removeItem('usuarioPosse' + getUser());
 			this.recarregarMesa();
 			this.selQtdPag = 15;
 			
@@ -548,6 +556,7 @@ function processDescription(descr, limit = null) {
 }
 
 function initPopovers() {
+	var timeOut;
 	if (!$('.popover-dismiss').popover) { 
 		return; 
 	} 
@@ -558,18 +567,18 @@ function initPopovers() {
 		trigger: 'manual'
 	}).on("mouseenter", function() {
 		var _this = this;
-		
-		if ($(_this).attr('data-pessoa') !== undefined) {
-			mountPopoverMarcaPessoa(_this);
-		} else if ($(_this).attr('data-lotacao') !== undefined) {
-			mountPopoverMarcaLotacao(_this);
-		}
-		
-		$(_this).popover("show");
-		$(".popover").on("mouseleave", function() {
-			$(_this).popover('hide');
-		});
-
+		timeOut = setTimeout( function() {
+			if ($(_this).attr('data-pessoa') !== undefined) {
+				mountPopoverMarcaPessoa(_this);
+			} else if ($(_this).attr('data-lotacao') !== undefined) {
+				mountPopoverMarcaLotacao(_this);
+			}
+			
+			$(_this).popover("show");
+			$(".popover").on("mouseleave", function() {
+				$(_this).popover('hide');
+			});
+		}, 700);
 	}).on("click", function() {
 		var _this = this;
 		/*** Implementar function***/
@@ -584,6 +593,7 @@ function initPopovers() {
 				$(_this).popover("hide");
 			}
 		}, 100);
+		clearTimeout(timeOut);
 	})
 	
 	

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMesa2Controller.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMesa2Controller.java
@@ -107,7 +107,8 @@ public class ExMesa2Controller extends ExController {
 
 	@Post("app/mesa2.json")
 	public void json(Long idVisualizacao, boolean exibeLotacao, boolean trazerAnotacoes, boolean trazerArquivados, 
-			boolean trazerComposto, boolean trazerCancelados, boolean ordemCrescenteData, String parms) throws Exception {
+			boolean trazerComposto, boolean trazerCancelados, boolean ordemCrescenteData, 
+			boolean usuarioPosse, String parms) throws Exception {
 		
 		List<br.gov.jfrj.siga.ex.bl.Mesa2.GrupoItem> g = new ArrayList<br.gov.jfrj.siga.ex.bl.Mesa2.GrupoItem>();
 		Map<String, Mesa2.SelGrupo> selGrupos = null;
@@ -150,13 +151,13 @@ public class ExMesa2Controller extends ExController {
 				gruposMesa = Mesa2.getContadores(dao(), vis.getTitular(), lotaTitular, selGrupos, 
 						exibeLotacao, marcasAIgnorar);
 				g = Mesa2.getMesa(dao(), vis.getTitular(), lotaTitular, selGrupos, 
-						gruposMesa, exibeLotacao, trazerAnotacoes, trazerComposto, ordemCrescenteData, marcasAIgnorar);
+						gruposMesa, exibeLotacao, trazerAnotacoes, trazerComposto, ordemCrescenteData, usuarioPosse, marcasAIgnorar);
 			} else {
 				lotaTitular = getTitular().getLotacao();
 				gruposMesa = Mesa2.getContadores(dao(), getTitular(), lotaTitular, selGrupos, 
 						exibeLotacao, marcasAIgnorar);
 				g = Mesa2.getMesa(dao(), getTitular(), lotaTitular, selGrupos, 
-						gruposMesa, exibeLotacao, trazerAnotacoes, trazerComposto, ordemCrescenteData, marcasAIgnorar);
+						gruposMesa, exibeLotacao, trazerAnotacoes, trazerComposto, ordemCrescenteData, usuarioPosse, marcasAIgnorar);
 			}
 	
 			String s = ExAssinadorExternoController.gson.toJson(g);

--- a/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
@@ -71,6 +71,14 @@
 						</label>
 					</div>            
 	            </div>
+	            <div class="form-group my-1 border-bottom">
+					<div class="form-check">
+						<input type="checkbox" class="form-check-input" id="usuarioPosse" v-model="usuarioPosse" :disabled="carregando">
+						<label class="form-check-label" for="usuarioPosse">
+							<small>Exibir usuário em posse do documento</small>
+						</label>
+					</div>            
+	            </div>
 				<div class="form-group pb-2 mb-1 border-bottom">
 					<label for="selQtdPagId"><small>Qtd. de documentos a trazer</small></label>
 					<select class="form-control form-control-sm p-0" v-model="selQtdPag" :class="{disabled: carregando}">
@@ -215,9 +223,14 @@
 									<thead v-if="!carregando">
 										<tr class="table-head d-flex">
 											<th scope="col" class="col-1 d-none d-md-block">Tempo</th>
-											<th scope="col" class="col-9 col-md-2"><fmt:message key = "usuario.mesavirtual.codigo"/></th>
-											<th scope="col" class="col-4 d-none d-md-block">Descrição</th>
-											<th scope="col" class="col-3 col-md-2">Origem</th>
+											<th scope="col" class="col-md-2"
+													v-bind:class="usuarioPosse ? 'col-8' : 'col-9'">
+												<fmt:message key="usuario.mesavirtual.codigo"/></th>
+											<th scope="col" class="d-none d-md-block"
+											 	v-bind:class="usuarioPosse ? 'col-3' : 'col-4'">Descrição</th>
+											<th scope="col" class="col-md-1"
+												v-bind:class="usuarioPosse ? 'col-2' : 'col-3'">Origem</th>
+											<th v-if="usuarioPosse" scope="col" class="col-md-1 col-2">Usuário em Posse</th>
 											<th scope="col" class="col-3 d-none d-md-block"><fmt:message key = "usuario.mesavirtual.etiquetas"/></th>
 	<!-- 											<th v-show="gruposTemAlgumErro">Atenção</th> -->
 										</tr>
@@ -227,7 +240,8 @@
 											<tr class="d-flex">
 												<td class="col-1 d-none d-md-block" 
 													:title="f.datahoraDDMMYYYHHMM">{{f.tempoRelativo}}</td>
-												<td class="col-9 col-md-2">
+												<td class="col-md-2"
+														v-bind:class="usuarioPosse ? 'col-8' : 'col-9'">
 													<c:if test="${siga_cliente == 'GOVSP'}">
 														<span v-if="trazerComposto">
 															<span v-if="f.tipoDoc == 'Avulso'"><i class="far fa-file text-secondary" title="Documento Avulso"></i></span>
@@ -244,25 +258,31 @@
 													</c:choose>
 													<span class="d-inline d-md-none"> - {{f.descr}}</span>
 												</td>
-												<td class="col-4 d-none d-md-block">
+												<td class="d-none d-md-block" v-bind:class="usuarioPosse ? 'col-3' : 'col-4'">
 													<span class="text-break" :title='processDescription(f.descr)' >{{ processDescription(f.descr, 60) }}</span>
 												</td>
-												<td class="col-3 col-md-2">
-													<c:if test="${siga_cliente == 'GOVSP'}">
-														<span v-if="f.dataDevolucao == 'ocultar'"></span>
-														<span v-if="f.dataDevolucao == 'alerta'"><i class="fa fa-exclamation-triangle text-warning"></i></span>
-														<span v-if="f.dataDevolucao == 'atrasado'"><i class="fa fa-exclamation-triangle text-danger"></i></span>
-													</c:if>
-													{{f.origem}}
+												<td class="col-md-1"
+														v-bind:class="usuarioPosse ? 'col-2' : 'col-3'">
+													<small>
+														<c:if test="${siga_cliente == 'GOVSP'}">
+															<span v-if="f.dataDevolucao == 'ocultar'"></span>
+															<span v-if="f.dataDevolucao == 'alerta'"><i class="fa fa-exclamation-triangle text-warning"></i></span>
+															<span v-if="f.dataDevolucao == 'atrasado'"><i class="fa fa-exclamation-triangle text-danger"></i></span>
+														</c:if>
+														{{f.origem}}
+													</small>
 												</td>
-												<td class="col-3 d-none d-md-block" style="padding: 0;">
+												<td v-if="usuarioPosse" class="col-md-1 col-2">
+													<small>{{f.lotaPosse}} / {{f.nomePessoaPosse}}</small>
+												</td>												
+												<td class="col-3 d-none d-md-block p-1">
 													<span v-if="f.anotacao != null">
-														<a tabindex="0" class="anotacao fas fa-sticky-note text-warning popover-dismiss ml-1" role="button" 
+														<a tabindex="0" class="anotacao fas fa-sticky-note text-warning popover-dismiss ml-2" role="button" 
 																data-toggle="popover" data-trigger="hover focus" :data-content="f.anotacao"></a>
 													</span>
 													<span class="xrp-label-container">
 														<span v-for="m in f.list">
-															<a class="popover-dismiss ml-1" role="button" 
+															<a class="popover-dismiss" role="button" 
 																data-toggle="popover" data-trigger="hover focus" :title="m.titulo" data-html="true" :data-pessoa="m.pessoa" :data-lotacao="m.lotacao">
 																<span class="text-size-8 badge badge-pill badge-secondary tagmesa m-1 btn-xs" v-bind:style="{color: '#' + m.cor + ' !important'}">												
 																	<i :class="m.icone" :style="{color: m.cor}"></i> {{m.nome}}<span v-if="m.ref1">, planejada: {{m.ref1}}</span><span v-if="m.ref2">, limite: {{m.ref2}}</span>


### PR DESCRIPTION
Criada uma nova configuração na mesa virtual (Exibir usuário em posse do documento):

![image](https://user-images.githubusercontent.com/49542320/111716093-16600300-8834-11eb-974d-9b11411e7cc3.png)

Se habilitada, mostra uma coluna contendo a unidade/usuário em posse do documento:

![image](https://user-images.githubusercontent.com/49542320/111716202-49a29200-8834-11eb-9295-04244a2393ab.png)

Incluindo também um delay para não ocorrer chamadas ao servidor ao passar o mouse sobre as marcas (só chama se manter o mouse por 0,7 segundo):

![image](https://user-images.githubusercontent.com/49542320/111716258-650d9d00-8834-11eb-8bc1-dd6fab90d307.png)

