### PR TITLE
Limitação da coluna descr_documento_ai conforme property

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -231,6 +231,9 @@ import br.gov.jfrj.siga.ex.BIE.ExBoletimDoc;
 				+ "				order by  doc.dtFinalizacao") })
 public abstract class AbstractExDocumento extends ExArquivo implements
 		Serializable {
+	
+	/* Limitador para indexação do campo pesquisável da descrição do documento. Length Default 4000. Length indexável: 3150*/
+	private static final int LENGTH_DESCR_DOCUMENTO_AI = System.getProperty("sigaex.descricao.documento.ai.length") != null ? Integer.parseInt(System.getProperty("sigaex.descricao.documento.ai.length")) : 4000;
 
 	@Id
 	@SequenceGenerator(sequenceName = "EX_DOCUMENTO_SEQ", name = "EX_DOCUMENTO_SEQ")
@@ -816,7 +819,7 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 	 */
 	public void setDescrDocumento(final java.lang.String descrDocumento) {
 		this.descrDocumento = descrDocumento;
-		this.descrDocumentoAI = Texto.removeAcentoMaiusculas(this.descrDocumento);
+		setDescrDocumentoAI(descrDocumento);
 	}
 
 	/**
@@ -1157,7 +1160,10 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 	}
 
 	public void setDescrDocumentoAI(java.lang.String descrDocumentoAI) {
-		this.descrDocumentoAI = descrDocumentoAI;
+		if(descrDocumentoAI != null)
+			this.descrDocumentoAI = Texto.removeAcentoMaiusculas(descrDocumentoAI).substring(0, descrDocumentoAI.length() < LENGTH_DESCR_DOCUMENTO_AI ? descrDocumentoAI.length() : LENGTH_DESCR_DOCUMENTO_AI );
+		else
+			this.descrDocumentoAI = descrDocumentoAI;
 	}
 	
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -228,6 +228,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 		addPrivateProperty("webdav.senha", null);
 		addPublicProperty("controlar.numeracao.expediente", "false");
 		addPublicProperty("recebimento.automatico", "true");
+		addPublicProperty("descricao.documento.ai.length", "4000");
 		
 		addPublicProperty("exibe.nome.acesso", "false");
 				


### PR DESCRIPTION
Caso seja utilizado a indexação do campo DESCR_DOCUMENTO_AI, o Oracle tem um limite indexável de 3215.
Implementado um limitador caso opte-se por indexar coluna.

Script para adequação da coluna:

-- Alter table varchar 3150
ALTER TABLE SIGA.EX_DOCUMENTO  
MODIFY (DESCR_DOCUMENTO_AI VARCHAR2(3150));

-- drop idx existente
drop   index SIGA.IACS_EX_DOCUMENTO_00797

-- recria index
create index SIGA.IACS_EX_DOCUMENTO_00797
		on siga.EX_DOCUMENTO
		   (ID_ORGAO_USU,ANO_EMISSAO,DESCR_DOCUMENTO_AI)
		   global partition by hash (ID_ORGAO_USU, ANO_EMISSAO)
		   partitions 32
		   online
		   nocompress
		   initrans 32
		   compute statistics
		   storage(freelists        32
					freelist groups  2
					buffer_pool      keep
					flash_cache      default
					cell_flash_cache keep
					)
		   nologging
		   tablespace siga_data_ts
		   parallel 32;
alter index SIGA.IACS_EX_DOCUMENTO_00797 parallel (degree 1);

Criar property: 
<property name="sigaex.descricao.documento.ai.length" value="3150"/>

Default: 4000