### PR TITLE
GOVSP65402 Ajustes nas queries da pesquisa avançada

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1485,7 +1485,7 @@ public class CpBL {
 				marcador.setIdGrupo(grupoId);
 				marcador.setIdCor(idCor);
 				marcador.setIdIcone(idIcone);
-				marcador.setIsListavelPesquisa(true);
+				marcador.setListavelPesquisaDefault(true);
 				dao().gravarComHistorico(marcador, marcadorAnt, dtAtivacao, identidade);
 			} else {
 				throw new AplicacaoException ("Marcador não existente para esta " + msgLotacao 
@@ -1502,7 +1502,7 @@ public class CpBL {
 			marcador.setIdIcone(idIcone);
 			marcador.setDpLotacaoIni(idFinalidade.getIdTpMarcador() == CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO ? lotacao.getLotacaoInicial() : null);
 			marcador.setOrdem(ordem);
-			marcador.setIsListavelPesquisa(true);
+			marcador.setListavelPesquisaDefault(true);
 			dao().gravarComHistorico(marcador, null, dtAtivacao, identidade);
 		}
 	}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1485,6 +1485,7 @@ public class CpBL {
 				marcador.setIdGrupo(grupoId);
 				marcador.setIdCor(idCor);
 				marcador.setIdIcone(idIcone);
+				marcador.setIsListavelPesquisa(true);
 				dao().gravarComHistorico(marcador, marcadorAnt, dtAtivacao, identidade);
 			} else {
 				throw new AplicacaoException ("Marcador não existente para esta " + msgLotacao 
@@ -1501,6 +1502,7 @@ public class CpBL {
 			marcador.setIdIcone(idIcone);
 			marcador.setDpLotacaoIni(idFinalidade.getIdTpMarcador() == CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO ? lotacao.getLotacaoInicial() : null);
 			marcador.setOrdem(ordem);
+			marcador.setIsListavelPesquisa(true);
 			dao().gravarComHistorico(marcador, null, dtAtivacao, identidade);
 		}
 	}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
@@ -107,8 +107,8 @@ public abstract class AbstractCpMarcador extends HistoricoAuditavelSuporte imple
 	@Column(name = "HIS_ATIVO")
 	private Integer hisAtivo;
 
-	@Column(name = "IS_LISTAVEL_PESQUISA")
-	private Integer isListavelPesquisa;
+	@Column(name = "LISTAVEL_PESQUISA_DEFAULT")
+	private Integer listavelPesquisaDefault;
 
 	public Long getIdMarcador() {
 		return idMarcador;
@@ -254,12 +254,12 @@ public abstract class AbstractCpMarcador extends HistoricoAuditavelSuporte imple
 		this.idFinalidade = finalidade;
 	}
 
-	public boolean getIsListavelPesquisa() {
-		return (isListavelPesquisa != null && isListavelPesquisa == 1? true : false);
+	public boolean isListavelPesquisaDefault() {
+		return (listavelPesquisaDefault != null && listavelPesquisaDefault == 1? true : false);
 	}
 
-	public void setIsListavelPesquisa(boolean isListavelPesquisa) {
-		this.isListavelPesquisa = (isListavelPesquisa? 1 : 0);
+	public void setListavelPesquisaDefault(boolean listavelPesquisaDefault) {
+		this.listavelPesquisaDefault = (listavelPesquisaDefault? 1 : 0);
 	}
 
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractCpMarcador.java
@@ -107,6 +107,9 @@ public abstract class AbstractCpMarcador extends HistoricoAuditavelSuporte imple
 	@Column(name = "HIS_ATIVO")
 	private Integer hisAtivo;
 
+	@Column(name = "IS_LISTAVEL_PESQUISA")
+	private Integer isListavelPesquisa;
+
 	public Long getIdMarcador() {
 		return idMarcador;
 	}
@@ -249,6 +252,14 @@ public abstract class AbstractCpMarcador extends HistoricoAuditavelSuporte imple
 
 	public void setIdFinalidade(CpMarcadorFinalidadeEnum finalidade) {
 		this.idFinalidade = finalidade;
+	}
+
+	public boolean getIsListavelPesquisa() {
+		return (isListavelPesquisa != null && isListavelPesquisa == 1? true : false);
+	}
+
+	public void setIsListavelPesquisa(boolean isListavelPesquisa) {
+		this.isListavelPesquisa = (isListavelPesquisa? 1 : 0);
 	}
 
 }

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V105_0__cp_marcador_is_listavel_pesquisa.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V105_0__cp_marcador_is_listavel_pesquisa.sql
@@ -1,0 +1,10 @@
+-- Criacao da coluna is_listavel_pesquisa
+alter session set current_schema=corporativo;
+
+alter table corporativo.cp_marcador add is_listavel_pesquisa number(1, 0);
+-- Seta marcadores que devem ser listados na pesquisa
+update corporativo.cp_marcador set is_listavel_pesquisa = 1 where id_marcador <> 3 and id_marcador <> 14 and id_marcador <> 25;
+-- Seta marcadores que nao devem ser listados na pesquisa
+update corporativo.cp_marcador set is_listavel_pesquisa = 0 where id_marcador = 3 or id_marcador = 14 or id_marcador = 25;
+
+comment on column "CORPORATIVO"."CP_MARCADOR"."IS_LISTAVEL_PESQUISA" is '1 = lista na pesquisa de docs - 0 ou null = nao lista';

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V105_0__cp_marcador_is_listavel_pesquisa.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V105_0__cp_marcador_is_listavel_pesquisa.sql
@@ -1,10 +1,9 @@
--- Criacao da coluna is_listavel_pesquisa
-alter session set current_schema=corporativo;
+-- Criacao da coluna LISTAVEL_PESQUISA_DEFAULT
 
-alter table corporativo.cp_marcador add is_listavel_pesquisa number(1, 0);
+alter table corporativo.cp_marcador add LISTAVEL_PESQUISA_DEFAULT number(1, 0);
 -- Seta marcadores que devem ser listados na pesquisa
-update corporativo.cp_marcador set is_listavel_pesquisa = 1 where id_marcador <> 3 and id_marcador <> 14 and id_marcador <> 25;
+update corporativo.cp_marcador set LISTAVEL_PESQUISA_DEFAULT = 1 where id_marcador <> 3 and id_marcador <> 14 and id_marcador <> 25;
 -- Seta marcadores que nao devem ser listados na pesquisa
-update corporativo.cp_marcador set is_listavel_pesquisa = 0 where id_marcador = 3 or id_marcador = 14 or id_marcador = 25;
+update corporativo.cp_marcador set LISTAVEL_PESQUISA_DEFAULT = 0 where id_marcador = 3 or id_marcador = 14 or id_marcador = 25;
 
-comment on column "CORPORATIVO"."CP_MARCADOR"."IS_LISTAVEL_PESQUISA" is '1 = lista na pesquisa de docs - 0 ou null = nao lista';
+comment on column "CORPORATIVO"."CP_MARCADOR"."LISTAVEL_PESQUISA_DEFAULT" is '1 = lista na pesquisa de docs - 0 ou null = nao lista';

--- a/siga-cp/src/main/resources/db/mysql/sigacp/V105.0__cp_marcador_is_listavel_pesquisa.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V105.0__cp_marcador_is_listavel_pesquisa.sql
@@ -1,0 +1,7 @@
+-- Criacao da coluna is_listavel_pesquisa
+ALTER TABLE corporativo.cp_marcador ADD IS_LISTAVEL_PESQUISA tinyint(4) COMMENT '1 = lista na pesquisa de docs - 0 ou null = nao lista';
+
+-- Seta marcadores que devem ser listados na pesquisa
+UPDATE corporativo.cp_marcador SET IS_LISTAVEL_PESQUISA = 1 WHERE ID_MARCADOR <> 3 AND ID_MARCADOR <> 14 AND ID_MARCADOR <> 25;
+-- Seta marcadores que nao devem ser listados na pesquisa
+UPDATE corporativo.cp_marcador SET IS_LISTAVEL_PESQUISA = 0 WHERE ID_MARCADOR = 3 OR ID_MARCADOR = 14 OR ID_MARCADOR = 25;

--- a/siga-cp/src/main/resources/db/mysql/sigacp/V105.0__cp_marcador_is_listavel_pesquisa.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V105.0__cp_marcador_is_listavel_pesquisa.sql
@@ -1,7 +1,7 @@
--- Criacao da coluna is_listavel_pesquisa
-ALTER TABLE corporativo.cp_marcador ADD IS_LISTAVEL_PESQUISA tinyint(4) COMMENT '1 = lista na pesquisa de docs - 0 ou null = nao lista';
+-- Criacao da coluna is_LISTAVEL_PESQUISA_DEFAULT
+ALTER TABLE corporativo.cp_marcador ADD LISTAVEL_PESQUISA_DEFAULT tinyint(4) COMMENT '1 = lista na pesquisa de docs - 0 ou null = nao lista';
 
 -- Seta marcadores que devem ser listados na pesquisa
-UPDATE corporativo.cp_marcador SET IS_LISTAVEL_PESQUISA = 1 WHERE ID_MARCADOR <> 3 AND ID_MARCADOR <> 14 AND ID_MARCADOR <> 25;
+UPDATE corporativo.cp_marcador SET LISTAVEL_PESQUISA_DEFAULT = 1 WHERE ID_MARCADOR <> 3 AND ID_MARCADOR <> 14 AND ID_MARCADOR <> 25;
 -- Seta marcadores que nao devem ser listados na pesquisa
-UPDATE corporativo.cp_marcador SET IS_LISTAVEL_PESQUISA = 0 WHERE ID_MARCADOR = 3 OR ID_MARCADOR = 14 OR ID_MARCADOR = 25;
+UPDATE corporativo.cp_marcador SET LISTAVEL_PESQUISA_DEFAULT = 0 WHERE ID_MARCADOR = 3 OR ID_MARCADOR = 14 OR ID_MARCADOR = 25;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -30,12 +30,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -54,10 +54,8 @@ import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.util.Texto;
 import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
-import br.gov.jfrj.siga.cp.CpTipoMarcadorEnum;
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorGrupoEnum;
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorEnum;
-import br.gov.jfrj.siga.cp.model.enm.CpMarcadorFinalidadeEnum;
 import br.gov.jfrj.siga.dp.CpMarcador;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
 import br.gov.jfrj.siga.dp.DpLotacao;
@@ -72,6 +70,7 @@ import br.gov.jfrj.siga.ex.ExEmailNotificacao;
 import br.gov.jfrj.siga.ex.ExEstadoDoc;
 import br.gov.jfrj.siga.ex.ExFormaDocumento;
 import br.gov.jfrj.siga.ex.ExItemDestinacao;
+import br.gov.jfrj.siga.ex.ExMarca;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExModelo;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
@@ -100,7 +99,6 @@ import br.gov.jfrj.siga.persistencia.ExDocumentoDaoFiltro;
 import br.gov.jfrj.siga.persistencia.ExMobilApiBuilder;
 import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
 import br.gov.jfrj.siga.persistencia.ExModeloDaoFiltro;
-import br.gov.jfrj.sigale.ex.vo.ExMobilApiVO;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class ExDao extends CpDao {
@@ -695,10 +693,21 @@ public class ExDao extends CpDao {
 			query.setMaxResults(itemPagina);
 		}
 		List l = query.getResultList();
+		List<Object[]> l2 = new ArrayList<Object[]>(); 
+		if (l != null && l.size() > 0) {
+			query = em().createQuery("select doc, mob, label from ExMarca label"
+					+ " inner join label.exMobil mob inner join mob.exDocumento doc"
+					+ " where label.idMarca in (:listIdMarca)");
+			query.setParameter("listIdMarca", l);
+			l2 = query.getResultList();
+			Collections.sort(l2, Comparator.comparing( item -> l.indexOf(
+				    		Long.valueOf (((ExMarca) (item[2])).getIdMarca()))));
+		}
+		
 		long tempoTotal = System.nanoTime() - tempoIni;
 		// System.out.println("consultarPorFiltroOtimizado: " +
 		// tempoTotal/1000000 + " ms -> " + query + ", resultado: " + l);
-		return l;
+		return l2;
 	}
 
 	private IMontadorQuery carregarPlugin() {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -536,10 +536,6 @@ public class ExDao extends CpDao {
 			query.setParameter("idMarcadorIni", marcador.getHisIdIni());
 			query.setParameter("dbDatetime", this.consultarDataEHoraDoServidor());
 
-		} else {
-			query.setParameter("id1", 3L);
-			query.setParameter("id2", 14L);
-			query.setParameter("id3", 25L);
 		}
 
 		if (flt.getUltMovRespSelId() != null && flt.getUltMovRespSelId() != 0) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -42,7 +42,7 @@ public class MontadorQuery implements IMontadorQuery {
 			sbf.append(" and (dt_ini_marca is null or dt_ini_marca < :dbDatetime)");
 			sbf.append(" and (dt_fim_marca is null or dt_fim_marca > :dbDatetime)");
 		} else {
-			sbf.append(" and not (label.cpMarcador.idMarcador = :id1 or label.cpMarcador.idMarcador = :id2 or label.cpMarcador.idMarcador = :id3)");
+			sbf.append(" and label.cpMarcador.isListavelPesquisa = 1");
 		}
 
 		if (flt.getUltMovRespSelId() != null && flt.getUltMovRespSelId() != 0) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -30,7 +30,7 @@ public class MontadorQuery implements IMontadorQuery {
 		if (apenasCount)
 			sbf.append("select count(1) from ExMarca label inner join label.exMobil mob inner join mob.exDocumento doc");
 		else
-			sbf.append("select doc, mob, label from ExMarca label inner join label.exMobil mob inner join mob.exDocumento doc");
+			sbf.append("select label.idMarca from ExMarca label inner join label.exMobil mob inner join mob.exDocumento doc");
 
 		//Nato: desabilitei este where pois causava muito impacto na velocidade da consulta. Precisamos criar uma variavel denormalizada mais a frente para resolver esse problema.
 		//sbf.append(" where not exists (from ExMovimentacao where exTipoMovimentacao.idTpMov = 10 and (exMobil.idMobil = mob.idMobil ");
@@ -183,15 +183,15 @@ public class MontadorQuery implements IMontadorQuery {
 
 		if (!apenasCount) {
 			if (flt.getOrdem() == null || flt.getOrdem() == 0)
-				sbf.append(" order by doc.dtDoc desc, doc.idDoc desc, label.idMarca desc");
+				sbf.append(" order by doc.dtDoc desc, doc.idDoc desc");
 			else if (flt.getOrdem() == 1)
-				sbf.append(" order by label.dtIniMarca desc, doc.idDoc desc, label.idMarca desc");
+				sbf.append(" order by label.dtIniMarca desc, doc.idDoc desc");
 			else if (flt.getOrdem() == 2)
-				sbf.append(" order by doc.anoEmissao desc, doc.numExpediente desc, mob.numSequencia, doc.idDoc desc, label.idMarca desc");
+				sbf.append(" order by doc.anoEmissao desc, doc.numExpediente desc, mob.numSequencia, doc.idDoc desc");
 			else if (flt.getOrdem() == 3)
-				sbf.append(" order by doc.dtFinalizacao desc, doc.idDoc desc, label.idMarca desc");
+				sbf.append(" order by doc.dtFinalizacao desc, doc.idDoc desc");
 			else if (flt.getOrdem() == 4)
-				sbf.append(" order by doc.idDoc desc, label.idMarca desc");
+				sbf.append(" order by doc.idDoc desc");
 		}
 		
 		String s = sbf.toString();

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -42,7 +42,7 @@ public class MontadorQuery implements IMontadorQuery {
 			sbf.append(" and (dt_ini_marca is null or dt_ini_marca < :dbDatetime)");
 			sbf.append(" and (dt_fim_marca is null or dt_fim_marca > :dbDatetime)");
 		} else {
-			sbf.append(" and label.cpMarcador.isListavelPesquisa = 1");
+			sbf.append(" and label.cpMarcador.listavelPesquisaDefault = 1");
 		}
 
 		if (flt.getUltMovRespSelId() != null && flt.getUltMovRespSelId() != 0) {


### PR DESCRIPTION
Na query do montador query, traz somente os ids da marca. Os dados dos 50 registros da página são trazidos em outra query para evitar tabulação em memória e processamento desnecessário no BD.

Foi criada a coluna IS_LISTAVEL_PESQUISA na CP_MARCADOR,  para evitar pesquisa por <> conforme recomendações da equipe de banco de dados do GOVSP.

Foi removida a ordenação por marcas porque causava um sort no Oracle sem utilização do índice (full scan).