### PR TITLE
GOVSP1945* - Pesquisa de lotações por órgão

### DIFF
--- a/siga/src/main/java/br/gov/jfrj/siga/api/v1/ISigaApiV1.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/api/v1/ISigaApiV1.java
@@ -213,6 +213,7 @@ public interface ISigaApiV1 {
 	}
 
 	public class LotacoesGetRequest implements ISwaggerRequest {
+		public String siglaOrgaoQuery;
 		public String texto;
 		public String idLotacaoIni;
 	}

--- a/siga/src/main/java/br/gov/jfrj/siga/api/v1/LotacoesGet.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/api/v1/LotacoesGet.java
@@ -16,16 +16,22 @@ import br.gov.jfrj.siga.base.Texto;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.dao.CpDao;
+import br.gov.jfrj.siga.dp.dao.CpOrgaoUsuarioDaoFiltro;
 import br.gov.jfrj.siga.dp.dao.DpLotacaoDaoFiltro;
 
 public class LotacoesGet implements ILotacoesGet {
 	@Override
 	public void run(LotacoesGetRequest req, LotacoesGetResponse resp) throws Exception {
 		try (ApiContext ctx = new ApiContext(false, true)) {
-			if (req.texto != null && req.idLotacaoIni != null) {
+			if ((((req.texto != null? 1:0) + (req.idLotacaoIni != null? 1:0) + (req.siglaOrgaoQuery != null? 1:0)) > 1)) {
 				throw new AplicacaoException("Pesquisa permitida somente por um dos argumentos.");
 			}
 	
+			if (req.siglaOrgaoQuery != null && !req.siglaOrgaoQuery.isEmpty()) {
+				resp.list = pesquisarPorOrgao(req, resp);
+				return;
+			}
+				
 			if (req.texto != null && !req.texto.isEmpty()) {
 				resp.list = pesquisarPorTexto(req, resp);
 				return;
@@ -43,6 +49,22 @@ public class LotacoesGet implements ILotacoesGet {
 			e.printStackTrace(System.out);
 			throw e;
 		}
+	}
+
+	private List<Lotacao> pesquisarPorOrgao(LotacoesGetRequest req, LotacoesGetResponse resp) {
+		final DpLotacaoDaoFiltro flt = new DpLotacaoDaoFiltro();
+		final CpOrgaoUsuarioDaoFiltro fltOrg = new CpOrgaoUsuarioDaoFiltro();
+		fltOrg.setSigla(req.siglaOrgaoQuery);
+		CpOrgaoUsuario org = (CpOrgaoUsuario) CpDao.getInstance()
+				.consultarPorSigla(fltOrg);
+		if (org != null)
+			flt.setIdOrgaoUsu(Long.valueOf(org.getId()));
+		else
+			throw new AplicacaoException("Órgão não encontrado.");
+		
+		List<DpLotacao> l; 
+		l = CpDao.getInstance().consultarLotacaoPorOrgao(org);
+		return l.stream().map(this::lotacaoToResultadoPesquisa).collect(Collectors.toList());
 	}
 
 	private List<Lotacao> pesquisarPorTexto(LotacoesGetRequest req, LotacoesGetResponse resp) {

--- a/siga/src/main/resources/br/gov/jfrj/siga/api/v1/swagger.yaml
+++ b/siga/src/main/resources/br/gov/jfrj/siga/api/v1/swagger.yaml
@@ -3,8 +3,28 @@ swagger: '2.0'
 info:
   version: "1.0.0"
   title: SigaApiV1
-  description: API para o Siga-Doc
-
+  description: "Esta API pertence ao módulo principal do SIGA. Cada
+    módulo possui um conjunto de APIs. Por exemplo o módulo de documentos
+    (sigaex) possui também um link do swagger contendo a documentação para
+    o conjunto de funções para manipular documentos do SIGA. Basta alterar
+    o link desta página substituindo a palavra <i>siga</i> por <i>sigaex</i>.
+    
+    <p>Todas as funções necessitam de um token, que deve ser gerado 
+    fazendo o seguinte procedimento:
+    <ul><li>Passar no header a chave: <i>'Authorization: Basic
+    xxxxxxxxx'</i> onde <i>xxxxxxxxx</i> é a informação 'usuario:password' 
+    <b>codificado em base64</b>;</li>
+    <li>O Webservice POST /autenticar irá retornar um json contendo o token de 
+    acesso JWT;</li>
+    <li>Este token deverá ser passado no header para cada request 
+    realizado, na chave Authorization.</li></ul>
+    <p>Se desejar, esta página permite fazer testes unitários via swagger: 
+    <ul><li>Clique no botão <i>Authorize</i> e insira o usuário/senha 
+    no <i>Basic Authentication</i>.</li>
+    <li>Execute o POST /autenticar e copie o token do json de
+    resultado.</li>
+    <li>Clique novamente no authorize e cole no campo do <i>Bearer</i> o token.
+    </li></ul>"
 basePath: /siga/api/v1
 schemes: [http,https]
 consumes: [application/json,application/x-www-form-urlencoded]
@@ -258,6 +278,12 @@ parameters:
     description: Lotação é de acesso externo? (true/false)
     required: false
     type: boolean
+  siglaOrgaoQuery:
+    name: siglaOrgaoQuery
+    in: query
+    description: Sigla do órgão
+    required: false
+    type: string
     
 
 ################################################################################
@@ -490,14 +516,17 @@ paths:
   /lotacoes:
     get:
       summary: "Pesquisa de lotações"
-      description: "Retorna uma lista de lotações. A pesquisa será feita de acordo com os parâmetros informados:
+      description: "Retorna uma lista de lotações. A pesquisa será feita de acordo com os parâmetros informados 
+        (informar somente um):
         <ul>
+        <li><b>siglaOrgaoQuery=</b>Pesquisa as lotações do órgão especificado.</li>
         <li><b>idLotacaoIni=</b>Pesquisa a Lotação Atual da Lotação Inicial solicitada.</li>
         <li><b>texto=</b>Pesquisa as lotacoes cuja sigla ou nome contém uma determinada palavra.</li></ul>"
       tags: [cadastro]
       security:
         - Bearer: []
       parameters:
+        - $ref: "#/parameters/siglaOrgaoQuery"
         - $ref: "#/parameters/texto"
         - $ref: "#/parameters/idLotacaoIni"
       responses:


### PR DESCRIPTION
Alterado o webservice GET /lotacoes, incluindo um parâmetro opcional (sigla do órgão).
Se passado o parâmetro, são devolvidas todas as lotações existentes para o órgão.

Documentação disponível no swagger:

/siga/api/v1/swagger-ui