### PR TITLE
EX: i18n trâmite em lote e para SP sem restrição de acesso à descrição

### DIFF
--- a/siga-cp/src/main/resources/messages_GOVSP.properties
+++ b/siga-cp/src/main/resources/messages_GOVSP.properties
@@ -95,3 +95,6 @@ marcador.semEfeito.label=Cancelado
 marcador.cancelado.label=Sem efeito
 responsavel.externo=Externo
 responsavel.campo.livre=Campo Livre
+protocolo.transferencia=Protocolo de Tramitação
+documentos.nao.transferidos=Documento(s) Não Tramitado(s)
+documentos.transferidos=Documento(s) Tramitado(s) Com Sucesso

--- a/siga-cp/src/main/resources/messages_SIGA.properties
+++ b/siga-cp/src/main/resources/messages_SIGA.properties
@@ -95,3 +95,6 @@ marcador.semEfeito.label=Sem Efeito
 marcador.cancelado.label=Cancelado
 responsavel.externo=Externo
 responsavel.campo.livre=Campo Livre
+protocolo.transferencia=Protocolo de Transferência
+documentos.nao.transferidos=Documento(s) Não Transferido(s)
+documentos.transferidos=Documento(s) Transferido(s) Com Sucesso

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aGerarProtocoloArqTransf.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aGerarProtocoloArqTransf.jsp
@@ -18,7 +18,7 @@
 	<div class="container-fluid">
 		<div class="card bg-light mb-3">
 			<div class="card-header">
-				<h5>Protocolo de Transferência</h5>
+				<h5><fmt:message key='protocolo.transferencia' /></h5>
 			</div>
 
 			<div class="card-body">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirLote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirLote.jsp
@@ -233,7 +233,16 @@
 												<td class="text-center"></td>
 												<td class="text-center"></td>
 											</c:if>
-											<td>${f:descricaoConfidencial(documento.doc, lotaTitular)}</td>
+											<td>
+												<c:choose>
+													<c:when test="${siga_cliente == 'GOVSP'}">
+														${documento.doc.descrDocumento}
+													</c:when>
+													<c:otherwise>
+														${f:descricaoConfidencial(documento.doc, lotaTitular)}
+													</c:otherwise>
+												</c:choose>
+											</td>
 										</tr>
 									</siga:paginador>
 								</tbody>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirLoteGravar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirLoteGravar.jsp
@@ -17,7 +17,7 @@
 	<div class="container-fluid">
 		<div class="card bg-light mb-3">
 			<div class="card-header">
-				<h5>Protocolo de Transferência</h5>
+				<h5><fmt:message key='protocolo.transferencia' /></h5>
 			</div>
 
 			<div class="card-body">
@@ -41,7 +41,7 @@
 		</div>
 		<div class="card bg-light mb-3">
 			<div class="card-header">
-				<h5>Documento(s) Não Transferido(s)</h5>
+				<h5><fmt:message key='documentos.nao.transferidos' /></h5>
 			</div>
 
 			<div class="card-body">
@@ -79,7 +79,7 @@
 			<input type="hidden" name="itens" value="${itens[1]}" />
 			<div class="card bg-light mb-3">
 				<div class="card-header">
-					<h5>Documento(s) Transferido(s) Com Sucesso</h5>
+					<h5><fmt:message key='documentos.transferidos' /></h5>
 				</div>
 
 				<div class="card-body">
@@ -169,9 +169,16 @@
 										<td></td>
 										<td></td>
 									</c:if>
-								<td class="text-left">
-									${f:descricaoConfidencial(documento[0], lotaTitular)}
-								</td>
+									<td class="text-left">
+										<c:choose>
+											<c:when test="${siga_cliente == 'GOVSP'}">
+												${documento[0].descrDocumento}
+											</c:when>
+											<c:otherwise>
+												${f:descricaoConfidencial(documento[0], lotaTitular)}
+											</c:otherwise>
+										</c:choose>
+									</td>
 							</tr>
 						</c:forEach>
 					</table>


### PR DESCRIPTION
Realizada a internacionalização da rotina de trâmite em lote.
Retirada a restrição de visualização da descrição do documento para GOVSP, seguindo os moldes de outras telas.
Mantida a função f:descricaoConfidencial para demais órgão, embora a tela de pesquisa utilize a f:descricaoSePuderAcessar

Para diferente de SP, mantém as rotinas iguais:
![image](https://user-images.githubusercontent.com/20362170/122438736-68b6da00-cf71-11eb-8c9a-cd57720dbe54.png)

Para SP, substitui os termos e deixa a descrição aberta sem restrição conforme solicitação:
![image](https://user-images.githubusercontent.com/20362170/122438828-8126f480-cf71-11eb-9773-ef6c6664d9d3.png)
