### PR TITLE
RM76362 - Permite pesquisa da lotação com a sigla do órgão ou sem

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
@@ -58,8 +58,9 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 
 		@NamedQuery(name = "consultarPorIdDpLotacao", query = "select lot from DpLotacao lot where lot.idLotacao = :idLotacao"),
 		@NamedQuery(name = "consultarPorSiglaDpLotacao", query = "select lot from DpLotacao lot where"
-				+ "      upper(lot.siglaLotacao) = upper(:siglaLotacao)"
-				+ "      and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"
+				+ "      ((lot.siglaLotacao = upper(:siglaLotacao)"
+				+ "      and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu))"
+				+ "      or (:siglaOrgaoLotacao is not null and lot.siglaLotacao = upper(:siglaOrgaoLotacao)))"
 				+ "	     and lot.dataFimLotacao = null"),
 		@NamedQuery(name = "consultarPorSiglaDpLotacaoComLike", query = "select lot from DpLotacao lot where"
 				+ "        upper(lot.siglaLotacao) like upper('%' || :siglaLotacao || '%') "

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -719,18 +719,26 @@ public class CpDao extends ModeloDao {
 	public DpLotacao consultarPorSigla(final DpLotacao o) {
 		final Query query = em().createNamedQuery("consultarPorSiglaDpLotacao");
 		query.setParameter("siglaLotacao", o.getSiglaLotacao());
-		if (o.getOrgaoUsuario() != null)
-			if (o.getOrgaoUsuario().getIdOrgaoUsu() != null)
+		if (o.getOrgaoUsuario() != null) {
+			// O argumento siglaOrgaoLotacao preve a situação onde a sigla pesquisada contem um prefixo coincidente à 
+			// sigla de um orgão existente que o setSigla() do DpLotacao retirou
+			if (o.getOrgaoUsuario().getIdOrgaoUsu() != null) {
 				query.setParameter("idOrgaoUsu", o.getOrgaoUsuario().getIdOrgaoUsu());
-			else
-				query.setParameter("idOrgaoUsu", consultarPorSigla(o.getOrgaoUsuario()).getId());
-		else
+				query.setParameter("siglaOrgaoLotacao", o.getOrgaoUsuario().getSigla() + o.getSigla());
+			} else {
+				CpOrgaoUsuario org = consultarPorSigla(o.getOrgaoUsuario());
+				query.setParameter("idOrgaoUsu", org.getId());
+				query.setParameter("siglaOrgaoLotacao", org.getSigla() + o.getSigla());
+			}
+		} else {
 			query.setParameter("idOrgaoUsu", 0L);
+			query.setParameter("siglaOrgaoLotacao", null);
+		}
 
 		query.setHint("org.hibernate.cacheable", true);
 		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CONFIGURACAO);
 		final List<DpLotacao> l = query.getResultList();
-		if (l.size() != 1)
+		if (l.size() == 0)
 			return null;
 		return l.get(0);
 	}


### PR DESCRIPTION
Se a uma sigla de uma lotação tinha na sua própria sigla letras que correspondessem a um outro órgão existente, pesquisava somente nesse órgão e não encontrava. No caso do erro, a sigla pesquisada era PGE-ADV, do órgão AE. Existia um órgão de sigla PGE, e o sistema pesquisava -ADV neste órgão.

Alterada a query para que permita a pesquisa com e sem o órgão do prefixo. 
Houve também uma otimização para evitar um uppercase da sigla, que tinha um custo alto de execução no banco.