### PR TITLE
GOVSP1830* - Configuração para proibir datas retroativas nos marcadores

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -249,5 +249,9 @@ public class Prop {
 		 * marcadores. Se false não exibe.
 		 * */
 		provider.addPublicProperty("/siga.marcadores.exibe.dataativacao", "false");
+		/* Cadastro de marcadores: Se true, permite data anterior a hoje nas datas de exibição e limite. 
+		 * Se false, não permite.
+		 * */
+		provider.addPublicProperty("/siga.marcadores.permite.data.retroativa", "true");
 	}
 }

--- a/siga/src/main/webapp/javascript/siga.js
+++ b/siga/src/main/webapp/javascript/siga.js
@@ -183,7 +183,7 @@ function descarrega() {
 	carregando = false;
 }
 
-function verifica_data(data, naoObriga, retornarMensagem) {
+function verifica_data(data, naoObriga, retornarMensagem, podeRetroativa = true) {
 	mydata = new String(data.value);
 	var mySplit;
 	var msg = "";
@@ -202,28 +202,37 @@ function verifica_data(data, naoObriga, retornarMensagem) {
 		if ((dia == null) || (mes == null) || (ano == null) || (dia == "")
 				|| (mes == "") || (ano == "")) {
 			msg = msg
-			+ "A data deve estar num dos seguintes formatos: DD/MM/AAAA ou DDMMAAAA\n";						
+			+ "A data deve estar num dos seguintes formatos: DD/MM/AAAA ou DDMMAAAA. \n";						
 		}
 
 		if (isNaN(dia) || isNaN(mes) || isNaN(ano)) {
-			msg = msg + "A data só pode conter caracteres numéricos\n";			
+			msg = msg + "A data só pode conter caracteres numéricos. \n";			
 		}
 
 		// verifica o dia valido para cada mes
 		if (((dia < 1 || dia > 31) || (dia > 30)
 				&& (mes == 4 || mes == 6 || mes == 9 || mes == 11))
 				|| (mes == 2 && (dia > 29 || (dia > 28 && (parseInt(ano / 4) != ano / 4))))) {
-			msg = msg + "Dia inválido\n";
+			msg = msg + "Dia inválido. \n";
 		}
 
 		// verifica se o mes e valido
 		if (mes < 1 || mes > 12) {
-			msg = msg + "Mês inválido\n";
+			msg = msg + "Mês inválido. \n";
 		}
 
 		// verifica se o ano é maior que 9999
-		if (ano.length > 4 || ano.length == 3) {
-			msg = msg + "Ano deve ser no máximo 9999\n";
+		if (isNaN(ano) || ano.length > 4 || ano.length == 3) {
+			msg = msg + "Ano deve ser no máximo 9999. \n";
+		}			
+		
+		// Verifica se não pode data retroativa (anterior a hoje)
+		var dt = new Date(mes + "-" + dia + "-" + ano); 
+		var today = new Date();
+		today.setHours(0, 0, 0, 0);
+		
+		if (!podeRetroativa && dt < today) {
+			msg = msg + "Data não pode ser anterior à hoje. \n";
 		}			
 		
 		if (msg.length > 0) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -2551,6 +2551,14 @@ public class ExMovimentacaoController extends ExController {
 			movimentacaoBuilder.setLotaSubscritorSel(lotaSubscritorSel);
 		}
 
+		if (!Prop.getBool("/siga.marcadores.permite.data.retroativa")) {
+			if (!Utils.empty(planejada) && !DateUtils.isSameDay(new Date(), dtPlanejada) && dtPlanejada.before(new Date())) 
+				throw new AplicacaoException("Data Planejada não pode ser anterior à hoje.");
+			
+			if (!Utils.empty(limite) && !DateUtils.isSameDay(new Date(), dtLimite) && dtLimite.before(new Date())) 
+				throw new AplicacaoException("Data Limite não pode ser anterior à hoje.");
+		} 
+			
 		movimentacaoBuilder.setIdMarcador(marcador);
 		final ExMovimentacao mov = movimentacaoBuilder.construir(dao());
 		mov.setDescrMov(texto);

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
@@ -1,5 +1,6 @@
 <!-- Marcar Modal -->
 <%@ page contentType="text/html; charset=UTF-8"%>
+<c:set var="podeRetroativa" scope="session" value="${f:resource('/siga.marcadores.permite.data.retroativa')}" />
 <div class="modal fade" id="definirMarcaModal" tabindex="-1"
 	role="dialog" aria-labelledby="anotarModalLabel" aria-hidden="true">
 	<div class="modal-dialog" role="document">
@@ -15,7 +16,7 @@
 				</button>
 			</div>
 			<div class="modal-body">
-				<form id="anotarForm" name="marcar_gravar" method="POST"
+				<form id="marcarForm" name="marcar_gravar" method="POST"
 					action="${linkTo[ExMovimentacaoController].aMarcarGravar()}">
 					<input type="hidden" name="sigla" value="${m.sigla}" />
 					<div class="form-group">
@@ -64,13 +65,13 @@
 									v-if="marcador && marcador.planejada != 'DESATIVADA'">
 									<label for="planejada">Data de Exibição</label> <input
 										name="planejada" id="planejada" class="form-control campoData"
-										onblur="javascript:verifica_data(this,0);" autocomplete="off" />
+										autocomplete="off" />
 								</div>
 								<div class="col col-12 col-md-6"
 									v-if="marcador && marcador.limite != 'DESATIVADA'">
 									<label for="limite">Prazo Final</label> <input name="limite"
 										id="limite" class="form-control campoData"
-										onblur="javascript:verifica_data(this,0);" autocomplete="off" />
+										autocomplete="off" />
 								</div>
 							</div>
 							<div class="form-group"
@@ -86,7 +87,7 @@
 			<div class="modal-footer">
 				<button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
 				<button type="button" class="btn btn-primary"
-					onclick="javascript: document.getElementById('anotarForm').submit();">Gravar</button>
+					onclick="javascript: sbmt();">Gravar</button>
 			</div>
 		</div>
 	</div>
@@ -256,10 +257,26 @@
 						if (component.errormsg === undefined) {
 							component.errormsg = "Erro desconhecido!";
 						}
-					},
+					}
 				}
 			});
 
 	window.initdefinirMarcaModal = function() {
 	}
+
+	function sbmt() {
+		var dtPlanejada = document.getElementById('planejada');
+		var dtLimite = document.getElementById('limite');
+		
+		if (!${podeRetroativa} && dtPlanejada != null)
+			if (!verifica_data(dtPlanejada,0,false,false))
+				return;
+
+		if (!${podeRetroativa} && dtLimite != null)
+			if (!verifica_data(dtLimite,0,false,false))
+				return;
+		
+		document.getElementById('marcarForm').submit();
+	}
+	
 </script>


### PR DESCRIPTION
Criada uma configuração para que na definição de marca no documento não seja permitida uma data anterior à data atual nas datas limite (Prazo Final) ou de exibição.
Se a property "siga.marcadores.permite.data.retroativa" for true ou não for informada, as datas retroativas serão permitidas.
Caso contrário, não serão permitidas e será exibida a mensagem "Data não pode ser anterior à hoje.":

![image](https://user-images.githubusercontent.com/49542320/116397702-4d471280-a7fd-11eb-8a83-480d47de9834.png)




