### PR TITLE
GOVSP1944* - Webservice de Consulta de Protocolo Gerado

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaConsultarProtocoloGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaConsultarProtocoloGet.java
@@ -1,0 +1,71 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import com.crivano.swaggerservlet.SwaggerException;
+import com.crivano.swaggerservlet.SwaggerServlet;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.base.Prop;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExProtocolo;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocumentosSiglaConsultarProtocoloGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.DocumentosSiglaConsultarProtocoloGetResponse;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IDocumentosSiglaConsultarProtocoloGet;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.bl.ExBL;
+import br.gov.jfrj.siga.vraptor.SigaObjects;
+import br.gov.jfrj.siga.base.util.Utils;
+
+public class DocumentosSiglaConsultarProtocoloGet implements IDocumentosSiglaConsultarProtocoloGet {
+
+	@Override
+	public void run(DocumentosSiglaConsultarProtocoloGetRequest req, DocumentosSiglaConsultarProtocoloGetResponse resp) throws Exception {
+		try (ApiContext ctx = new ApiContext(true, true)) {
+			ApiContext.assertAcesso("");
+			SigaObjects so = ApiContext.getSigaObjects();
+	
+			DpPessoa cadastrante = so.getCadastrante();
+			DpLotacao lotaCadastrante = cadastrante.getLotacao();
+			DpPessoa titular = cadastrante;
+			DpLotacao lotaTitular = cadastrante.getLotacao();
+	
+			ExMobil mob = SwaggerHelper.buscarEValidarMobil(req.sigla, so, req, resp, "Documento a consultar protocolo");
+	
+			ApiContext.assertAcesso(mob, titular, lotaTitular);
+
+			final Ex ex = Ex.getInstance();
+			final ExBL exBL = ex.getBL();
+			
+			ExProtocolo prot = new ExProtocolo();
+			prot = exBL.obterProtocolo(mob.getDoc());
+			
+			if(prot == null) {
+				throw new AplicacaoException("Protocolo ainda não foi gerado para este documento.");
+			}
+			DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+			Calendar c = Calendar.getInstance();
+			c.setTime(prot.getData());
+			String servidor = Prop.get("/sigaex.url");
+			String caminho = Utils.getBaseUrl(SwaggerServlet.getHttpServletRequest()) 
+					+ "/public/app/processoautenticar?n=" + prot.getCodigo();
+			resp.numeroProtocolo = prot.getCodigo();
+			resp.linkProtocolo = caminho;
+			resp.dataHoraEmissaoProtocolo = df.format(c.getTime());
+		} catch (AplicacaoException | SwaggerException e) {
+			throw e;
+		} catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw e;
+		}
+	}
+	
+	@Override
+	public String getContext() {
+		return "Consultar protocolo do documento";
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -493,6 +493,20 @@ public interface IExApiV1 {
 		public void run(DocumentosSiglaGerarProtocoloPostRequest req, DocumentosSiglaGerarProtocoloPostResponse resp) throws Exception;
 	}
 
+	public class DocumentosSiglaConsultarProtocoloGetRequest implements ISwaggerRequest {
+		public String sigla;
+	}
+
+	public class DocumentosSiglaConsultarProtocoloGetResponse implements ISwaggerResponse {
+		public String numeroProtocolo;
+		public String linkProtocolo;
+		public String dataHoraEmissaoProtocolo;
+	}
+
+	public interface IDocumentosSiglaConsultarProtocoloGet extends ISwaggerMethod {
+		public void run(DocumentosSiglaConsultarProtocoloGetRequest req, DocumentosSiglaConsultarProtocoloGetResponse resp) throws Exception;
+	}
+
 	public class SugestaoPostRequest implements ISwaggerRequest {
 		public String nome;
 		public String email;

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -928,6 +928,40 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /documentos/{sigla}/consultar-protocolo:
+    get:
+      consumes: ["application/x-www-form-urlencoded"]
+      tags: [consulta]
+      security:
+        - Bearer: []      
+      parameters:
+        - $ref: "#/parameters/sigla"
+      description: Obtem o número de protocolo e link para acompanhamento de um expediente ou processo
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              numeroProtocolo:
+                type: string
+              linkProtocolo:
+                type: string
+              dataHoraEmissaoProtocolo:
+                type: string
+        403:
+          description: Acesso ao documento não permitido
+          schema:
+            $ref: "#/definitions/Error"
+        404:
+          description: Protocolo ainda não foi gerado para este documento
+          schema:
+            $ref: "#/definitions/Error"        
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
   /sugestao:
     post:
       consumes: ["application/x-www-form-urlencoded"]


### PR DESCRIPTION
Criado o Web Service com o seguinte endpoint:

/sigaex/api/v1/documentos/{sigla}/consultar-protocolo

Documentação disponível no swagger:

/sigaex/api/v1/swagger-ui

Caso o protocolo ainda não tenha sido gerado, devolver erro 404 - "Protocolo ainda não foi gerado para este documento"