### PR TITLE
GOVSP1898* - INC000004231845 - Erro ao tentar assinar Termo de desentranhamento

### DIFF
--- a/siga/src/main/webapp/javascript/siga.js
+++ b/siga/src/main/webapp/javascript/siga.js
@@ -73,9 +73,9 @@ function popitup(url) {
 	winProp = 'width=' + popW + ',height=' + popH + ',left=' + winleft
 	+ ',top=' + winUp + ',scrollbars=yes,resizable';
 	
-	if(url.includes("/exibir?")) {
-		url = montarUrlDocPDF (url, document.getElementById("visualizador").value);
-	}
+//	if(url.includes("/exibir?")) {
+//		url = montarUrlDocPDF (url, document.getElementById("visualizador").value);
+//	}
 	newwindow = window.open(url, nameWindow, winProp);
 
 	if (window.focus) {


### PR DESCRIPTION
De: Douglas Souza Barbosa 
Enviado: terça-feira, 20 de abril de 2021 17:09

1898* - INC000004231845 - Erro ao tentar assinar Termo de desentranhamento.

- O erro ocorre ao tentar Ver/Assinar um documento que foi desentranhado, ao clicar no link recebo mensagem de erro no PDF de arquivo corrompido ou inválido.
- Ao verificar o código percebi que na classe siga.js há um método que faz uma verificação somente para montar a url do documento em formato PDF, se tiver o contexto "/exibir?", a url será modificada por uma nova url passando o pdf.js como visualizador, sem essa verificação o arquivo abre da mesma forma que estava antes da alteração feita no dia 15/03.

![image](https://user-images.githubusercontent.com/20362170/115710552-dc10e680-a348-11eb-9ae1-3aea2273776c.png)


Erro exibido ao clicar em Ver/Assinar

ao comentar o trecho onde é feita a verificação na classe Siga.js método popitup :

if(url.includes("/exibir?")) {
  url = montarUrlDocPDF (url, document.getElementById("visualizador").value);
}

![image](https://user-images.githubusercontent.com/20362170/115710490-cac7da00-a348-11eb-9e58-5e129d542135.png)


clicando em Ver/Assinar após comentar as  linhas no código 