### PR TITLE
66472* Permitir pesquisa por modelos proibidos na tela "Criar Novo"

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5992,12 +5992,14 @@ public class ExBL extends CpBL {
 			}
 			modeloSetFinal = provSet;
 		} else {
-			provSet = new ArrayList<ExModelo>();
-			for (ExModelo mod : modeloSetFinal)
-				if (getConf().podePorConfiguracao(titular, lotaTitular, mod,
-						CpTipoConfiguracao.TIPO_CONFIG_CRIAR_COMO_NOVO))
-					provSet.add(mod);
-			modeloSetFinal = provSet;
+			if (protegido) {
+				provSet = new ArrayList<ExModelo>();
+				for (ExModelo mod : modeloSetFinal)
+					if (getConf().podePorConfiguracao(titular, lotaTitular, mod,
+							CpTipoConfiguracao.TIPO_CONFIG_CRIAR_COMO_NOVO))
+						provSet.add(mod);
+				modeloSetFinal = provSet;
+			}
 		}
 
 		if (autuando) {


### PR DESCRIPTION
Listar modelos que estiverem com a configuração "Criar Como Novo" / "Não Pode" nos combos de modelos das telas de pesquisa/configuração.

Esta configuração criada por GOVSP bloqueia a criação de documentos de um determinado modelo na tela de "Criar Novo", possibilitando somente a criação via botão "Incluir Documento" onde o documento é criado e juntado automaticamente.