### PR TITLE
GOVSP66218* - Tela Pesquisa: Não trazer espécies e modelos imediatamente

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -254,5 +254,10 @@ public class Prop {
 		 * Se false, não permite.
 		 * */
 		provider.addPublicProperty("/siga.marcadores.permite.data.retroativa", "true");
+		/* Tela de Pesquisa, combos de espécies e modelos: 
+		 * - True: Confere se a espécie tem modelos no combo da tela de pesquisa.  
+		 * - False ou inexistente: Não confere, evitando leitura dos modelos.
+		 * */
+		provider.addPublicProperty("/siga.pesquisa.confere.modelos", "true");
 	}
 }

--- a/siga/src/main/webapp/javascript/siga.js
+++ b/siga/src/main/webapp/javascript/siga.js
@@ -1311,8 +1311,10 @@ to get the response data.</param>
 <param name="obj_id">The object or the id of 
 the object to set the innerHTML for.</param>
 */
-function SetInnerHTMLFromAjaxResponse(url, obj_id)
+function SetInnerHTMLFromAjaxResponse(url, obj_id, funcaoAntes = null, funcaoDepois = null)
 {
+  if (funcaoAntes != null)
+	funcaoAntes();
   mostraCarregando();
   active++;
   
@@ -1340,6 +1342,9 @@ function SetInnerHTMLFromAjaxResponse(url, obj_id)
   })
   .always(function() {
 		ocultaCarregando();
+	    if (funcaoDepois != null)
+		  funcaoDepois();
+
   });
   
   return;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -808,9 +808,13 @@ public class ExMobilController extends
 		}
 
 		final List<ExFormaDocumento> formasDoc = new ArrayList<ExFormaDocumento>();
-		formasDoc.addAll(bl.obterFormasDocumento(bl.obterListaModelos(null, null,
-				false, false, null, null, false, getTitular(), getLotaTitular(), false),
-				null, tipoForma));
+		if (Prop.get("/siga.pesquisa.confere.modelos").equals("true")) {
+			formasDoc.addAll(bl.obterFormasDocumento(bl.obterListaModelos(null, null,
+					false, false, null, null, false, getTitular(), getLotaTitular(), false),
+					null, tipoForma));
+		} else {
+			formasDoc.addAll(dao().listarTodosOrdenarPorSigla());
+		}
 		return formasDoc;
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaFormas.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaFormas.jsp
@@ -6,13 +6,13 @@
 
 
 <div class="form-group" id="idFormaDocGroup">
-	<label><fmt:message key="documento.label.especie"/></label> 
-	<select class="form-control siga-select2" id="idFormaDoc" name="idFormaDoc" onchange="javascript:alteraForma();">
+	<label><fmt:message key="documento.label.especie"/> <span id="idFormaDoc-spinner" class="spinner-border text-secondary d-none"></span></label> 
+	<select class="form-control siga-select2" id="idFormaDoc" name="idFormaDoc" onchange="javascript:alteraForma(false);">
 		<option value="0">[Todos]</option>
 		<c:forEach items="${todasFormasDocPorTipoForma}" var="item">
 			<option value="${item.idFormaDoc}"
 				${item.idFormaDoc == idFormaDoc ? 'selected' : ''}>
-				${item.descrFormaDoc}
+				${item.siglaFormaDoc} - ${item.descrFormaDoc}
 			</option>
 		</c:forEach>
 	</select>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaModelos.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaModelos.jsp
@@ -5,7 +5,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
 <div class="form-group" id="idModGroup">
-	<label><fmt:message key="documento.modelo2"/></label> 
+	<label><fmt:message key="documento.modelo2"/> <span id="idMod-spinner" class="spinner-border text-secondary d-none"></span></label> 
 	<select class="form-control siga-select2" id="idMod" name="idMod">
 		<c:forEach items="${modelos}" var="item">
 			<option value="${item.idMod}" ${item.idMod == idMod ? 'selected' : ''}>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -14,26 +14,39 @@
 
 		$(document).ready(function() {
 			alteraOrigem();
-			alteraTipoDaForma();
-			alteraForma();				
+			var frmsel = document.getElementById('idFormaDoc')
+			var modsel = document.getElementById('idMod')
+			${idFormaDoc != null && idFormaDoc != 0? 'alteraTipoDaForma(false);' : ''}
+			${idMod != null && idMod != 0? 'alteraForma(false);' : ''}
 		});
 		
-		function alteraTipoDaForma() {
-			SetInnerHTMLFromAjaxResponse(
-					'/sigaex/app/expediente/doc/carregar_lista_formas?tipoForma='
-							+ document.getElementById('tipoForma').value
-							+ '&idFormaDoc=' + '${idFormaDoc}', document
-							.getElementById('comboFormaDiv'));
-			
+		function alteraTipoDaForma(abrir) {
+			if ($('#idFormaDoc-spinner').hasClass('d-none')) {
+				$('#idFormaDoc-spinner').removeClass('d-none');
+				$('#idFormaDoc').prop('disabled', 'disabled');
+				SetInnerHTMLFromAjaxResponse(
+						'/sigaex/app/expediente/doc/carregar_lista_formas?tipoForma='
+								+ document.getElementById('tipoForma').value
+								+ '&idFormaDoc=' + '${idFormaDoc}', document
+								.getElementById('comboFormaDiv'), null, 
+								(abrir? function(){	$('#idFormaDoc').select2('open'); } : null)							
+								);
+			}
 		}
 	
-		function alteraForma() {
-			var idFormaDoc = document.getElementById('idFormaDoc');
-			SetInnerHTMLFromAjaxResponse(
-					'/sigaex/app/expediente/doc/carregar_lista_modelos?forma='
-							+ (idFormaDoc != null ? idFormaDoc.value : '${idFormaDoc}' )
-							+ '&idMod='	+ '${idMod}', document
-							.getElementById('comboModeloDiv'));
+		function alteraForma(abrir) {
+			if ($('#idMod-spinner').hasClass('d-none')) {
+				$('#idMod-spinner').removeClass('d-none');
+				$('#idMod').prop('disabled', 'disabled');
+				var idFormaDoc = document.getElementById('idFormaDoc');
+				SetInnerHTMLFromAjaxResponse(
+						'/sigaex/app/expediente/doc/carregar_lista_modelos?forma='
+								+ (idFormaDoc != null ? idFormaDoc.value : '${idFormaDoc}' )
+								+ '&idMod='	+ '${idMod}', document
+								.getElementById('comboModeloDiv'), null, 
+								(abrir? function(){	$('#idMod').select2('open'); } : null)							
+								);
+			}
 		}
 		
 		function sbmtAction(id, action) {
@@ -526,7 +539,7 @@
 							<label for="tipoForma">Tipo da Espécie</label> 
 							<select
 								class="form-control" id="tipoForma" name="idTipoFormaDoc"
-								onchange="javascript:alteraTipoDaForma();">
+								onchange="javascript:alteraTipoDaForma(false);">
 								<option value="0">[Todos]</option>
 								<c:forEach items="${tiposFormaDoc}" var="item">
 									<option value="${item.idTipoFormaDoc}"
@@ -537,11 +550,25 @@
 						</div>
 
 						<div class="form-group col-md-3">
-							<div style="display: inline" id="comboFormaDiv"></div>
+							<div style="display: inline" id="comboFormaDiv">
+								<div class="form-group" id="idFormaDocGroup" onclick="javascript:alteraTipoDaForma(true);">
+									<label><fmt:message key="documento.label.especie"/> <span id="idFormaDoc-spinner" class="spinner-border text-secondary d-none"></span></label> 
+									<select class="form-control siga-select2" id="idFormaDoc" name="idFormaDoc">
+										<option value="0">[Todos]</option>
+									</select>
+								</div>
+							</div>
 						</div>
 
 						<div class="form-group col-md-6">
-							<div style="display: inline" id="comboModeloDiv"></div>
+							<div style="display: inline" id="comboModeloDiv">
+								<div class="form-group" id="idModGroup" onclick="javascript:alteraForma(true);">
+									<label><fmt:message key="documento.modelo2"/> <span id="idMod-spinner" class="spinner-border text-secondary d-none"></span></label> 
+									<select class="form-control siga-select2" id="idMod" name="idMod">
+										<option value="0" >[Todos]</option>
+									</select>
+								</div>
+							</div>
 						</div>
 					</div>
 


### PR DESCRIPTION
Alteração necessária para redução da quantidade de chamadas da query de modelos.
Passa a obter os dados dos combos de espécie e modelo somente se o usuário clicar no combo. Desta forma, ao entrar na página de pesquisa, não irá executar a query. Só irá executar se o usuário desejar pesquisar por espécie/modelo.

Deixa também de verificar se a espécie tem modelos no controller se configurado na property /siga.pesquisa.confere.modelos

No combo de espécie, passa a exibir a sigla do modelo na frente da descrição.