### PR TITLE
RM72298 - Melhoria na busca avancada por documentos | Remocao de Obri…

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -35,6 +35,10 @@ public class MontadorQuery implements IMontadorQuery {
 		//Nato: desabilitei este where pois causava muito impacto na velocidade da consulta. Precisamos criar uma variavel denormalizada mais a frente para resolver esse problema.
 		//sbf.append(" where not exists (from ExMovimentacao where exTipoMovimentacao.idTpMov = 10 and (exMobil.idMobil = mob.idMobil ");
 		//sbf.append("    or exMobil.idMobil = (from ExMobil where exTipoMobil.idTipoMobil = 1 and exDocumento.idDoc = mob.exDocumento.idDoc)))");
+		if (flt.getIdMod() != null && flt.getIdMod() != 0) {
+			sbf.append(" INNER JOIN doc.exModelo exMod ");
+		}
+		
 		sbf.append(" where");
 
 		if (flt.getUltMovIdEstadoDoc() != null	&& flt.getUltMovIdEstadoDoc() != 0) {
@@ -178,7 +182,7 @@ public class MontadorQuery implements IMontadorQuery {
 		}
 
 		if (flt.getIdMod() != null && flt.getIdMod() != 0) {
-			sbf.append(" and doc.exModelo.hisIdIni = :hisIdIni");
+			sbf.append(" and exMod.hisIdIni = :hisIdIni");
 		}
 
 		if (!apenasCount) {

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -35,7 +35,6 @@
 
 			if ("${podePesquisarDescricaoLimitada}" === "true") {
 				if ($('#orgaoUsu').val() != 0 && $('#idFormaDoc').find(':selected').val() != "0" 
-						&& $('#idMod').find(':selected').val() != "0" 
 						&& $('#anoEmissaoString').val() != 0) {
 					habilitaDescricao();
 				} else {
@@ -460,7 +459,7 @@
 									</c:if>
 									/>
 									<c:if test="${podePesquisarDescricao && podePesquisarDescricaoLimitada}">
-										<small>Campo "Descrição" habilitado para pesquisa após o preenchimento dos campos "Órgão", "Espécie", "Documento" e "Ano de Emissão"</small>
+										<small>Campo "Descrição" habilitado para pesquisa após o preenchimento dos campos "Órgão", "Espécie" e "Ano de Emissão"</small>
 									</c:if>
 							</div>
 						</div>


### PR DESCRIPTION
Melhoria na busca avançada por documentos, onde anteriormente na busca, o Hibernate estava gerando uma query com CROSS JOIN siga.ex_modelo, diminuindo a performance da busca no banco, exemplo abaixo:
/*HQL do Hibernate*/
SELECT
	label.idMarca
FROM
	ExMarca label
INNER JOIN label.cpMarcador marcador
INNER JOIN label.exMobil mob
INNER JOIN mob.exDocumento doc
WHERE
	marcador.listavelPesquisaDefault = 1
	AND doc.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu
	AND doc.anoEmissao = :anoEmissao
	AND doc.exFormaDocumento.idFormaDoc = :idFormaDoc
	AND doc.exModelo.hisIdIni = :hisIdIni
ORDER BY
	doc.dtDoc DESC,
	doc.idDoc DESC;
	
/*SQL gerado pelo Hibernate*/
SELECT
	*
FROM
	(
	SELECT
		exmarca0_.ID_MARCA AS col_0_0_
	FROM
		corporativo.cp_marca exmarca0_
	INNER JOIN corporativo.cp_marcador cpmarcador1_ ON
		exmarca0_.ID_MARCADOR = cpmarcador1_.ID_MARCADOR
	INNER JOIN siga.ex_mobil exmobil2_ ON
		exmarca0_.ID_REF = exmobil2_.ID_MOBIL
	INNER JOIN siga.ex_documento exdocument3_ ON
		exmobil2_.ID_DOC = exdocument3_.ID_DOC
	_**CROSS JOIN siga.ex_modelo exmodelo4_**_
	WHERE
		exmarca0_.ID_TP_MARCA = 1
		AND exdocument3_.ID_MOD = exmodelo4_.ID_MOD
		AND cpmarcador1_.LISTAVEL_PESQUISA_DEFAULT = 1
		AND exdocument3_.ID_ORGAO_USU =?
		AND exdocument3_.ANO_EMISSAO =?
		AND exdocument3_.ID_FORMA_DOC =?
		AND exmodelo4_.HIS_ID_INI =?
	ORDER BY
		exdocument3_.DT_DOC DESC,
		exdocument3_.ID_DOC DESC )
WHERE
	rownum <= ?

Remoção de Obrigatoriedade da seleção do Documento na pesquisa avançada.