### PR TITLE
GOVSP70313 - Arquivos Auxiliares - O sistema não deve restringir a inclusão de arquivos em ".pdf" - Adequar a mensagem de acordo com o que já existe no manual #1875

### DIFF
--- a/siga-cp/src/main/resources/messages_GOVSP.properties
+++ b/siga-cp/src/main/resources/messages_GOVSP.properties
@@ -52,6 +52,7 @@ documento.vinculacao=Acompanhamento do Documento
 documento.filho=Juntado
 documento.publicar.portaltransparencia=Publicar no Portal da Transparência
 documento.publicar.portaltransparencia.texto=Governo Aberto SP é uma iniciativa do Governo do Estado de São Paulo, de disponibilização, através da internet, de documentos, informações e dados governamentais de domínio público para a livre utilização pela sociedade, garantindo à mesma, acesso aos dados primários, de forma que possam ser reutilizados produzindo novas informações e aplicações digitais para a sociedade.
+documento.arquivoAuxiliar.texto=Os arquivos auxiliares não integram o conteúdo oficial do documento, por esse motivo, não são visualizados quando o documento é salvo no formato PDF/A. Os arquivos auxiliares devem ser utilizados somente para o compartilhamento de documentos e informações de caráter acessório ou complementar.
 usuario.lotacao=Unidade
 usuario.lotacoes=Unidades
 usuario.pessoa=Usuário

--- a/siga-cp/src/main/resources/messages_SIGA.properties
+++ b/siga-cp/src/main/resources/messages_SIGA.properties
@@ -52,6 +52,7 @@ documento.vinculacao=Vinculação
 documento.filho=Filho
 documento.publicar.portaltransparencia=Publicar no Portal da Transparência
 documento.publicar.portaltransparencia.texto=Disponibilização de documentos, informações e dados governamentais de domínio público para a livre utilização pela sociedade, garantindo à mesma, acesso aos dados primários, de forma que possam ser reutilizados produzindo novas informações e aplicações digitais para a sociedade.
+documento.arquivoAuxiliar.texto=Esta funcionalidade destina-se à inserção de documento no formato original, equivalente ao que foi inserido em PDF, possibilitando, assim, a edição do arquivo original pelo destinatário e a inserção de nova versão, em PDF, no dossiê do documento ou para fins de consulta posterior, referência, exemplos. O arquivo auxiliar não faz, entretanto, parte do expediente ou processo. Para esse fim, deve ser utilizada a opção "anexar" ou "incluir documento".
 usuario.lotacao=Lota&ccedil;&atilde;o
 usuario.lotacoes=Lota&ccedil;&otilde;es
 usuario.pessoa=Pessoa

--- a/siga-cp/src/main/resources/messages_TRF2.properties
+++ b/siga-cp/src/main/resources/messages_TRF2.properties
@@ -53,6 +53,7 @@ documento.vinculacao=Vinculação
 documento.filho=Filho
 documento.publicar.portaltransparencia=Publicar no Portal da Transparência
 documento.publicar.portaltransparencia.texto=Disponibilização de documentos, informações e dados governamentais de domínio público para a livre utilização pela sociedade, garantindo à mesma, acesso aos dados primários, de forma que possam ser reutilizados produzindo novas informações e aplicações digitais para a sociedade.
+documento.arquivoAuxiliar.texto=Esta funcionalidade destina-se à inserção de documento no formato original, equivalente ao que foi inserido em PDF, possibilitando, assim, a edição do arquivo original pelo destinatário e a inserção de nova versão, em PDF, no dossiê do documento ou para fins de consulta posterior, referência, exemplos. O arquivo auxiliar não faz, entretanto, parte do expediente ou processo. Para esse fim, deve ser utilizada a opção "anexar" ou "incluir documento".
 usuario.lotacao=Lota&ccedil;&atilde;o
 usuario.lotacoes=Lota&ccedil;&otilde;es
 usuario.pessoa=Pessoa

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -237,6 +237,8 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 
 		addPublicProperty("modelos.cabecalho.titulo", "PODER JUDICIÁRIO");
 		addPublicProperty("modelos.cabecalho.subtitulo", null);
+		
+		addPublicProperty("arquivosAuxiliares.extensoes.excecao", ".bat,.exe,.sh,.dll,.pdf");
 
 		// Siga-Le
 		addPublicProperty("smtp.sugestao.destinatario", getProp("/siga.smtp.usuario.remetente"));

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -403,7 +403,7 @@ public class ExMovimentacaoController extends ExController {
 		
 		String fileExtension = arquivo.getFileName().substring(arquivo.getFileName().lastIndexOf("."));
 		
-		if (fileExtension.equals(".bat") || fileExtension.equals(".exe") || fileExtension.equals(".sh") || fileExtension.equals(".dll") || fileExtension.equals(".pdf") ) {
+		if (Prop.get("arquivosAuxiliares.extensoes.excecao").contains(fileExtension)) {
 			throw new AplicacaoException(
 					"Extensão " + fileExtension + " inválida para inclusão do arquivo.");
 		}

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/anexarArquivoAuxiliar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/anexarArquivoAuxiliar.jsp
@@ -6,6 +6,7 @@
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
 <%@ taglib uri="http://localhost/functiontag" prefix="f"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
 <siga:pagina titulo="Anexação de Arquivo Auxiliar">
 
@@ -29,7 +30,7 @@
 					enctype="multipart/form-data" class="form">
 					<input type="hidden" name="postback" value="1" />
 					<input type="hidden" name="sigla" value="${sigla}" />
-					<p class="alert alert-warning"><strong>Atenção!</strong> Esta funcionalidade destina-se à inserção de documento no formato original, equivalente ao que foi inserido em PDF, possibilitando, assim, a edição do arquivo original pelo destinatário e a inserção de nova versão, em PDF, no dossiê do documento ou para fins de consulta posterior, referência, exemplos. O arquivo auxiliar não faz, entretanto, parte do expediente ou processo. Para esse fim, deve ser utilizada a opção "anexar" ou "incluir documento".</p>
+					<p class="alert alert-warning"><strong>Atenção!</strong> <fmt:message key="documento.arquivoAuxiliar.texto"/></p>
 					<div class="row">
 						<div class="col-sm-6">
 							<div class="form-control custom-file">


### PR DESCRIPTION
- Criado uma property para informar quais extensões não podem ser utilizadas nos arquivos auxiliares
- Internacionalizar a mensagem que é apresentada na tela de arquivos auxiliares

Property criada: sigaex.arquivosAuxiliares.extensoes.excecao