### PR TITLE
Atualiza ModelosListaHierarquicaGet

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
@@ -45,6 +45,7 @@ public class ModelosListaHierarquicaGet implements IModelosListaHierarquicaGet {
 			mi.level = (long) m.getLevel();
 			mi.group = m.getGroup();
 			mi.selected = m.getSelected();
+			mi.keywords = m.getKeywords();
 			resp.list.add(mi);
 		}
 	}


### PR DESCRIPTION
Na tela de criação de documentos a combo de seleção de modelos passou a não exibir o campo keywords.
correção se trata da atualização da classe ModelosListaHierarquicaGet para exibir novamente o atributo keywords,