### PR TITLE
RM76362 Permitir WS GET /lotacao/sigla pesquisar sem prefixo do órgão

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpLotacao.java
@@ -189,6 +189,14 @@ public class DpLotacao extends AbstractDpLotacao implements Serializable,
 		}
 	}
 
+	public void setSiglaSemOrgao(String sigla) {
+		if (sigla == null) {
+			setSiglaLotacao("");
+			return;
+		}
+		setSiglaLotacao(sigla.toUpperCase());
+	}
+
 	/*
 	 * public String getSiglaLotacao() { if (getOrgaoUsuario() != null) return
 	 * getOrgaoUsuario().getAcronimoOrgaoUsu() + "/" + super.getSiglaLotacao();

--- a/siga/src/main/java/br/gov/jfrj/siga/api/v1/ISigaApiV1.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/api/v1/ISigaApiV1.java
@@ -249,6 +249,7 @@ public interface ISigaApiV1 {
 	public interface ILotacoesSiglaGet extends ISwaggerMethod {
 		public static class Request implements ISwaggerRequest {
 			public String sigla;
+			public Boolean pesquisarSemOrgao;
 		}
 
 		public static class Response implements ISwaggerResponse {

--- a/siga/src/main/java/br/gov/jfrj/siga/api/v1/LotacoesSiglaGet.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/api/v1/LotacoesSiglaGet.java
@@ -18,7 +18,13 @@ public class LotacoesSiglaGet implements ILotacoesSiglaGet {
 			throw new SwaggerException("O parâmetro sigla é obrigatório.", 400, null, req, resp, null);
 
 		final DpLotacao flt = new DpLotacao();
-		flt.setSigla(req.sigla.toUpperCase());
+		if (req.pesquisarSemOrgao != null && req.pesquisarSemOrgao)
+			// Se true, assume que não vai ter sigla do orgao como prefixo
+			flt.setSiglaSemOrgao(req.sigla.toUpperCase());
+		else 
+			// Se false, poderá ou não ter sigla do orgao como prefixo
+			flt.setSigla(req.sigla.toUpperCase());
+			
 		DpLotacao lota = CpDao.getInstance().consultarPorSigla(flt);
 		if (lota == null)
 			throw new SwaggerException("Nenhuma lotação foi encontrada contendo a sigla informada.", 404, null, req,

--- a/siga/src/main/resources/br/gov/jfrj/siga/api/v1/swagger.yaml
+++ b/siga/src/main/resources/br/gov/jfrj/siga/api/v1/swagger.yaml
@@ -284,6 +284,12 @@ parameters:
     description: Sigla do órgão
     required: false
     type: string
+  pesquisarSemOrgao:
+    name: pesquisarSemOrgao
+    in: query
+    description: "<ul><li><b>false ou não informado</b> -  Verifica se na sigla há um prefixo que seja igual à sigla de algum órgão cadastrado. Se houver, retira essa sigla da sigla da unidade e pesquisa somente dentro desse órgão. <P>Ex.: Pesquisa pela unidade PGEADV: <ul><li>Se existir um órgão de sigla PGE: irá pesquisar ADV dentro do órgão PGE.</li><li>Se não existir um órgão de sigla PGE: irá pesquisar pela unidade PGEADV.</li></ul></li><li><b>true</b> - Pesquisa da lotação sem a sigla do órgão como prefixo. </li>"
+    required: false
+    type: boolean
     
 
 ################################################################################
@@ -589,12 +595,13 @@ paths:
   /lotacoes/{sigla}:
     get:
       summary: "Pesquisa de lotacoes por sigla"
-      description: "Retorna a lotacao correspondente a sigla pesquisda" 
+      description: "Retorna a lotacao correspondente à sigla pesquisada. Pode ter a sigla do órgão ou não como prefixo, conforme parâmetro pesquisarSemOrgao." 
       tags: [cadastro]
       security:
         - Bearer: []
       parameters:
         - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/pesquisarSemOrgao"
       responses:
         200:
           description: Successful response


### PR DESCRIPTION
No Webservice GET /lotacao/sigla, se a sigla da lotação for 'PGE-ADV' e houver um órgão de sigla 'PGE', ele pesquisará dentro desse órgão a unidade '-ADV' e não irá encontrar.

Foi criado o parâmetro boolean "pesquisarSemOrgao" para permitir a pesquisa sem prever que pode haver o prefixo do órgão:
![image](https://user-images.githubusercontent.com/49542320/129385013-db3b1fa0-88b0-4cbb-8e2d-407a06fed7de.png)

Se não for passado (para manter a compatibilidade com chamadas já existentes) ou for false ele irá se comportar da forma atual (pesquisa com prefixo do órgão se existir).

Se for passado true, a pesquisa será somente pela sigla informada.

closes #1924 