### PR TITLE
GOVSP1865* - Gravar nível de acesso no webservice de inclusão de documentos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -7668,6 +7668,56 @@ public class ExBL extends CpBL {
 		}
 	}
 
+	public List<ExNivelAcesso> getListaNivelAcesso(ExTipoDocumento exTpDoc, ExFormaDocumento forma, ExModelo exMod, 
+			ExClassificacao classif, DpPessoa titular, DpLotacao lotaTitular) {
+		List<ExNivelAcesso> listaNiveis = ExDao.getInstance().listarOrdemNivel();
+		ArrayList<ExNivelAcesso> niveisFinal = new ArrayList<ExNivelAcesso>();
+		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
+
+		ExConfiguracao config = new ExConfiguracao();
+		CpTipoConfiguracao exTpConfig = new CpTipoConfiguracao();
+		config.setDpPessoa(titular);
+		config.setLotacao(lotaTitular);
+		config.setExTipoDocumento(exTpDoc);
+		config.setExFormaDocumento(forma);
+		config.setExModelo(exMod);
+		config.setExClassificacao(classif);
+
+		ExConfiguracao exConfiguracaoMin;
+		exTpConfig.setIdTpConfiguracao(CpTipoConfiguracao.TIPO_CONFIG_NIVEL_ACESSO_MINIMO);
+		config.setCpTipoConfiguracao(exTpConfig);
+		try {
+			exConfiguracaoMin = (ExConfiguracao) Ex.getInstance().getConf().buscaConfiguracao(config, new int[] { ExConfiguracaoBL.NIVEL_ACESSO }, dt);
+		} catch (Exception e) {
+			exConfiguracaoMin = null;
+		}
+
+		ExConfiguracao exConfiguracaoMax;
+		exTpConfig.setIdTpConfiguracao(CpTipoConfiguracao.TIPO_CONFIG_NIVEL_ACESSO_MAXIMO);
+		config.setCpTipoConfiguracao(exTpConfig);
+		try {
+			exConfiguracaoMax = (ExConfiguracao) Ex.getInstance().getConf().buscaConfiguracao(config, new int[] { ExConfiguracaoBL.NIVEL_ACESSO }, dt);
+		} catch (Exception e) {
+			exConfiguracaoMax = null;
+		}
+
+		if (exConfiguracaoMin != null && exConfiguracaoMax != null && exConfiguracaoMin.getExNivelAcesso() != null
+				&& exConfiguracaoMax.getExNivelAcesso() != null) {
+			int nivelMinimo = exConfiguracaoMin.getExNivelAcesso().getGrauNivelAcesso();
+			int nivelMaximo = exConfiguracaoMax.getExNivelAcesso().getGrauNivelAcesso();
+
+			for (ExNivelAcesso nivelAcesso : listaNiveis) {
+				if (nivelAcesso.getGrauNivelAcesso() >= nivelMinimo && nivelAcesso.getGrauNivelAcesso() <= nivelMaximo) {
+					niveisFinal.add(nivelAcesso);
+				}
+			}
+		} else {
+			niveisFinal.addAll(listaNiveis);
+ 		}
+
+		return niveisFinal;
+	}
+	
 	
 }
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosPost.java
@@ -6,8 +6,12 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+
+import javax.persistence.NoResultException;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -230,28 +234,42 @@ public class DocumentosPost implements IDocumentosPost {
 				}
 				
 				if (req.nivelacesso != null) {
-					doc.setExNivelAcesso(dao()
-							.consultarExNidelAcesso(req.nivelacesso));
+					ExNivelAcesso nivel;
+					try {
+						nivel = dao().consultarExNidelAcesso(req.nivelacesso);
+					} catch (NoResultException e) {
+	    				throw new AplicacaoException("Nível de acesso não encontrado.");
+					}
+					if (!isNivelAcessoValido(so.getTitular(), so.getTitular().getLotacao(), doc, nivel))
+	    				throw new AplicacaoException("Nível de acesso não permitido.");
+					doc.setExNivelAcesso(nivel);
 				} else {
-					final ExNivelAcesso nivelDefault =  ExNivelAcesso
-							.getNivelAcessoDefault(doc.getExTipoDocumento(), doc.getExFormaDocumento(),
-									doc.getExModelo(), doc.getExClassificacao(), 
-									so.getTitular(), so.getLotaTitular());
-					
-					if (nivelDefault != null) {
-						doc.setExNivelAcesso(dao().consultar(nivelDefault, 
-								ExNivelAcesso.class, false));
+					if (doc.getExModelo() != null
+							&& doc.getExModelo().getExNivelAcesso() != null) {
+						doc.setExNivelAcesso(doc.getExModelo().getExNivelAcesso());
 					} else {
-						doc.setExNivelAcesso(dao().consultar(ExNivelAcesso.ID_PUBLICO, 
-								ExNivelAcesso.class, false));
+					
+						final ExNivelAcesso nivelDefault =  ExNivelAcesso
+								.getNivelAcessoDefault(doc.getExTipoDocumento(), doc.getExFormaDocumento(),
+										doc.getExModelo(), doc.getExClassificacao(), 
+										so.getTitular(), so.getLotaTitular());
+						
+						if (nivelDefault != null) {
+							doc.setExNivelAcesso(dao().consultar(nivelDefault, 
+									ExNivelAcesso.class, false));
+						} else {
+							if ( Boolean.valueOf(System.getProperty("siga.doc.acesso.limitado"))) {
+								doc.setExNivelAcesso(dao().consultar(ExNivelAcesso.ID_LIMITADO_AO_ORGAO, 
+										ExNivelAcesso.class, false));
+							} else {
+								doc.setExNivelAcesso(dao().consultar(ExNivelAcesso.ID_PUBLICO, 
+										ExNivelAcesso.class, false));
+							}
+							
+						}
 					}
 				}
 	
-				if (doc.getExModelo() != null
-						&& doc.getExModelo().getExNivelAcesso() != null) {
-					doc.setExNivelAcesso(doc.getExModelo().getExNivelAcesso());
-				}
-				
 				String camposModelo = "";
 				String conteudo = req.entrevista;
 				Map <String, String> conteudoMap;
@@ -389,6 +407,17 @@ public class DocumentosPost implements IDocumentosPost {
 				throw e;
 			}
 		}
+	}
+
+	private boolean isNivelAcessoValido(DpPessoa titular, DpLotacao lotaTitular, ExDocumento doc, ExNivelAcesso nivel) {
+		List<ExNivelAcesso> lst = Ex.getInstance().getBL().getListaNivelAcesso(doc.getExTipoDocumento(), doc.getExFormaDocumento(),
+				doc.getExModelo(), doc.getExClassificacao(), titular, lotaTitular);
+		for (ExNivelAcesso nv : lst) {
+			if (nv.equals(nivel)) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	protected  ExDao dao() {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExController.java
@@ -101,52 +101,8 @@ public class ExController extends SigaController {
 	}
 
 	protected  List<ExNivelAcesso> getListaNivelAcesso(ExTipoDocumento exTpDoc, ExFormaDocumento forma, ExModelo exMod, ExClassificacao classif) {
-		List<ExNivelAcesso> listaNiveis = ExDao.getInstance().listarOrdemNivel();
-		ArrayList<ExNivelAcesso> niveisFinal = new ArrayList<ExNivelAcesso>();
-		Date dt = ExDao.getInstance().consultarDataEHoraDoServidor();
-
-		ExConfiguracao config = new ExConfiguracao();
-		CpTipoConfiguracao exTpConfig = new CpTipoConfiguracao();
-		config.setDpPessoa(getTitular());
-		config.setLotacao(getLotaTitular());
-		config.setExTipoDocumento(exTpDoc);
-		config.setExFormaDocumento(forma);
-		config.setExModelo(exMod);
-		config.setExClassificacao(classif);
-
-		ExConfiguracao exConfiguracaoMin;
-		exTpConfig.setIdTpConfiguracao(CpTipoConfiguracao.TIPO_CONFIG_NIVEL_ACESSO_MINIMO);
-		config.setCpTipoConfiguracao(exTpConfig);
-		try {
-			exConfiguracaoMin = (ExConfiguracao) Ex.getInstance().getConf().buscaConfiguracao(config, new int[] { ExConfiguracaoBL.NIVEL_ACESSO }, dt);
-		} catch (Exception e) {
-			exConfiguracaoMin = null;
-		}
-
-		ExConfiguracao exConfiguracaoMax;
-		exTpConfig.setIdTpConfiguracao(CpTipoConfiguracao.TIPO_CONFIG_NIVEL_ACESSO_MAXIMO);
-		config.setCpTipoConfiguracao(exTpConfig);
-		try {
-			exConfiguracaoMax = (ExConfiguracao) Ex.getInstance().getConf().buscaConfiguracao(config, new int[] { ExConfiguracaoBL.NIVEL_ACESSO }, dt);
-		} catch (Exception e) {
-			exConfiguracaoMax = null;
-		}
-
-		if (exConfiguracaoMin != null && exConfiguracaoMax != null && exConfiguracaoMin.getExNivelAcesso() != null
-				&& exConfiguracaoMax.getExNivelAcesso() != null) {
-			int nivelMinimo = exConfiguracaoMin.getExNivelAcesso().getGrauNivelAcesso();
-			int nivelMaximo = exConfiguracaoMax.getExNivelAcesso().getGrauNivelAcesso();
-
-			for (ExNivelAcesso nivelAcesso : listaNiveis) {
-				if (nivelAcesso.getGrauNivelAcesso() >= nivelMinimo && nivelAcesso.getGrauNivelAcesso() <= nivelMaximo) {
-					niveisFinal.add(nivelAcesso);
-				}
-			}
-		} else {
-			niveisFinal.addAll(listaNiveis);
- 		}
-
-		return niveisFinal;
+		return Ex.getInstance().getBL().getListaNivelAcesso(exTpDoc, forma, exMod,
+				classif, getTitular(), getLotaTitular());
 	}
 
 	protected  ExNivelAcesso getNivelAcessoDefault(final ExTipoDocumento exTpDoc, final ExFormaDocumento forma, final ExModelo exMod, final ExClassificacao classif) {


### PR DESCRIPTION
Foi corrigido o webservice POST /documentos para verificar se o nível de acesso informado existe e se ele está na lista de níveis de acessos permitidos para o documento/pessoa. A função para gerar esta lista foi transferida do controller para o ExBL para evitar duplicidade de código.