### PR TITLE
GOVSP67783* - WS GET /documentos/sigla - mostrar ação de receber documentos

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGet.java
@@ -17,6 +17,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
+import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExDocumento;
@@ -50,7 +51,8 @@ public class DocumentosSiglaGet implements IDocumentosSiglaGet {
 		}
 
 		// Recebimento automático
-		if (Ex.getInstance().getComp().deveReceberEletronico(titular, lotaTitular, mob)) {
+		if (Prop.getBool("recebimento.automatico") 
+				&& Ex.getInstance().getComp().deveReceberEletronico(titular, lotaTitular, mob)) {
 			try {
 				Ex.getInstance().getBL().receber(cadastrante, lotaTitular, mob, new Date());
 			} catch (Exception e) {


### PR DESCRIPTION
Ocorria que estava realizando o recebimento automático, sem verificar a property 'recebimento.automatico' que estava como false no ambiente. Passa a verificar após esta correção.

Resolves #1853 