### PR TITLE
66164* - Exibir conteúdo no acompanhamento de protoc. do doc filho

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -263,5 +263,10 @@ public class Prop {
 		 * armazenado em session storage no browser do usuário.
 		 * */
 		provider.addPublicProperty("/siga.session.modelos.tempo.expiracao", "60");
+		/* Tela de Acompanhamento de Protocolo: Se true, mostra conteúdo de um despacho no acompanhamento de protocolo 
+		 * mesmo que seja no caso de protocolo gerado no documento filho. Deve estar disponibilizado pela função 
+		 * "Disponibilizar no acompanhamento de protocolo".
+		 * */
+		provider.addPublicProperty("/sigaex.protocolo.exibe.despacho", "false");
 	}
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -2318,6 +2318,16 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return false;
 	}
 	
+	/**
+	 * Verifica se sempre deve exibir o conteudo do despacho no histórico do acompanhamento do protocolo,
+	 * independente de ser um acompanhamento de protocolo gerado no documento filho de um processo
+	 * @return
+	 */
+	public boolean deveExibirDespachoNoAcompanhamento() {
+		return Ex.getInstance().getComp()
+				.deveExibirDespachoNoAcompanhamentoDoProtocolo(this.getDoc());
+	}
+	
 	public PessoaLotacaoParser getAtendente() {
 		DpPessoa resp = doc().getCadastrante();
 		DpLotacao lotaResp = doc().getLotaCadastrante();

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -4943,6 +4943,11 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 					CpTipoConfiguracao.TIPO_CONFIG_MOVIMENTAR, null, null, null, null, null, null);
 	}
 		
+	public boolean deveExibirDespachoNoAcompanhamentoDoProtocolo(final ExDocumento doc) {
+		return Prop.getBool("/sigaex.protocolo.exibe.despacho")
+				&& doc.getExFormaDocumento().getDescricao().contains("Despacho");
+	}
+		
 	public boolean podePublicarPortalTransparencia(final DpPessoa cadastrante,
 			final DpLotacao lotacao, final ExMobil mob) {
 		

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaHtmlGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaHtmlGet.java
@@ -47,13 +47,15 @@ public class DocumentosSiglaHtmlGet implements IDocumentosSiglaHtmlGet {
 			String n = verifyJwtToken(jwt).get("n").toString();
 			ExProtocolo protocolo = ExDao.getInstance().obterProtocoloPorCodigo(n);
 			ExDocumento docPai = protocolo.getExDocumento();
-			if (!(docPai.getIdDoc() == mob.getExMobilPai().getDoc().getIdDoc() && mob.podeExibirNoAcompanhamento())) {
+			if (!((docPai.getIdDoc() == mob.getExMobilPai().getDoc().getIdDoc() 
+						|| mob.deveExibirDespachoNoAcompanhamento())
+					&& mob.podeExibirNoAcompanhamento())) {
 				throw new SwaggerException("Documento não permitido para visualização: " + req.sigla, 403, null, req,
 						resp, null);
 			}
 		} else {
 			ctx.buscarEValidarUsuarioLogado();
-			ctx.assertAcesso("");
+			ctx.assertAcesso(mob, ctx.getCadastrante(), ctx.getCadastrante().getLotacao());
 		}
 		ExDocumento doc = mob.doc();
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -237,6 +237,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 
 		addPublicProperty("modelos.cabecalho.titulo", "PODER JUDICIÁRIO");
 		addPublicProperty("modelos.cabecalho.subtitulo", null);
+		addPublicProperty("protocolo.exibe.despacho", "false");
 
 		// Siga-Le
 		addPublicProperty("smtp.sugestao.destinatario", getProp("/siga.smtp.usuario.remetente"));

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExProcessoAutenticacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExProcessoAutenticacaoController.java
@@ -189,7 +189,8 @@ public class ExProcessoAutenticacaoController extends ExController {
 			if (mob == null) {
 				throw new AplicacaoException("Documento não encontrado: " + sigla);
 			}
-			if (!(idDocPai == mob.getExMobilPai().getDoc().getIdDoc()
+			if (!((idDocPai == mob.getExMobilPai().getDoc().getIdDoc()
+						|| mob.deveExibirDespachoNoAcompanhamento())
 					&& mob.podeExibirNoAcompanhamento())) {
 				throw new AplicacaoException("Documento não permitido para visualização: " + sigla);
 			}
@@ -343,6 +344,7 @@ public class ExProcessoAutenticacaoController extends ExController {
 			result.include("msg", exDocumentoDTO.getMsg());
 			result.include("docVO", docVO);
 			result.include("mob", exDocumentoDTO.getMob());
+			result.include("isProtocoloFilho", (idMovJuntada != null ? true : false));
 
 		}
 	}

--- a/sigaex/src/main/webapp/WEB-INF/page/exProcessoAutenticacao/processoArquivoAutenticado.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exProcessoAutenticacao/processoArquivoAutenticado.jsp
@@ -134,8 +134,9 @@
 														<c:choose>
 															<c:when test="${m.sigla ne mov.exMobil.sigla}">
 																${mov.exMobil}
-																<c:if test="${m.sigla == mov.exMobil.exMobilPai.sigla 
-																				&& mov.exMobil.podeExibirNoAcompanhamento()}">
+																<c:if test="${(((not isProtocoloFilho) 
+																			or (mov.exMobil.deveExibirDespachoNoAcompanhamento())) 
+																		and (mov.exMobil.podeExibirNoAcompanhamento()))}">
 																	&nbsp<a class="showConteudoDoc link-btn btn btn-sm btn-light" href="#" 
 																		onclick="popitup('/sigaex/public/app/processoArquivoAutenticado_stream?sigla=${mov.exMobil}');"
 																		rel="popover" data-title="${mov.exMobil}" 


### PR DESCRIPTION
Se a property "sigaex.protocolo.exibe.despacho" estiver setada true, exibe o conteúdo do despacho no acompanhamento de protocolo mesmo se a geração do protocolo for no documento filho.

Exemplo:

Foi criado um documento capturado, autenticado e gerado o protocolo de acompanhamento deste.

No acompanhamento de protocolo deste documento aparecerá o seguinte histórico:
![image](https://user-images.githubusercontent.com/49542320/121717537-ac17d100-cab7-11eb-967f-62a3c07a5d30.png)

Foi juntado este documento com um outro documento pai e em seguida incluído um despacho com disponibilização do conteúdo no acompanhamento de protocolo.

![image](https://user-images.githubusercontent.com/49542320/121718145-57c12100-cab8-11eb-8871-7f7fd86161bb.png)


Ao clicar no documento pai (STA-EXP-2021/00016-A), o histórico deste é exibido. Se a property "sigaex.protocolo.exibe.despacho" for igual a "true", o despacho terá o botão "Ver" e será possível visualizar o conteúdo deste.

![image](https://user-images.githubusercontent.com/49542320/121718294-89d28300-cab8-11eb-9425-bdaa280dbd83.png)


closes #1867 