### PR TITLE
GOVSP78512 - Erro na tela de cadastro de configuração - espécie e modelo

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExConfiguracaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExConfiguracaoController.java
@@ -475,12 +475,6 @@ public class ExConfiguracaoController extends ExController {
 		ExTipoFormaDoc tipoEspecie = c.getExTipoFormaDoc();
 		ExFormaDocumento especie = c.getExFormaDocumento();
 
-		if (c.getExModelo() != null && especie == null)
-			especie = c.getExModelo().getExFormaDocumento();
-
-		if (especie != null && tipoEspecie == null)
-			tipoEspecie = especie.getExTipoFormaDoc();
-
 		if (tipoEspecie != null)
 			result.include("idTpFormaDoc", tipoEspecie.getIdTipoFormaDoc());
 
@@ -488,7 +482,7 @@ public class ExConfiguracaoController extends ExController {
 			result.include("idFormaDoc", especie.getIdFormaDoc());
 
 		if (c.getExModelo() != null)
-			result.include("idMod", c.getExModelo().getIdMod());
+			result.include("idMod", c.getExModelo().getModeloAtual().getId());
 
 		if (c.getExNivelAcesso() != null)
 			result.include("idNivelAcesso", c.getExNivelAcesso().getIdNivelAcesso());

--- a/sigaex/src/main/webapp/WEB-INF/page/exConfiguracao/edita.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exConfiguracao/edita.jsp
@@ -9,40 +9,36 @@
 <siga:cfg-edita>
 	<script type="text/javascript" language="Javascript1.1">
 		$(document).ready(function() {
-			alteraTipoDaForma();
-			setTimeout("alteraForma()", 5000);
+			alteraTipoDaForma('${idTpFormaDoc}', '${idFormaDoc}', false);
+			alteraForma('${idMod}');
 		});
 
-		function alteraTipoDaForma() {
+		function alteraTipoDaForma(idTpForma, idForma, carregaModelos) {
+			sigaSpinner.mostrar();
 			ReplaceInnerHTMLFromAjaxResponse(
 					'${pageContext.request.contextPath}/app/expediente/doc/carregar_lista_formas?tipoForma='
-							+ document.getElementById('tipoForma').value
-							+ '&idFormaDoc=' + '${idFormaDoc}', null, document
+							+ idTpForma + '&idFormaDoc=' + idForma, null, document
 							.getElementById('comboFormaDiv'), function() {
-						transformarEmSelect2(null, '#idFormaDoc',
-								'#idFormaDocGroup');
-						alteraForma()
+						if (carregaModelos) 
+							alteraForma(0);
 					});
 		}
 
-		function alteraForma() {
-			// console.log('altera-forma', document.getElementById('idFormaDoc').value)
-			var especie
+		function alteraForma(idMod) {
+			sigaSpinner.mostrar();
+			var especie = 0
 			var inpEspecie = document.getElementById('idFormaDoc')
 			if (inpEspecie)
-				especie = inpEspecie.value
-			var modelo = '${idMod}'
-			var inpModelo = document.getElementById('idMod')
-			if (inpModelo)
-				modelo = inpModelo.value
-				// if (modelo === undefined)
-				// 	modelo = '';
-
+				especie = inpEspecie.value;
+			var modelo = idMod;
+			if (!idMod)
+				modelo = 0;
 			ReplaceInnerHTMLFromAjaxResponse(
 					'${pageContext.request.contextPath}/app/expediente/doc/carregar_lista_modelos?forma='
 							+ especie + '&idMod=' + modelo, null, document
 							.getElementById('comboModeloDiv'), function() {
 						transformarEmSelect2(null, '#idMod', '#idModGroup')
+						sigaSpinner.ocultar();
 					});
 		}
 	</script>
@@ -125,7 +121,7 @@
 								<siga:select name="idTpFormaDoc" list="tiposFormaDoc"
 									listKey="idTipoFormaDoc" listValue="descTipoFormaDoc"
 									theme="simple" headerKey="0" headerValue="[Indefinido]"
-									onchange="javascript:alteraTipoDaForma();" id="tipoForma"
+									onchange="javascript:alteraTipoDaForma(this.value,0,true);" id="tipoForma"
 									value="${idTpFormaDoc}" />
 							</c:otherwise>
 						</c:choose>
@@ -160,7 +156,8 @@
 												${config.exFormaDocumento.descrFormaDoc}
 											</c:when>
 							<c:otherwise>
-								<div style="display: inline" id="comboModeloDiv"></div>
+								<div style="display: inline" id="comboModeloDiv"></div><small>
+								Se selecionado um modelo, os parâmetros Tipo da Espécie e Espécie serão ignorados ao salvar.</small> 
 							</c:otherwise>
 						</c:choose>
 					</div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaFormas.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aCarregarListaFormas.jsp
@@ -7,7 +7,7 @@
 
 <div class="form-group" id="idFormaDocGroup">
 	<label><fmt:message key="documento.label.especie"/> <span id="idFormaDoc-spinner" class="spinner-border text-secondary d-none"></span></label> 
-	<select class="form-control siga-select2" id="idFormaDoc" name="idFormaDoc" onchange="javascript:alteraForma(false);">
+	<select class="form-control siga-select2" id="idFormaDoc" name="idFormaDoc" onchange="javascript:alteraForma(this.value);">
 		<option value="0">[Todos]</option>
 		<c:forEach items="${todasFormasDocPorTipoForma}" var="item">
 			<option value="${item.idFormaDoc}"


### PR DESCRIPTION
closes #1940 

No ExConfiguracaoController, antes de carregar a tela era setada a espécie de acordo com o modelo e o tipo da espécie de acordo com a espécie, se estes estivessem na configuração editada. Removido este código para trazer sempre o que está no banco. 

O id do modelo trazido era o id inicial, não encontrando na lista de modelos. Convertido para o id do modelo atual.

Alterado o funcionamento da tela para:
- Inicialmente trazer o que está salvo no banco
- Ao alterar o Tipo de Espécie, limpa o que estiver selecionado na espécie e no modelo;
- Ao alterar a Espécie, limpa o que estiver selecionado no modelo.

