### PR TITLE
GOVSP1958* - Corrigir Vunerabilidade de Segurança no Cadastro de pessoa / Unidade.

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1210,9 +1210,30 @@ public class CpBL {
 
 		ou.setIdOrgaoUsu(idOrgaoUsu);
 		ou = CpDao.getInstance().consultarPorId(ou);
-		cargo.setId(idCargo);
-		lotacao.setId(idLotacao);
-		funcao.setIdFuncao(idFuncao);
+		
+		if (!"ZZ".equals(identidadeCadastrante.getCpOrgaoUsuario().getSigla())){
+			if (!ou.getIdOrgaoUsu().equals(identidadeCadastrante.getCpOrgaoUsuario().getIdOrgaoUsu())) {
+				throw new AplicacaoException("Usuário não pode cadastrar nesse órgão.");
+			}
+		}
+				
+		cargo = CpDao.getInstance().consultar(idCargo, DpCargo.class, false);
+		if (!ou.getIdOrgaoUsu().equals(cargo.getOrgaoUsuario().getIdOrgaoUsu())) {
+			throw new AplicacaoException("Cargo informado não pertence ao órgão informado.");
+		}
+		
+		lotacao = CpDao.getInstance().consultar(idLotacao, DpLotacao.class, false);
+		if (!ou.getIdOrgaoUsu().equals(lotacao.getOrgaoUsuario().getIdOrgaoUsu())) {
+			throw new AplicacaoException("Lotação informada não pertence ao órgão informado.");
+		}
+		
+		if (idFuncao != null && idFuncao != 0) {
+			funcao  = CpDao.getInstance().consultar(idFuncao, DpFuncaoConfianca.class, false);
+			
+			if (!ou.getIdOrgaoUsu().equals(funcao.getOrgaoUsuario().getIdOrgaoUsu())) {
+				throw new AplicacaoException("Função de Confiança informada não pertence ao órgão informado.");
+			}
+		}
 
 		pessoa.setOrgaoUsuario(ou);
 		pessoa.setCargo(cargo);
@@ -1223,6 +1244,8 @@ public class CpBL {
 			pessoa.setFuncaoConfianca(null);
 		}
 		pessoa.setSesbPessoa(ou.getSigla());
+		
+
 
 		// ÓRGÃO / CARGO / FUNÇÃO DE CONFIANÇA / LOTAÇÃO e CPF iguais.
 		DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();


### PR DESCRIPTION
Verificações e consistência de objetos no cadastro de pessoa estava apenas no front-end, permitindo que o usuário com acesso ao cadastro de pessoa pudesse manipular os IDs dos objetos na DOM e provocando a persistência incorreta, podendo o usuário obter acessos indevidos ao órgão, lotações, documentos...

Adicionada verificação se o órgão é permitido ao usuário cadastrante, Se o cargo, lotação e função pertence ao órgão usuário.


Ex.: da Consistência

![image](https://user-images.githubusercontent.com/20362170/114196757-0b2a5f80-9928-11eb-98ff-9742d404579f.png)

![image](https://user-images.githubusercontent.com/20362170/114196626-ecc46400-9927-11eb-825d-a91e1d209bed.png)

![image](https://user-images.githubusercontent.com/20362170/114196056-63ad2d00-9927-11eb-9e12-d8446e373d4e.png)

Até então, sem a verificação na BL DP_PESSOA seria persistido com ID de um órgão e Lotacao de outro órgao, liberando a mesa virtual da lotacao e seus documentos:

![image](https://user-images.githubusercontent.com/20362170/114197748-06b27680-9929-11eb-9b92-7486c447f8cb.png)
![image](https://user-images.githubusercontent.com/20362170/114197890-2f3a7080-9929-11eb-8a23-59bf7eb858d8.png)
![image](https://user-images.githubusercontent.com/20362170/114198143-5f820f00-9929-11eb-9f06-933ac5e98e4f.png)

