### PR TITLE
GOVSP1864* - Possibilitar ao WS GET /mesa trazer documentos por lotacao ou pessoa

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1741,7 +1741,8 @@ public class ExDao extends CpDao {
 				+ " where (marca.dtIniMarca is null or marca.dtIniMarca < :dbDatetime)"
 				+ " and (marca.dtFimMarca is null or marca.dtFimMarca > :dbDatetime)"
 				+ " and (marca.dpPessoaIni.idPessoa = :titular or "
-				+ " (marca.dpPessoaIni.idPessoa = null and marca.dpLotacaoIni.idLotacao = :lotaTitular))";
+				+ (titular != null? " (marca.dpPessoaIni.idPessoa = null and ": "(")
+				+ " marca.dpLotacaoIni.idLotacao = :lotaTitular))";
 		if(Prop.isGovSP()) {
 			q += " and ((mobil.exDocumento.numExpediente is null and marcador = 1) or (mobil.exDocumento.numExpediente is not null))"
 					+ " and marcador <> 10";

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -265,6 +265,7 @@ public interface IExApiV1 {
 	}
 
 	public class MesaGetRequest implements ISwaggerRequest {
+		public String filtroPessoaLotacao;
 	}
 
 	public class MesaGetResponse implements ISwaggerResponse {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/MesaGet.java
@@ -48,9 +48,29 @@ public class MesaGet implements IMesaGet {
 	
 			ApiContext.buscarEValidarUsuarioLogado();
 			SigaObjects so = ApiContext.getSigaObjects();
-			DpPessoa cadastrante = so.getCadastrante();
 			
-			List<Object[]> l = ExDao.getInstance().listarDocumentosPorPessoaOuLotacao(cadastrante, cadastrante.getLotacao());
+			DpPessoa pes = null;
+			DpLotacao lota = null;
+			DpPessoa cadastrante = so.getCadastrante();
+			DpLotacao lotaCadastrante = cadastrante.getLotacao();
+			if (req.filtroPessoaLotacao != null) {
+				switch(req.filtroPessoaLotacao) {
+					case "Pessoa":
+						pes = cadastrante;
+						break;
+					case "Lotacao":
+						lota = lotaCadastrante;
+						break;
+					default:
+						pes = cadastrante;
+						lota = lotaCadastrante;
+				}
+			} else {
+				pes = cadastrante;
+				lota = lotaCadastrante;
+			}
+			
+			List<Object[]> l = ExDao.getInstance().listarDocumentosPorPessoaOuLotacao(pes, lota);
 
 			HashMap<ExMobil, List<MeM>> map = new HashMap<>();
 
@@ -67,7 +87,7 @@ public class MesaGet implements IMesaGet {
 				map.get(mobil).add(mm);
 			}
 
-			resp.list = listarReferencias(TipoDePainelEnum.UNIDADE, map, cadastrante, cadastrante.getLotacao(), 
+			resp.list = listarReferencias(TipoDePainelEnum.UNIDADE, map, cadastrante, lotaCadastrante, 
 					ExDao.getInstance().consultarDataEHoraDoServidor());
 		} catch (AplicacaoException | SwaggerException e) {
 			throw e;

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -327,7 +327,17 @@ parameters:
     description: Identificador da classificacao
     type: string
     required: false
-   
+  filtroPessoaLotacao:
+    name: filtroPessoaLotacao
+    in: query
+    description: Informa se deseja filtrar documentos por pessoa ou lotação
+    required: false
+    type: string
+    default: Pessoa e Lotacao
+    enum:
+      - Pessoa e Lotacao
+      - Pessoa
+      - Lotacao
 
 ################################################################################
 #                                           Paths                              #
@@ -530,7 +540,8 @@ paths:
       tags: [mesa]
       security:
         - Bearer: []      
-      parameters: []
+      parameters: 
+        - $ref: "#/parameters/filtroPessoaLotacao"
       responses:
         200:
           description: Successful response


### PR DESCRIPTION
O WS GET /mesa atualmente traz documenos da lotação + pessoa. 
Passa a permitir a escolha entre um dos dois, como na mesa 2, através do parâmetro opcional descrito no swagger:

![image](https://user-images.githubusercontent.com/49542320/112035448-5407a900-8b1e-11eb-968c-8d482f714dba.png)

Se não informado, traz por pessoa+lotação como fazia anteriormente, para manter compatibilidade com o SIGA-LE.