### PR TITLE
GOVSP1752* - INC000004049085 - Inserção de Função e Unidade do cossignatário para documento capturado no rodapé.

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -18,6 +18,8 @@
  ******************************************************************************/
 package br.gov.jfrj.itextpdf;
 
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO;
 import static br.gov.jfrj.siga.ex.util.ProcessadorHtml.novoHtmlPersonalizado;
 
 import java.awt.Color;
@@ -212,7 +214,9 @@ public class Documento {
 
 				/*** Exibe para Documentos Capturados a Funcao / Unidade ***/
 				if (movAssinatura.getExDocumento().isInternoCapturado()) { /* Interno Exibe Personalização se realizada */
-					s.append(Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(movAssinatura));
+					if (movAssinatura.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA) || movAssinatura.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO)) {
+						s.append(Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(movAssinatura));
+					}
 				} else if(movAssinatura.getExDocumento().isExternoCapturado()) { 
 					s.append(" - ");
 					s.append(movAssinatura.getCadastrante().getFuncaoString());

--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -201,23 +201,33 @@ public class Documento {
 			Set<ExMovimentacao> movsAssinatura, Date dtDoc) {
 		ArrayList<String> assinantes = new ArrayList<String>();
 		for (ExMovimentacao movAssinatura : movsAssinatura) {
-			String s;
+			StringBuilder s = new StringBuilder();
 			Date dataDeInicioDeObrigacaoExibirRodapeDeAssinatura=null;
 			if (movAssinatura.getExTipoMovimentacao().getId().equals(ExTipoMovimentacao.TIPO_MOVIMENTACAO_SOLICITACAO_DE_ASSINATURA)) {
-				s = Texto.maiusculasEMinusculas(movAssinatura.getCadastrante().getNomePessoa());
+				s.append(Texto.maiusculasEMinusculas(movAssinatura.getCadastrante().getNomePessoa()));
 			} else {
 				dataDeInicioDeObrigacaoExibirRodapeDeAssinatura = Prop.getData("rodape.data.assinatura.ativa");
-				s = movAssinatura.getDescrMov().trim().toUpperCase();
-				s = s.split(":")[0];
-				s = s.intern();
-				if(Prop.isGovSP()
-						|| (dataDeInicioDeObrigacaoExibirRodapeDeAssinatura != null && !dataDeInicioDeObrigacaoExibirRodapeDeAssinatura.after(dtDoc)
-								)	) {
-						s +=" - " + Data.formatDDMMYYYY_AS_HHMMSS(movAssinatura.getData());
-					}				 
+				s.append(movAssinatura.getDescrMov().trim().toUpperCase().split(":")[0]);
+				
+
+				/*** Exibe para Documentos Capturados a Funcao / Unidade ***/
+				if (movAssinatura.getExDocumento().isInternoCapturado()) { /* Interno Exibe Personalização se realizada */
+					s.append(Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(movAssinatura));
+				} else if(movAssinatura.getExDocumento().isExternoCapturado()) { 
+					s.append(" - ");
+					s.append(movAssinatura.getCadastrante().getFuncaoString());
+					s.append(" / ");
+					s.append(movAssinatura.getCadastrante().getLotacao().getSigla());
+				}
+				/**** ****/
+				
+				if(Prop.isGovSP() || (dataDeInicioDeObrigacaoExibirRodapeDeAssinatura != null && !dataDeInicioDeObrigacaoExibirRodapeDeAssinatura.after(dtDoc))) {
+					s.append(" - ");
+					s.append(Data.formatDDMMYYYY_AS_HHMMSS(movAssinatura.getData()));
+				}				 
 			}
-			if (!assinantes.contains(s)) {
-				assinantes.add(s);
+			if (!assinantes.contains(s.toString())) {
+				assinantes.add(s.toString());
 			}
 		}
 		return assinantes;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -19,6 +19,7 @@
 package br.gov.jfrj.siga.ex.bl;
 
 import static br.gov.jfrj.siga.ex.ExMobil.isMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -43,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -1696,7 +1698,7 @@ public class ExBL extends CpBL {
 		boolean fSubstituindoCosignatario = false;
 		final String formaAssinaturaSenha = senhaIsPIN ? "PIN" : "Senha";
 		final String concordanciaAssinaturaSenha = senhaIsPIN ? "o" : "a";
-
+		
 		if (matriculaSubscritor == null || matriculaSubscritor.isEmpty())
 			throw new AplicacaoException("Matrícula do Subscritor não foi informada.");
 
@@ -7666,6 +7668,70 @@ public class ExBL extends CpBL {
 			cancelarAlteracao();
 			throw new AplicacaoException("Erro ao permitir a disponibilização do documento no acompanhamento do protocolo.", 0, e);
 		}
+	}
+	
+	public String extraiPersonalizacaoAssinatura(final ExMovimentacao movimentacao) {
+		/*
+		 *getNmFuncaoSubscritor = [0] - personalizarFuncao [1] - personalizarUnidade [2] - personalizarLocalidade [3] - personalizarNome
+		 */
+		
+		if (!movimentacao.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA)) {
+			return null;
+		}
+		
+		
+		SortedSet<ExMovimentacao> listaMovimentacoes = movimentacao.mob().getExMovimentacaoSet();
+		ExMovimentacao movimentacaoOrigem = null; 
+		String[] personalizacaoAssinatura = new String[4];	
+		
+		if (movimentacao.getExDocumento().getSubscritor().equivale(movimentacao.getSubscritor())) {
+			if (movimentacao.getExDocumento().getNmFuncaoSubscritor() != null ) {
+				personalizacaoAssinatura = movimentacao.getExDocumento().getNmFuncaoSubscritor().split(";");
+			} else {
+				return "";
+			}
+			
+		} else {
+		
+			for (ExMovimentacao mov : listaMovimentacoes) {
+				if (!mov.equals(mov)) {
+					if (mov.getIdTpMov() == ExTipoMovimentacao.TIPO_MOVIMENTACAO_INCLUSAO_DE_COSIGNATARIO) {
+						if (mov.getExMovimentacaoCanceladora() == null) {
+							if (mov.getSubscritor().equivale(movimentacao.getSubscritor())) {
+								movimentacaoOrigem = mov;
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (movimentacaoOrigem.getNmFuncaoSubscritor() != null ) {
+				personalizacaoAssinatura = movimentacaoOrigem.getNmFuncaoSubscritor().split(";");
+			} else {
+				return "";
+			}
+			
+		}
+		
+
+		StringBuilder funcaoCargoPersonalizadoAssinatura = new StringBuilder();
+		
+		funcaoCargoPersonalizadoAssinatura.append(" - ");
+		if (!"".equals(personalizacaoAssinatura[0])) {
+			funcaoCargoPersonalizadoAssinatura.append(personalizacaoAssinatura[0]);
+		} else {
+			funcaoCargoPersonalizadoAssinatura.append(movimentacao.getCadastrante().getFuncaoString());
+		}
+		funcaoCargoPersonalizadoAssinatura.append(" / ");
+		if (personalizacaoAssinatura.length > 1) {
+			if (!"".equals(personalizacaoAssinatura[1])) {
+			 funcaoCargoPersonalizadoAssinatura.append(personalizacaoAssinatura[1]);
+			}
+		} else {
+			funcaoCargoPersonalizadoAssinatura.append(movimentacao.getCadastrante().getLotacao().getSigla());
+		}
+		return funcaoCargoPersonalizadoAssinatura.toString();
+
 	}
 
 	

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -20,6 +20,7 @@ package br.gov.jfrj.siga.ex.bl;
 
 import static br.gov.jfrj.siga.ex.ExMobil.isMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso;
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -7675,10 +7676,9 @@ public class ExBL extends CpBL {
 		 *getNmFuncaoSubscritor = [0] - personalizarFuncao [1] - personalizarUnidade [2] - personalizarLocalidade [3] - personalizarNome
 		 */
 		
-		if (!movimentacao.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA)) {
-			return null;
+		if (!movimentacao.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA) && !movimentacao.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO) ) {
+			throw new RuntimeException("Não é possível extrair personalização de movimentações que não são de assinatura.");
 		}
-		
 		
 		SortedSet<ExMovimentacao> listaMovimentacoes = movimentacao.mob().getExMovimentacaoSet();
 		ExMovimentacao movimentacaoOrigem = null; 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -138,7 +138,7 @@ public class ExMovimentacaoVO extends ExVO {
 
 		descricao = mov.getObs();
 
-		if (mov.getNmFuncaoSubscritor() != null && mov.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA)) {
+		if (mov.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA) || mov.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO)) {
 			descricao += Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(mov);
 		}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -56,6 +56,7 @@ import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_REORDENAC
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA;
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA_EXTERNA;
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_VINCULACAO_PAPEL;
+import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA;
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.hasDespacho;
 
 import java.util.HashMap;
@@ -73,6 +74,7 @@ import br.gov.jfrj.siga.base.Data;
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.util.Texto;
+import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
@@ -135,6 +137,10 @@ public class ExMovimentacaoVO extends ExVO {
 			parte.put("resp", new ExParteVO(mov.getResp()));
 
 		descricao = mov.getObs();
+
+		if (mov.getNmFuncaoSubscritor() != null && mov.getIdTpMov().equals(TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA)) {
+			descricao += Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(mov);
+		}
 
 		addAcoes(mov, cadastrante, titular, lotaTitular);
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
@@ -111,7 +111,6 @@
 						<c:forEach var="mov" items="${m.movs}">
 								<tr class="${mov.classe} ${mov.disabled}">
 									<c:set var="dt" value="${mov.dtRegMovDDMMYYHHMMSS}" />
-									<c:set var="dt" value="${mov.dtRegMovDDMMYY}" />
 									<c:choose>
 										<c:when test="${dt == dtUlt}">
 											<c:set var="dt" value="" />
@@ -136,7 +135,7 @@
  											descricao="${mov.parte.cadastrante.descricao} - ${mov.parte.cadastrante.sigla}" 
  											pessoaParam="${mov.parte.cadastrante.sigla}" /> 
 									</td>
-									<td>
+									<td> 
 										${mov.descricao}
 										<c:if test='${mov.idTpMov != 2}'>
 											${mov.complemento}


### PR DESCRIPTION
### Contextualização da Solicitação
1.1. O objetivo deste requisito é a melhoria na funcionalidade na assinatura do cossignatário para
documentos capturados/digitalizados, para que possamos “Visualizar” as informações
preenchidas (“Função” e “Unidade”) quando assinada no rodapé dos documentos
capturados, independentemente se optamos pela opção “Personalizar”.

2. Justificativa:
2.1. No chamado ITSM a usuária indica inconsistência nas informações apresentadas no rodapé
dos documentos capturados internos, pois não é apresentada a função do cossignatário
quando esta é personalizada. Usuária entende que tal informação deva constar no
documento.

### Estratificação do Requisito

4.1. Documento Interno Produzido
 Não tem tarefa a ser feita

4.2. Documento Capturado
4.2.1.2. Incluir cargo e unidade oriundos do cadastro de usuários no rodapé de Autenticação

4.3. Documento Capturado Interno

4.3.1.2. Para o usuário responsável pela assinatura e o(s) cossignatário(s),incluir cargo e unidade e quando houver personalização, substituir no documento as informações do cadastro de usuário
pelas informações incluídas nos campos “Função” e “Unidade” do “Personalizar”.

4.3.1.3. Incluir cargo e unidade oriundos do cadastro de usuários no rodapé de Autenticação

Formato Rodapé conforme Protótipo

>  NOME - CARGO ou FUNÇÃO PERSONALIZADA / UNIDADE ou UNIDADE PERSONALIZADA - DATA

4.5. Histórico do documento.
4.5.1.1. Registrar no histórico a os campos “Função” e “Unidade” quando houver personalização da assinatura do responsável pela assinatura e/ou do cossignatário.
4.5.1.2. Atualmente só é exibido a informação de ”Data”, necessário a inserção da hora.

 5.2. É preciso apresentar no histórico do documento a personalização da assinatura do responsável pela assinatura e/ou cossignatário, seja em documento interno produzido, seja
em documento capturado interno.

### Testes

DCI: Sem Personalização
![image](https://user-images.githubusercontent.com/20362170/114443996-c0694b80-9ba4-11eb-826a-440ffb8aa796.png)

DCI: Com Personalização
![image](https://user-images.githubusercontent.com/20362170/115722124-11bbcc80-a355-11eb-9316-d39068f7c823.png)
![image](https://user-images.githubusercontent.com/20362170/115722207-25673300-a355-11eb-80af-ec224114b527.png)

Quando for Externo Capturado só exibe o Cargo/Unidade e sem personalização
![image](https://user-images.githubusercontent.com/20362170/114444144-e8f14580-9ba4-11eb-93a8-cdb1460948f1.png)
![image](https://user-images.githubusercontent.com/20362170/114444170-ee4e9000-9ba4-11eb-9475-556f86bcd4ec.png)

Documentos Interno Produzido: Só constar no histórico da movimentação sem exibição no rodapé:
![image](https://user-images.githubusercontent.com/20362170/115722454-65c6b100-a355-11eb-8a9d-ed0251ec7b0d.png)
![image](https://user-images.githubusercontent.com/20362170/115722508-724b0980-a355-11eb-8cbc-dfeb0359addd.png)


**OBSERVAÇÃO**

- NÃO há configuração/propriedade. Comportamento será default. Caso não seja o entendimento de todos os órgãos, solicitar a personalização via properties para ativar e desativar a persistência e exibição no histórico e rodapé conforme requisito.
