### PR TITLE
GOVSP65964* Tela Criar Novo: Armazenar Lista de Modelos no Browser

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -259,5 +259,9 @@ public class Prop {
 		 * - False ou inexistente: Não confere, evitando leitura dos modelos.
 		 * */
 		provider.addPublicProperty("/siga.pesquisa.confere.modelos", "true");
+		/* Tela de Criar/Editar Documentos: Qtde de minutos para recarregar o combo de modelos que fica 
+		 * armazenado em session storage no browser do usuário.
+		 * */
+		provider.addPublicProperty("/siga.session.modelos.tempo.expiracao", "60");
 	}
 }

--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Utils.java
@@ -1,7 +1,9 @@
 package br.gov.jfrj.siga.base.util;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -9,6 +11,8 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+
+import br.gov.jfrj.siga.base.GZip;
 
 public class Utils {
 	/**
@@ -67,5 +71,28 @@ public class Utils {
 		             .map(Cookie::getValue)
 		             .orElse(null);		
 	} 
+
+	public static String encodeAndZip(String json) {
+		byte[] compressed;
+		try {
+			compressed = GZip.compress(json.getBytes(StandardCharsets.UTF_8));
+		} catch (IOException e) {
+			throw new RuntimeException("Erro codificando JSON", e);
+		}
+		String base64 = java.util.Base64.getEncoder().encodeToString(compressed);
+		return base64;
+	}
+
+	public static String unzipAndDecode(String base64) {
+		byte[] compressed = java.util.Base64.getDecoder().decode(base64);
+		byte[] decompressed;
+		try {
+			decompressed = GZip.decompress(compressed);
+		} catch (IOException e) {
+			throw new RuntimeException("Erro decodificando JSON", e);
+		}
+		String json = new String(decompressed, StandardCharsets.UTF_8);
+		return json;
+	}
 	
 }

--- a/siga/src/main/webapp/javascript/siga.js
+++ b/siga/src/main/webapp/javascript/siga.js
@@ -1763,3 +1763,33 @@ $(function() {
 function isNumeric(n) {
   return !isNaN(parseFloat(n)) && isFinite(n);
 }
+
+function getUser() {
+	return document.getElementById('cadastrante').title;
+}
+
+function setUserSessionStorage(nomeParm, value) {
+	window.sessionStorage.setItem(nomeParm + getUser(), value)
+}
+
+function getUserSessionStorage(nomeParm) {
+	let val = window.sessionStorage.getItem(nomeParm + getUser())
+	if (val === 'true')
+		val = true;
+	if (val === 'false')
+		val = false;
+	return val
+}
+
+function setUserLocalStorage(nomeParm, value) {
+	window.localStorage.setItem(nomeParm + getUser(), value)
+}
+
+function getUserLocalStorage(nomeParm) {
+	let val = window.localStorage.getItem(nomeParm + getUser())
+	if (val === 'true')
+		val = true;
+	if (val === 'false')
+		val = false;
+	return val
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -159,6 +159,16 @@ public interface IExApiV1 {
 		public String descr;
 	}
 
+	public class ModeloListaHierarquicaItem implements ISwaggerModel {
+		public String idModelo;
+		public String nome;
+		public String descr;
+		public int level;
+		public String keywords;
+		public boolean group;
+		public boolean selected;
+	}
+
 	public class ClassificacaoItem implements ISwaggerModel {
 		public String idClassificacao;
 		public String sigla;
@@ -197,6 +207,21 @@ public interface IExApiV1 {
 
 	public interface IModelosGet extends ISwaggerMethod {
 		public void run(ModelosGetRequest req, ModelosGetResponse resp) throws Exception;
+	}
+
+	public class ModelosListaHierarquicaGetRequest implements ISwaggerRequest {
+		public Boolean isEditandoAnexo;
+		public Boolean isCriandoSubprocesso;
+		public String siglaMobPai;
+		public Boolean isAutuando;
+	}
+
+	public class ModelosListaHierarquicaGetResponse implements ISwaggerResponse {
+		public List<ModeloListaHierarquicaItem> list;
+	}
+
+	public interface IModelosListaHierarquicaGet extends ISwaggerMethod {
+		public void run(ModelosListaHierarquicaGetRequest req, ModelosListaHierarquicaGetResponse resp) throws Exception;
 	}
 
 	public class DocumentosSiglaModelosParaIncluirGetRequest implements ISwaggerRequest {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
@@ -1,0 +1,65 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExModelo;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IModelosListaHierarquicaGet;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ModeloListaHierarquicaItem;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ModelosListaHierarquicaGetRequest;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ModelosListaHierarquicaGetResponse;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.util.ListaHierarquica;
+import br.gov.jfrj.siga.util.ListaHierarquicaItem;
+
+public class ModelosListaHierarquicaGet implements IModelosListaHierarquicaGet {
+
+	@Override
+	public String getContext() {
+		return "obter lista de modelos";
+	}
+
+	@Override
+	public void run(ModelosListaHierarquicaGetRequest req, ModelosListaHierarquicaGetResponse resp) throws Exception {
+		boolean isEditandoAnexo = (req.isEditandoAnexo != null && req.isEditandoAnexo? true : false);
+		boolean isCriandoSubprocesso = (req.isCriandoSubprocesso != null && req.isCriandoSubprocesso? true : false);
+		ExMobil mobPai = null; 
+		String headerValue = null;
+		boolean isAutuando = (req.isAutuando != null && req.isAutuando? true : false);
+
+		try (ApiContext ctx = new ApiContext(false, true)) {
+			ctx.assertAcesso("");
+
+			if (req.siglaMobPai != null) {
+				mobPai = ctx.buscarEValidarMobil(req.siglaMobPai, req, resp, "Documento Pai");
+			}
+			DpPessoa titular = ctx.getTitular();
+			DpLotacao lotaTitular = ctx.getLotaTitular();
+			List<ExModelo> modelos = Ex.getInstance().getBL().obterListaModelos(null, null, isEditandoAnexo,
+					isCriandoSubprocesso, mobPai, headerValue, true, titular, lotaTitular, isAutuando);
+
+			resp.list = new ArrayList<>();
+			for (ListaHierarquicaItem m : getListaHierarquica(modelos).getList()) {
+				ModeloListaHierarquicaItem mi = new ModeloListaHierarquicaItem();
+				mi.idModelo = (m.getValue() != null ? m.getValue().toString() : "");
+				mi.nome = m.getText();
+				mi.descr = m.getSearchText();
+				mi.level = m.getLevel();
+				mi.group = m.getGroup();
+				mi.selected = m.getSelected();
+				resp.list.add(mi);
+			}
+		}
+	}
+
+	private ListaHierarquica getListaHierarquica(List<ExModelo> modelos) {
+		ListaHierarquica lh = new ListaHierarquica();
+		for (ExModelo m : modelos) {
+			lh.add(m.getNmMod(),m.getDescMod(), m.getId(), false);
+		}
+		return lh;
+	}
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -407,7 +407,7 @@ public class ExDocumentoController extends ExController {
 				exDocumentoDTO.getMobilPaiSel(),
 				exDocumentoDTO.isCriandoAnexo(), exDocumentoDTO.getAutuando(),
 				exDocumentoDTO.getIdMobilAutuado(),
-				exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null, null);
+				exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null);
 	}
 
 	@Transacional
@@ -460,7 +460,7 @@ public class ExDocumentoController extends ExController {
 
 	@Post("app/expediente/doc/recarregar")
 	public ExDocumentoDTO recarregar(final ExDocumentoDTO exDocumentoDTO,
-			final String[] vars, String jsonHierarquiaDeModelos)
+			final String[] vars)
 			throws IllegalAccessException, InvocationTargetException,
 			IOException {
 		
@@ -480,8 +480,7 @@ public class ExDocumentoController extends ExController {
 						exDocumentoDTO.getAutuando(),
 						exDocumentoDTO.getIdMobilAutuado(),
 						exDocumentoDTO.getCriandoSubprocesso(),
-						null, null, null, null,
-						jsonHierarquiaDeModelos);
+						null, null, null, null);
 		return exDocumentoDTO;
 	}
 
@@ -492,7 +491,7 @@ public class ExDocumentoController extends ExController {
 			final ExMobilSelecao mobilPaiSel, final Boolean criandoAnexo,
 			final Boolean autuando, final Long idMobilAutuado,
 			final Boolean criandoSubprocesso, String modelo, String lotaDest, 
-			String classif, String descr, String jsonHierarquiaDeModelos)
+			String classif, String descr)
 			throws IOException, IllegalAccessException,
 			InvocationTargetException {
 		assertAcesso("");
@@ -825,49 +824,8 @@ public class ExDocumentoController extends ExController {
 			// System.out.println("*** " + p + ", "
 			// + exDocumentoDTO.getParamsEntrevista().get(p));
 		}
-
-		boolean modeloEncontrado = false;
-		ListaHierarquica lh = null;
-		if (jsonHierarquiaDeModelos != null) {
-			String json = decodeHierarquiaDeModelos(jsonHierarquiaDeModelos);
-			ObjectMapper mapper = new ObjectMapper();
-			try {
-				lh = mapper.readValue(json,
-						ListaHierarquica.class);
-				for (ListaHierarquicaItem m : lh.getList()) {
-					if (m.getValue() != null
-							&& m.getValue().equals(exDocumentoDTO.getIdMod())) {
-						m.selected = true;
-						modeloEncontrado = true;
-					}
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		if (jsonHierarquiaDeModelos == null || !modeloEncontrado) {
-			lh = new ListaHierarquica();
-			for (ExModelo m : getModelos(exDocumentoDTO)) {
-				lh.add(m.getNmMod(),m.getDescMod(), m.getId(),
-						m.getId().equals(exDocumentoDTO.getIdMod()));
-			}
-
-			ObjectMapper mapper = new ObjectMapper();
-			try {
-				jsonHierarquiaDeModelos = encodeHierarquiaDeModelos(mapper.writeValueAsString(lh));
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		int cModelos = 0;
-		for (ListaHierarquicaItem i : lh.getList())
-			if (!i.group)
-				cModelos++;
-
 		result.include("vars", l);
 
-		result.include("possuiMaisQueUmModelo", cModelos > 1);
 		result.include("par", parFreeMarker);
 		result.include("hasPai", hasPai);
 		result.include("isPaiEletronico", isPaiEletronico);
@@ -885,8 +843,6 @@ public class ExDocumentoController extends ExController {
 		result.include("tipoEmitente", exDocumentoDTO.getTipoEmitente());
 		result.include("podeEditarData", podeEditarData);
 		result.include("podeEditarDescricao", podeEditarDescricao);
-		result.include("hierarquiaDeModelos", lh.getList());
-		result.include("jsonHierarquiaDeModelos", jsonHierarquiaDeModelos);
 		result.include("podeEditarModelo", exDocumentoDTO.getDoc().isFinalizado());
 		result.include("podeTrocarPdfCapturado", podeTrocarPdfCapturado(exDocumentoDTO));
 		result.include("ehPublicoExterno", AcessoConsulta.ehPublicoExterno(getTitular()));
@@ -895,29 +851,6 @@ public class ExDocumentoController extends ExController {
 		// Desabilita a proteção contra injeção maldosa de html e js
 		this.response.addHeader("X-XSS-Protection", "0");
 		return exDocumentoDTO;
-	}
-
-	private String encodeHierarquiaDeModelos(String json) {
-		byte[] compressed;
-		try {
-			compressed = GZip.compress(json.getBytes(StandardCharsets.UTF_8));
-		} catch (IOException e) {
-			throw new RuntimeException("Erro codificando hierarquia de modelos", e);
-		}
-		String base64 = java.util.Base64.getEncoder().encodeToString(compressed);
-		return base64;
-	}
-
-	private String decodeHierarquiaDeModelos(String base64) {
-		byte[] compressed = java.util.Base64.getDecoder().decode(base64);
-		byte[] decompressed;
-		try {
-			decompressed = GZip.decompress(compressed);
-		} catch (IOException e) {
-			throw new RuntimeException("Erro decodificando hierarquia de modelos", e);
-		}
-		String json = new String(decompressed, StandardCharsets.UTF_8);
-		return json;
 	}
 
 	private Object podeTrocarPdfCapturado(ExDocumentoDTO exDocumentoDTO) {
@@ -997,7 +930,7 @@ public class ExDocumentoController extends ExController {
 				exDocumentoDTO.getMobilPaiSel(),
 				exDocumentoDTO.isCriandoAnexo(), exDocumentoDTO.getAutuando(),
 				exDocumentoDTO.getIdMobilAutuado(),
-				exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null, null);
+				exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null);
 	}
 
 	@SuppressWarnings("static-access")
@@ -1662,7 +1595,7 @@ public class ExDocumentoController extends ExController {
 	@Post("/app/expediente/doc/gravar")
 	public void gravar(final ExDocumentoDTO exDocumentoDTO,
 			final String[] vars, final String[] campos,
-			final UploadedFile arquivo, String jsonHierarquiaDeModelos) {
+			final UploadedFile arquivo) {
 		
 		final Ex ex = Ex.getInstance();
 		final ExBL exBL = ex.getBL();		
@@ -1684,8 +1617,7 @@ public class ExDocumentoController extends ExController {
 						exDocumentoDTO.getAutuando(),
 						exDocumentoDTO.getIdMobilAutuado(),
 						exDocumentoDTO.getCriandoSubprocesso(),
-						null, null, null, null,
-						jsonHierarquiaDeModelos);
+						null, null, null, null);
 				return;
 			}
 
@@ -1924,7 +1856,7 @@ public class ExDocumentoController extends ExController {
 					exDocumentoDTO.getMobilPaiSel(),
 					exDocumentoDTO.isCriandoAnexo(), exDocumentoDTO.getAutuando(),
 					exDocumentoDTO.getIdMobilAutuado(),
-					exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null, null);
+					exDocumentoDTO.getCriandoSubprocesso(), null, null, null, null);
 		} else {
 			dao().gravar(exPreenchimento);
 			SigaTransacionalInterceptor.downgradeParaNaoTransacional();

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -457,17 +457,48 @@ parameters:
       - Expediente
       - Processo
 
+  isEditandoAnexo:
+    name: isEditandoAnexo
+    in: query
+    description: Informa true se está editando anexo
+    required: false
+    default: false
+    type: boolean
+    
+  isCriandoSubprocesso:
+    name: isCriandoSubprocesso
+    in: query
+    description: Informa true se está criando subprocesso
+    required: false
+    default: false
+    type: boolean
+    
+  siglaMobPai:
+    name: siglaMobPai
+    in: query
+    description: Id do mobil pai
+    required: false
+    type: string
+    
+  isAutuando:
+    name: isAutuando
+    in: query
+    description: Informa true se está autuando
+    required: false
+    default: false
+    type: boolean
+    
 ################################################################################
 #                                           Paths                              #
 ################################################################################
 paths:
   /modelos:
     get:
-      summary: Obtem a lista de modelos que o usuário pode criar
+      summary: Obtem a lista de modelos que o usuário pode criar.
       tags: [modelo]
       security:
         - Bearer: []
-      parameters: []
+      parameters: [] 
       responses:
         200:
           description: Successful response
@@ -483,6 +514,32 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /modelos/lista-hierarquica:
+    get:
+      summary: "Obtem a lista hierárquica de modelos que o usuário pode criar. Os nomes dos modelos devem estar cadastrados no formato Grupo: Nome do Modelo (separado por dois pontos)"
+      tags: [modelo]
+      security:
+        - Bearer: []
+      parameters: 
+        - $ref: "#/parameters/isEditandoAnexo"
+        - $ref: "#/parameters/isCriandoSubprocesso"
+        - $ref: "#/parameters/siglaMobPai"
+        - $ref: "#/parameters/isAutuando"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                items:
+                  $ref: "#/definitions/ModeloListaHierarquicaItem"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
   /documentos/{sigla}/modelos-para-incluir:
     get:
       summary: Obtem a lista de modelos que o usuário pode incluir em determinado documento
@@ -2557,7 +2614,7 @@ definitions:
         type: string
 
   ModeloItem:
-    description: Lista modelos disponíveis
+    description: Lista modelos disponíveis.
     type: object
     properties:
       idModelo:
@@ -2566,6 +2623,26 @@ definitions:
         type: string
       descr:
         type: string
+
+  ModeloListaHierarquicaItem:
+    description: Lista hierárquica de modelos disponíveis.
+    type: object
+    properties:        
+      idModelo:
+        type: string
+      nome:
+        type: string
+      descr:
+        type: string
+      level:
+        type: integer
+        format: int64
+      keywords:
+        type: string
+      group:
+        type: boolean
+      selected:
+        type: boolean
 
   ClassificacaoItem:
     description: Lista classificações documentais disponíveis


### PR DESCRIPTION
Passa a salvar a lista de modelos da tela de criação de documentos no browser do usuário em session storage evitando chamadas ao servidor. 

Só faz a chamada se mudar a query string da URL (para os casos de inclusão de documentos em processos ou autuando) ou se expirar o tempo (default: uma hora). Este tempo é parametrizável na property "siga.session.modelos.tempo.expiracao" .

Na session storage do browser, foram criadas as chaves:

- modelos<usuário> : lista de modelos obtida pela última vez no servidor.
- lastQry<usuário> : última query string passada na chamada do webservice GET /modelos/lista-hierarquica
- timeoutModelos<usuário> : data/hora da última chamada do webservice.

Criado o WS GET /modelos/lista-hierarquica para trazer a lista de modelos no formato necessário (grupo e modelos).

Resolves #1853 