### PR TITLE
GOVSP68801* Prazo para todos assinarem um documento

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
@@ -171,6 +171,10 @@ public enum CpMarcadorEnum {
 	//
 	PORTAL_TRANSPARENCIA(73, "Portal da Transparência", "fas fa-globe", "", CpMarcadorGrupoEnum.NENHUM),
 	//
+	PRAZO_DE_ASSINATURA_EXPIRADO(74, "Prazo de Assinatura Expirado", "fas fa-user-clock", "", CpMarcadorGrupoEnum.ALERTA),
+	//
+	ASSINADO(75, "Assinado", "fas fa-certificate", "", CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
+	//
 	URGENTE(1000, "Urgente", "fas fa-bomb", "", CpMarcadorGrupoEnum.ALERTA),
 
 	//

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V112_0__Marcador_prazo_de_assinatura_expirado.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V112_0__Marcador_prazo_de_assinatura_expirado.sql
@@ -1,0 +1,10 @@
+-- Inclusão do marcador Prazo de Assinatura Expirado e Assinado
+--
+Insert into corporativo.cp_marcador (id_marcador, descr_marcador, id_finalidade_marcador, ord_marcador, grupo_marcador,
+		id_cor, id_icone, his_id_ini, his_dt_ini, his_idc_ini, his_ativo, listavel_pesquisa_default) 
+    values (74, 'Prazo de Assinatura Expirado', 1, 250, 2,
+    	1, 25, 74, CURRENT_TIMESTAMP, 1, 1, 1);
+Insert into corporativo.cp_marcador (id_marcador, descr_marcador, id_finalidade_marcador, ord_marcador, grupo_marcador,
+		id_cor, id_icone, his_id_ini, his_dt_ini, his_idc_ini, his_ativo, listavel_pesquisa_default) 
+    values (75, 'Assinado', 1, 260, 7,
+    	1, 20, 75, CURRENT_TIMESTAMP, 1, 1, 1);

--- a/siga-cp/src/main/resources/db/mysql/sigacp/V112.0__Marcador_prazo_de_assinatura_expirado.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V112.0__Marcador_prazo_de_assinatura_expirado.sql
@@ -1,0 +1,10 @@
+-- Inclusão do marcador Prazo de Assinatura Expirado e Assinado
+--
+Insert into corporativo.cp_marcador (id_marcador, descr_marcador, id_finalidade_marcador, ord_marcador, grupo_marcador,
+		id_cor, id_icone, his_id_ini, his_dt_ini, his_idc_ini, his_ativo, listavel_pesquisa_default) 
+    values (74, 'Prazo de Assinatura Expirado', 1, 250, 2,
+    	1, 25, 74, CURRENT_TIMESTAMP, 1, 1, 1);
+Insert into corporativo.cp_marcador (id_marcador, descr_marcador, id_finalidade_marcador, ord_marcador, grupo_marcador,
+		id_cor, id_icone, his_id_ini, his_dt_ini, his_idc_ini, his_ativo, listavel_pesquisa_default) 
+    values (75, 'Assinado', 1, 260, 7,
+    	1, 20, 75, CURRENT_TIMESTAMP, 1, 1, 1);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
@@ -26,6 +26,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Calendar;
@@ -2964,5 +2967,54 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 		return this.getExFormaDocumento()
 				.getDescricao().contains("Despacho");
 	}
+
+	/**
+	 * Verifica se o prazo para todos assinarem o documento está vencido.
+	 */
+	public boolean isPrazoDeAssinaturaVencido() {
+		Date dtNow = ExDao.getInstance().consultarDataEHoraDoServidor();
+		ExMovimentacao mov = getMovPrazoDeAssinatura();
+
+		if (mov != null && mov.getDtParam1().before(dtNow)) 
+			return true;
+		return false;
+	}
+
+	/**
+	 * Obtem a movimentação de definição de prazo de assinatura.
+	 */
+	public ExMovimentacao getMovPrazoDeAssinatura() {
+		final Set<ExMovimentacao> movs = getMobilGeral().getExMovimentacaoSet();
+
+		if(movs != null)
+			for (final ExMovimentacao mov : movs) {
+				if (!mov.isCancelada()
+						&& mov.getExTipoMovimentacao().getIdTpMov() == ExTipoMovimentacao.TIPO_MOVIMENTACAO_PRAZO_ASSINATURA)
+					return mov;
+			}
+		return null;
+	}
 	
+	/**
+	 * Retorna a data do prazo de assinatura no formato dd/mm/aaaa hh:mm.
+	 */
+	public Date getDtPrazoDeAssinatura() {
+		ExMovimentacao mov = getMovPrazoDeAssinatura();
+		if (mov != null) {
+			return new Date(mov.getDtParam1().getTime());
+		}
+		return null;
+	}
+	/**
+	 * Retorna a data do prazo de assinatura no formato dd/mm/aaaa hh:mm.
+	 */
+	public String getDtPrazoDeAssinaturaDDMMYYYYHHMM() {
+		Date dt = getDtPrazoDeAssinatura();
+		if (dt != null) {
+	        LocalDateTime localDateTime = LocalDateTime.ofInstant(dt.toInstant(), ZoneId.systemDefault());
+			DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+			return localDateTime.format(fmt);
+		}
+		return "";
+	}
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExTipoMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExTipoMovimentacao.java
@@ -211,6 +211,8 @@ public class ExTipoMovimentacao extends AbstractExTipoMovimentacao implements Se
 	
 	final static public long TIPO_MOVIMENTACAO_EXIBIR_NO_ACOMPANHAMENTO_DO_PROTOCOLO = 79;
 	
+	final static public long TIPO_MOVIMENTACAO_PRAZO_ASSINATURA = 81;
+	
 	public static boolean hasDespacho(long id) {
 		return id == ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO
 				|| id == ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_INTERNO

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -1273,7 +1273,8 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 								titular,
 								lotaTitular,
 								ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO,
-								ExTipoDeConfiguracao.MOVIMENTAR);
+								ExTipoDeConfiguracao.MOVIMENTAR)
+				&& !mob.getDoc().isPrazoDeAssinaturaVencido();
 	}
 	
 	/*
@@ -1293,7 +1294,8 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 
 		return getConf().podePorConfiguracao(null, null, null, null, mob.doc().getExFormaDocumento(), mob.doc().getExModelo(), null,
 				null, exTpMov, null, null, null, lotaTitular, titular, null,null,
-				ExTipoDeConfiguracao.MOVIMENTAR);
+				ExTipoDeConfiguracao.MOVIMENTAR)
+			&& !mob.getDoc().isPrazoDeAssinaturaVencido();
 	}
 	
 	
@@ -3241,6 +3243,43 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 	}
 
 	/**
+	 * Retorna se é possível cancelar ou alterar uma movimentação de definição de prazo de assinatura,
+	 * passada através do parâmetro mov. As regras são as seguintes:
+	 * <ul>
+	 * <li>A movimentação não pode estar cancelada</li>
+	 * <li>Se o documento estiver assinado, só o subscritor pode cancelar. Caso contrário, só o cadastrante.</li>
+	 * <li>Não pode haver configuração impeditiva. Tipo de configuração:
+	 * Cancelar Movimentação</li>
+	 * </ul>
+	 * 
+	 * @param titular
+	 * @param subscritor
+	 * @param mob
+	 * @param mov
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean podeCancelarOuAlterarPrazoDeAssinatura(final DpPessoa titular,
+			final DpLotacao lotaTitular, final ExMobil mob,
+			final ExMovimentacao mov) {
+
+		if (mov.isCancelada())
+			return false;
+		
+		if (mob.getDoc().isAssinadoPeloSubscritorComTokenOuSenha()) {
+			if (mob.getDoc().getSubscritor() != null && !mob.getDoc().getSubscritor().equivale(titular))
+				return false;
+		} else {
+			if (mov.getCadastrante() != null && !mov.getCadastrante().equivale(titular))
+				return false;
+		}
+
+		return getConf().podePorConfiguracao(titular, lotaTitular,
+				mov.getIdTpMov(),
+				ExTipoDeConfiguracao.CANCELAR_MOVIMENTACAO);
+	}
+
+	/**
 	 * Retorna se é possível excluir anotação realizada no móbil, passada pelo
 	 * parâmetro mov. As seguintes regras incidem sobre a movimentação a ser
 	 * excluída:
@@ -4999,4 +5038,36 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 	public boolean podeCapturarPDF(final DpPessoa titular, final DpLotacao lotaTitular, final ExMobil mob) {
 		return podeCapturarPDF(titular, lotaTitular, mob, null);
 	}
+	/**
+	 * Retorna se é possível definir um prazo para assinatura do documento, conforme as regras:
+	 * <ul>
+	 * <li>Móbil deve ser geral</li>
+	 * <li>Móbil não pode estar cancelado ou sem efeito ou arquivado</li>
+	 * <li><i>podeMovimentar()</i> tem de ser verdadeiro para o móbil/usuário</li>
+	 * <li>Documento tem de estar pendente de assinatura</li>
+	 * <li>Móbil deve estar finalizado</li>
+	 * <li>Não pode haver configuração impeditiva</li>
+	 * </ul>
+	 * 
+	 * @param titular
+	 * @param lotaTitular
+	 * @param mob
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean podeDefinirPrazoAssinatura(DpPessoa titular, DpLotacao lotaTitular,
+			ExMobil mob) {
+
+		return mob.isGeral()
+				&& !mob.isCancelada()
+				&& !mob.doc().isSemEfeito()
+				&& !mob.isArquivado()
+				&& !mob.isSobrestado()
+				&& mob.doc().isFinalizado()
+				&& mob.doc().isPendenteDeAssinatura()
+				&& getConf().podePorConfiguracao(titular, lotaTitular, titular.getCargo(), titular.getFuncaoConfianca(), mob.doc().getExFormaDocumento(), mob.doc().getExModelo(), 
+						ExTipoMovimentacao.TIPO_MOVIMENTACAO_PRAZO_ASSINATURA,
+						ExTipoDeConfiguracao.MOVIMENTAR);
+	}
+
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -546,6 +546,9 @@ public class ExMobilVO extends ExVO {
 		addAcao("link_add", "Apensar", "/app/expediente/mov", "apensar", Ex
 				.getInstance().getComp().podeApensar(titular, lotaTitular, mob));
 
+		addAcao("date_previous", "Atribuir Prazo de Assinatura", "/app/expediente/mov", "definir_prazo_assinatura", Ex
+				.getInstance().getComp().podeDefinirPrazoAssinatura(titular, lotaTitular, mob));
+
 		// Não aparece a opção de Cancelar Movimentação para documentos
 		// temporários
 		

--- a/siga-ex/src/main/resources/db/migration/SIGA_UTF8_V101_0__inclusao_tipo_mov_prazo_assinatura.sql
+++ b/siga-ex/src/main/resources/db/migration/SIGA_UTF8_V101_0__inclusao_tipo_mov_prazo_assinatura.sql
@@ -1,0 +1,5 @@
+--------------------------------------------------------------------------------------------------
+--  Criação do Tipo de Movimentação: Prazo para Assinatura 
+--  Permite definir um prazo para todos assinarem um documento
+--------------------------------------------------------------------------------------------------
+insert into siga.ex_tipo_movimentacao (id_tp_mov, DESCR_TIPO_MOVIMENTACAO) values (81, 'Prazo para Assinatura');

--- a/siga-ex/src/main/resources/db/mysql/sigaex/V101.0__inclusao_tipo_mov_prazo_assinatura.sql
+++ b/siga-ex/src/main/resources/db/mysql/sigaex/V101.0__inclusao_tipo_mov_prazo_assinatura.sql
@@ -1,0 +1,5 @@
+--------------------------------------------------------------------------------------------------
+--  Criação do Tipo de Movimentação: Prazo para Assinatura 
+--  Permite definir um prazo para todos assinarem um documento
+--------------------------------------------------------------------------------------------------
+insert into siga.ex_tipo_movimentacao (id_tp_mov, DESCR_TIPO_MOVIMENTACAO) values (81, 'Prazo para Assinatura');

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoDTO.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoDTO.java
@@ -228,6 +228,8 @@ public class ExDocumentoDTO {
 
 	private String descrMov;
 	
+	private String dtPrazoAssinaturaString;
+	
 	private List<ExTipoDocumento> tiposDocumento;
 	
 	private List<ExNivelAcesso> listaNivelAcesso;
@@ -1022,6 +1024,14 @@ public class ExDocumentoDTO {
     
     public List<ExNivelAcesso> getListaNivelAcesso() {
 		return listaNivelAcesso;
+	}
+
+	public void setDtPrazoAssinaturaString(final String dtPrazoAssinaturaString) {
+		this.dtPrazoAssinaturaString = dtPrazoAssinaturaString;
+	}
+
+	public String getDtPrazoAssinatura() {
+		return dtPrazoAssinaturaString;
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -9,6 +9,11 @@ import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -3794,6 +3799,14 @@ public class ExMovimentacaoController extends ExController {
 						"Não é possível cancelar o documento vinculado.");
 		} else if (mov.getIdTpMov() == ExTipoMovimentacao.TIPO_MOVIMENTACAO_MARCACAO) {
 			ExPodeCancelarMarcacao.afirmar(mov, getTitular(), getLotaTitular());
+		} else if (mov.getIdTpMov() == ExTipoMovimentacao.TIPO_MOVIMENTACAO_PRAZO_ASSINATURA) {
+			if (!Ex.getInstance()
+					.getComp()
+					.podeCancelarOuAlterarPrazoDeAssinatura(getTitular(), 
+							getLotaTitular(), mob, mov))
+				throw new AplicacaoException(
+						"Usuário não permitido a cancelar ou alterar o prazo de assinatura. Se o documento estiver"
+						+ " assinado, deve ser o subscritor; senão deve ser quem cadastrou o prazo.");
 		} else {
 			if (!Ex.getInstance().getComp()
 					.podeCancelar(getTitular(), getLotaTitular(), mob, mov))
@@ -5191,4 +5204,74 @@ public class ExMovimentacaoController extends ExController {
 		ExDocumentoController.redirecionarParaExibir(result, siglaRetorno);
 	}
 	
+	@Get("/app/expediente/mov/definir_prazo_assinatura")
+	public void aDefinirPrazoAssinatura(final String sigla) {
+		final BuscaDocumentoBuilder documentoBuilder = BuscaDocumentoBuilder
+				.novaInstancia().setSigla(sigla);
+//		final ExMovimentacao movimentacao = movimentacaoBuilder
+//				.construir(dao());
+//		
+//		String dtPrazo = movimentacaoBuilder.getDescrMov() == null ? dtPrazo : movimentacaoBuilder.getDescrMov();
+//
+		final ExDocumento doc = buscarDocumento(documentoBuilder);
+		String dtPrazoStr = null;
+		if (doc != null) 
+			dtPrazoStr = doc.getDtPrazoDeAssinaturaDDMMYYYYHHMM();
+		
+		if (!Ex.getInstance()
+				.getComp()
+				.podeDefinirPrazoAssinatura(getTitular(), getLotaTitular(),
+						documentoBuilder.getMob())) {
+			throw new AplicacaoException("Não é permitido definir um prazo para assinatura para o documento.");
+		}	
+		
+		result.include("sigla", sigla);
+		result.include("mob", documentoBuilder.getMob());
+		if (dtPrazoStr != null && dtPrazoStr != "") {
+			result.include("dtPrazoString", dtPrazoStr.split(" ")[0]);
+			result.include("hrPrazoString", dtPrazoStr.split(" ")[1]);
+		}
+	}
+
+	@Transacional
+	@Post("/app/expediente/mov/definir_prazo_assinatura_gravar")
+	public void aDefinirPrazoAssinaturaGravar(final String sigla, String dtPrazoString, String hrPrazoString) {					
+		final BuscaDocumentoBuilder documentoBuilder = BuscaDocumentoBuilder
+				.novaInstancia().setSigla(sigla);
+		final ExDocumento documento = buscarDocumento(documentoBuilder);
+
+		Date dthrPrazo;
+		if (dtPrazoString != null) {
+			try {
+				DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+				LocalDateTime localDate = LocalDateTime.parse(dtPrazoString + (hrPrazoString != null ? " " + hrPrazoString : " 00:00"), fmt);
+				if (localDate.isBefore(LocalDateTime.now())) {
+					throw new AplicacaoException(
+							"Data de devolução não pode ser anterior à data de hoje: " + dtPrazoString);
+				}
+				dthrPrazo = Date.from(localDate.atZone(ZoneId.systemDefault()).toInstant()); 
+			} catch (DateTimeParseException e) {
+				throw new AplicacaoException("Data ou hora de Devolução inválida: " + dtPrazoString 
+					+ (hrPrazoString != null ? " " + hrPrazoString : ""));
+			}
+		} else {
+			throw new AplicacaoException("Data do prazo não foi informada.");
+		}
+		
+		try {	
+			Ex.getInstance()
+					.getBL()
+					.definirPrazoAssinatura(getTitular(), getLotaTitular(),
+							documento, getTitular(), dthrPrazo);
+	
+		} catch (RegraNegocioException | AplicacaoException e) {
+			result.include(SigaModal.ALERTA, SigaModal.mensagem(e.getMessage()));
+//			ExDocumentoController.redirecionarParaExibir(result, sigla);
+		}
+
+		result.include("dtPrazoString", dtPrazoString);
+		result.include("hrPrazoString", hrPrazoString);
+		ExDocumentoController.redirecionarParaExibir(result, sigla);
+	}
+
 }

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -1074,6 +1074,14 @@
 								 		- ${m.tamanhoDeArquivo}
 									</c:if>
 								</p>
+								<c:if test="${not empty docVO.dtPrazoDeAssinatura}">
+									<div>
+										<span>Prazo de Assinatura: ${docVO.dtPrazoDeAssinatura}</span>
+										<a class="float-right ${marca.exMovimentacao.podeCancelarOuAlterarPrazoDeAssinatura(titular, lotaTitular, m.mob, docVO.doc.movPrazoDeAssinatura)? '' : 'disabled' }" 
+										href="javascript:postToUrl('/sigaex/app/expediente/mov/cancelar_movimentacao_gravar?id=${docVO.doc.movPrazoDeAssinatura.idMov}&sigla=${docVO.doc.movPrazoDeAssinatura.exMobil.sigla}')" 
+											><i class="far fa-trash-alt"></i></a>
+									</div>
+								</c:if>
 							</tags:collapse>
 						</div>
 					</c:if>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aDefinirPrazoAssinatura.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aDefinirPrazoAssinatura.jsp
@@ -1,0 +1,67 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	buffer="64kb"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+<%@ taglib uri="http://localhost/customtag" prefix="tags"%>
+<%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
+
+<siga:pagina titulo="Atribuir Prazo para Assinatura">
+	<div class="container-fluid content" id="page">
+
+		<c:if test="${not mob.doc.eletronico}">
+			<script type="text/javascript">
+				$("html").addClass("fisico");
+				$("body").addClass("fisico");
+			</script>
+		</c:if>
+
+		<script type="text/javascript" language="Javascript1.1">
+			function sbmt() {
+				sigaSpinner.mostrar();
+		        document.getElementById('btnSubmit').disabled = true;
+		        sigladoc = "${sigla}".replace('-', '');
+                frm.action = 'definir_prazo_assinatura_gravar?sigla=' + sigladoc.replace('/', '') + '&dtPrazo=' + $('#dtPrazo').val() + '&hrPrazo=' + $('#hrPrazo').val();
+	            frm.method = 'POST';
+	            frm.submit();
+	        }
+		</script>
+
+	<!-- main content bootstrap -->
+	<div class="container-fluid">
+		<div class="card bg-light mb-3">
+			<div class="card-header">
+				<h5>
+					Atribuir Prazo para Assinatura - ${mob.siglaEDescricaoCompleta}
+				</h5>
+			</div>
+			<div class="card-body">
+				<form name="frm" action="definir_prazo_assinatura_gravar" method="post">
+					<input type="hidden" name="postback" value="1" /> 
+					<div class="row">
+						<div class="col-6 col-md-4">
+							<div class="form-group">
+								<label for="dtPrazoString">Prazo Final:</label> 
+								<input type="text" id="dtPrazoString" name="dtPrazoString" onblur="javascript:verifica_data(this,0);" 
+									value="${dtPrazoString}" class="form-control campoData" placeholder="dd/mm/aaaa" autocomplete="off"/>
+							</div>
+						</div>
+						<div class="col-6 col-md-3">
+							<div class="form-group">
+								<label for="hrPrazoString">Hora Final:</label> 
+								<input id="hrPrazoString" name="hrPrazoString" class="form-control"
+									onblur="verifica_hora(this,0);" maxlength="5" placeholder="hh:mm" value="${hrPrazoString}" /></input>
+							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-sm">
+							<input id="btnSubmit" type="button" value="Ok" class="btn btn-primary" onclick="sbmt();" />			
+							<a href="${linkTo[ExDocumentoController].exibe()}?sigla=${sigla}" class="btn btn-cancel ml-2">Cancela</a>														 												
+						</div>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+</siga:pagina>


### PR DESCRIPTION
Esta alteração possibilita definir um prazo para a assinatura de todos os signatários de um documento.

Para liberar esta funcionalidade, cadastrar a configuração "Movimentar/Prazo para assinatura" como "Pode" para a espécie/modelo/pessoa/lotação desejada.

Ao finalizar o documento, aparecerá o botão "Atribuir Prazo de Assinatura":
![image](https://user-images.githubusercontent.com/49542320/128543453-9f5b8e8f-4862-4255-abde-78ce99e55b61.png)

Ao clicar no botão, será possível definir a data/hora do prazo de assinatura:
![image](https://user-images.githubusercontent.com/49542320/128543557-dc6880a0-b0e9-4904-b472-8848bab28b76.png)

Para o controle de marcas do documento, foram utilizadas as data início e fim das marcas. Então se houver a movimentação de prazo da assinatura, as marcas de "Pendente de Assinatura", "Como Subscritor" e "Revisar" são geradas com uma data fim, desaparecendo do documento nesta data.

Uma marca "Prazo de Assinatura Expirado" é criada com uma data início na data do prazo, aparecendo no documento ao atingir a data.

Quando todos assinarem o documento, uma marca "Assinado" é criado para o mesmo. Ao tramitar, a marca passa a ser "Aguardando Andamento" como era antes.

O prazo pode ser alterado ou cancelado pelo cadastrante até o documento ser assinado. Após assinado, só o subscritor pode aterar/cancelar o prazo. Para possibilitar o cancelamento, é necessário configurar "Cancelar Movimentação / Prazo para Assinatura / Pode".