### PR TITLE
Criação Macro Freemarker para a inclusão do Endereçamento nos Documentos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
@@ -291,8 +291,6 @@ public class ProcessadorHtml {
 		s = s.replace("<!-- INICIO RODAPE", "<!-- INICIO RODAPE -->");
 		s = s.replace("FIM RODAPE -->", "<!-- FIM RODAPE -->");
 		
-		s = s.replace("<!-- INICIO ENDERECAMENTO", "<!-- INICIO ENDERECAMENTO -->");
-		s = s.replace("FIM ENDERECAMENTO -->", "<!-- FIM ENDERECAMENTO -->");
 		
 		
 		
@@ -371,8 +369,6 @@ public class ProcessadorHtml {
 		s = s.replace("<!-- FIM PRIMEIRO RODAPE -->", "FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE -->", "<!-- INICIO RODAPE");
 		s = s.replace("<!-- FIM RODAPE -->", "FIM RODAPE -->");
-		s = s.replace("<!-- INICIO ENDERECAMENTO -->", "<!-- INICIO ENDERECAMENTO");
-		s = s.replace("<!-- FIM ENDERECAMENTO -->", "FIM ENDERECAMENTO -->");
 
 
 		s = s.replace("\r\n", "*newline*");

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
@@ -291,6 +291,9 @@ public class ProcessadorHtml {
 		s = s.replace("<!-- INICIO RODAPE", "<!-- INICIO RODAPE -->");
 		s = s.replace("FIM RODAPE -->", "<!-- FIM RODAPE -->");
 		
+		s = s.replace("<!-- INICIO ENDERECAMENTO", "<!-- INICIO ENDERECAMENTO -->");
+		s = s.replace("FIM ENDERECAMENTO -->", "<!-- FIM ENDERECAMENTO -->");
+		
 		
 		
 		int posIniFootnote = s.indexOf("<div style=\"font-size:11pt;\" class=\"footnotes\">");
@@ -368,6 +371,9 @@ public class ProcessadorHtml {
 		s = s.replace("<!-- FIM PRIMEIRO RODAPE -->", "FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE -->", "<!-- INICIO RODAPE");
 		s = s.replace("<!-- FIM RODAPE -->", "FIM RODAPE -->");
+		s = s.replace("<!-- INICIO ENDERECAMENTO -->", "<!-- INICIO ENDERECAMENTO");
+		s = s.replace("<!-- FIM ENDERECAMENTO -->", "FIM ENDERECAMENTO -->");
+
 
 		s = s.replace("\r\n", "*newline*");
 		s = s.replace("\n", "*newline*");

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorReferencias.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorReferencias.java
@@ -68,6 +68,8 @@ public class ProcessadorReferencias {
 		s = s.replace("FIM PRIMEIRO RODAPE -->", "<!-- FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE", "<!-- INICIO RODAPE -->");
 		s = s.replace("FIM RODAPE -->", "<!-- FIM RODAPE -->");
+		s = s.replace("<!-- INICIO ENDERECAMENTO", "<!-- INICIO ENDERECAMENTO -->");
+		s = s.replace("FIM ENDERECAMENTO -->", "<!-- FIM ENDERECAMENTO -->");
 
 		s = marcarReferencias(s);
 
@@ -82,6 +84,8 @@ public class ProcessadorReferencias {
 		s = s.replace("<!-- FIM PRIMEIRO RODAPE -->", "FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE -->", "<!-- INICIO RODAPE");
 		s = s.replace("<!-- FIM RODAPE -->", "FIM RODAPE -->");
+		s = s.replace("<!-- INICIO ENDERECAMENTO -->", "<!-- INICIO ENDERECAMENTO");
+		s = s.replace("<!-- FIM ENDERECAMENTO -->", "FIM ENDERECAMENTO -->");
 		return s;
 	}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorReferencias.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorReferencias.java
@@ -68,8 +68,6 @@ public class ProcessadorReferencias {
 		s = s.replace("FIM PRIMEIRO RODAPE -->", "<!-- FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE", "<!-- INICIO RODAPE -->");
 		s = s.replace("FIM RODAPE -->", "<!-- FIM RODAPE -->");
-		s = s.replace("<!-- INICIO ENDERECAMENTO", "<!-- INICIO ENDERECAMENTO -->");
-		s = s.replace("FIM ENDERECAMENTO -->", "<!-- FIM ENDERECAMENTO -->");
 
 		s = marcarReferencias(s);
 
@@ -84,8 +82,7 @@ public class ProcessadorReferencias {
 		s = s.replace("<!-- FIM PRIMEIRO RODAPE -->", "FIM PRIMEIRO RODAPE -->");
 		s = s.replace("<!-- INICIO RODAPE -->", "<!-- INICIO RODAPE");
 		s = s.replace("<!-- FIM RODAPE -->", "FIM RODAPE -->");
-		s = s.replace("<!-- INICIO ENDERECAMENTO -->", "<!-- INICIO ENDERECAMENTO");
-		s = s.replace("<!-- FIM ENDERECAMENTO -->", "FIM ENDERECAMENTO -->");
+		
 		return s;
 	}
 

--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -2173,7 +2173,7 @@ Pede deferimento.</span><br/><br/><br/>
     <!-- FIM SUBSCRITOR [#nested/] -->
 [/#macro]
 
-[#macro cabecalhoCentralizadoPrimeiraPagina orgaoCabecalho=false]
+[#macro cabecalhoCentralizadoPrimeiraPagina orgaoCabecalho=false exibeRodapeEnderecamento=false]
 	<table style="float:none; clear:both;" width="100%" align="left" border="0" cellpadding="0"
 	    cellspacing="0" bgcolor="#FFFFFF">
 	    <tr bgcolor="#FFFFFF">
@@ -2210,6 +2210,9 @@ Pede deferimento.</span><br/><br/><br/>
 	        </td>
 	    </tr>
 	</table>
+	[#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
 [/#macro]
 
 [#macro cabecalhoCentralizado orgaoCabecalho=true]
@@ -2318,7 +2321,7 @@ Pede deferimento.</span><br/><br/><br/>
 </table>
 [/#macro]
 
-[#macro cabecalhoDireitaGenerico width="65" height="65" exibirOrgao=false]
+[#macro cabecalhoDireitaGenerico width="65" height="65" exibirOrgao=false exibeRodapeEnderecamento=false]
 <table width="100%" border="0" bgcolor="#FFFFFF">
     <tr bgcolor="#FFFFFF">
         <td width="100%">
@@ -2334,6 +2337,9 @@ Pede deferimento.</span><br/><br/><br/>
         </td>
     </tr>
 </table>
+[#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
 [/#macro]
 
 [#macro cabecalhoDireita]
@@ -2577,7 +2583,7 @@ Pede deferimento.</span><br/><br/><br/>
 <!-- FIM ASSINATURA -->
 [/#macro]
 
-[#macro estiloBrasaoAEsquerda tipo exibeData=true formatarOrgao=false numeracaoEsquerda=false tamanhoLetra="11pt" obs="" omitirCodigo=false width=65 height=65 exibirOrgao=true texto=""]
+[#macro estiloBrasaoAEsquerda tipo exibeData=true formatarOrgao=false numeracaoEsquerda=false tamanhoLetra="11pt" obs="" omitirCodigo=false width=65 height=65 exibirOrgao=true texto="" exibeRodapeEnderecamento=false]
     [@primeiroCabecalho]
     <table width="100%" border="0" bgcolor="#FFFFFF"><tr><td>
     [@cabecalhoEsquerdaPrimeiraPagina width=width height=height exibirOrgao=exibirOrgao/]
@@ -2633,9 +2639,12 @@ Pede deferimento.</span><br/><br/><br/>
     [@rodape]
     [@rodapeNumeracaoADireita texto=texto/]
     [/@rodape]
+    [#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
 [/#macro]
 
- [#macro estiloBrasaoADireita tipo exibeData=true formatarOrgao=false numeracaoEsquerda=false tamanhoLetra="11pt" obs="" omitirCodigo=false width=65 height=65 exibirOrgao=false texto=""]
+ [#macro estiloBrasaoADireita tipo exibeData=true formatarOrgao=false numeracaoEsquerda=false tamanhoLetra="11pt" obs="" omitirCodigo=false width=65 height=65 exibirOrgao=false texto="" exibeRodapeEnderecamento=false]
     [@primeiroCabecalho]
     <table width="100%" border="0" bgcolor="#FFFFFF"><tr><td>
     [@cabecalhoDireitaGenerico width=65 height=65 exibirOrgao=true/]
@@ -2677,6 +2686,9 @@ Pede deferimento.</span><br/><br/><br/>
    	[@rodapeClassificacaoDocumental align="right" texto=texto/]
     [@rodapeNumeracaoADireita texto="" /]
     [/@rodape]
+    [#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
 [/#macro]
 
 
@@ -2917,7 +2929,7 @@ Pede deferimento.</span><br/><br/><br/>
     [#else]     
         [#assign tl = "11pt"]
     [/#if]
-    [@estiloBrasaoCentralizado tipo=_tipo tamanhoLetra=tl formatarOrgao=false numeracaoCentralizada=true incluirMioloDJE=true]
+    [@estiloBrasaoCentralizado tipo=_tipo tamanhoLetra=tl formatarOrgao=false numeracaoCentralizada=true incluirMioloDJE=true exibeRodapeEnderecamento=false]
             [#if dispoe_sobre != ""]     
               <table style="float:none;" width="100%" border="0" cellpadding="2" cellspacing="0" bgcolor="#FFFFFF">
                   <tr>
@@ -2944,6 +2956,9 @@ Pede deferimento.</span><br/><br/><br/>
                 </center></span></p>
             </div>            
      [/@estiloBrasaoCentralizado]
+     [#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
 [/#macro]
 
 [#macro quebraPagina]

--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -2115,13 +2115,6 @@ Pede deferimento.</span><br/><br/><br/>
     FIM RODAPE -->
 [/#macro]
 
-[#macro enderecamento exibeEnderecamento=true]
-       <!-- INICIO ENDERECAMENTO
-         [#nested/]
-         FIM ENDERECAMENTO -->
-[/#macro]
-
-
 [#macro aberturaBIE]
     <!-- INICIO ABERTURA -->
         [#nested/]
@@ -2408,14 +2401,24 @@ Pede deferimento.</span><br/><br/><br/>
 [/#if]
 [/#macro]
 
-[#macro rodapeEnderecamento align="left" somenteTR=false texto=""]
-[#if texto?? && texto!=""]
-	<tr>
-		<td colspan="2" align="${align}" style="border-collapse: collapse; border-color: black; font-family:Arial; font-size:15pt;">
-			${texto} 
-		</td>
-	</tr>
-[/#if]
+
+[#macro rodapeEnderecamento]
+	<!-- INICIO ENDERECAMENTO -->
+	    <style>
+	    	.texto-enderecamento {
+	        	font-family: Verdana; 
+	            font-size: 13px;
+	            text-align: left;             
+	        }
+	    </style>     
+	  	<p class="texto-enderecamento">
+	      [#if (Vocativo!"") != ""]<b>${Vocativo!}<b><br />[/#if]
+	      [#if (Orgao!"") != ""]${Orgao!}[/#if]<br />
+	      [#if (Logradouro!"") != ""]${Logradouro!}[/#if][#if (Numero!"") != ""], ${Numero!}[/#if][#if (Complemento!"") != ""], ${Complemento!}<br />[/#if]
+	      [#if (Bairro!"") != ""]${Bairro!}<br />[/#if]
+	      [#if (CEP!"") != ""]${CEP}[/#if] [#if (Municipio!"") != ""]${Municipio!}[/#if] [#if (Municipio!"") != "" && (UF!"") != ""]- ${UF!}[/#if]    
+	    </p>
+    <!-- FIM ENDERECAMENTO -->
 [/#macro]
 
 [#macro rodapeNumeracaoADireita texto=""]
@@ -2677,7 +2680,7 @@ Pede deferimento.</span><br/><br/><br/>
 [/#macro]
 
 
-[#macro estiloBrasaoCentralizado tipo tamanhoLetra="11pt"  exibeAssinatura=true formatarOrgao=true orgaoCabecalho=true numeracaoCentralizada=false dataAntesDaAssinatura=false incluirMioloDJE=false omitirCodigo=false omitirData=false topoPrimeiraPagina='' incluirAssinaturaBIE=true exibeClassificacaoDocumental=true exibeEnderecamento=true]
+[#macro estiloBrasaoCentralizado tipo tamanhoLetra="11pt"  exibeAssinatura=true formatarOrgao=true orgaoCabecalho=true numeracaoCentralizada=false dataAntesDaAssinatura=false incluirMioloDJE=false omitirCodigo=false omitirData=false topoPrimeiraPagina='' incluirAssinaturaBIE=true exibeClassificacaoDocumental=true exibeRodapeEnderecamento=false]
     [@primeiroCabecalho]${topoPrimeiraPagina!}
     [@cabecalhoCentralizadoPrimeiraPagina orgaoCabecalho/]
     [/@primeiroCabecalho]
@@ -2757,10 +2760,15 @@ Pede deferimento.</span><br/><br/><br/>
 	   [#if exibeClassificacaoDocumental]
 	   		[@rodapeClassificacaoDocumental/]
 	   [/#if]
+	   
    [/@primeiroRodape]
    [@rodape]
-   [@rodapeNumeracaoADireita/]
+   		[@rodapeNumeracaoADireita/]
    [/@rodape]
+   [#if exibeRodapeEnderecamento]
+   		[@rodapeEnderecamento/]
+   [/#if]
+  
 [/#macro]
 
 [#macro processo]

--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -2115,6 +2115,13 @@ Pede deferimento.</span><br/><br/><br/>
     FIM RODAPE -->
 [/#macro]
 
+[#macro enderecamento exibeEnderecamento=true]
+       <!-- INICIO ENDERECAMENTO
+         [#nested/]
+         FIM ENDERECAMENTO -->
+[/#macro]
+
+
 [#macro aberturaBIE]
     <!-- INICIO ABERTURA -->
         [#nested/]
@@ -2401,6 +2408,16 @@ Pede deferimento.</span><br/><br/><br/>
 [/#if]
 [/#macro]
 
+[#macro rodapeEnderecamento align="left" somenteTR=false texto=""]
+[#if texto?? && texto!=""]
+	<tr>
+		<td colspan="2" align="${align}" style="border-collapse: collapse; border-color: black; font-family:Arial; font-size:15pt;">
+			${texto} 
+		</td>
+	</tr>
+[/#if]
+[/#macro]
+
 [#macro rodapeNumeracaoADireita texto=""]
 <table width="100%" border="0" cellpadding="0" bgcolor="#FFFFFF">
 	[#if texto?? && texto!=""]
@@ -2660,7 +2677,7 @@ Pede deferimento.</span><br/><br/><br/>
 [/#macro]
 
 
-[#macro estiloBrasaoCentralizado tipo tamanhoLetra="11pt"  exibeAssinatura=true formatarOrgao=true orgaoCabecalho=true numeracaoCentralizada=false dataAntesDaAssinatura=false incluirMioloDJE=false omitirCodigo=false omitirData=false topoPrimeiraPagina='' incluirAssinaturaBIE=true exibeClassificacaoDocumental=true]
+[#macro estiloBrasaoCentralizado tipo tamanhoLetra="11pt"  exibeAssinatura=true formatarOrgao=true orgaoCabecalho=true numeracaoCentralizada=false dataAntesDaAssinatura=false incluirMioloDJE=false omitirCodigo=false omitirData=false topoPrimeiraPagina='' incluirAssinaturaBIE=true exibeClassificacaoDocumental=true exibeEnderecamento=true]
     [@primeiroCabecalho]${topoPrimeiraPagina!}
     [@cabecalhoCentralizadoPrimeiraPagina orgaoCabecalho/]
     [/@primeiroCabecalho]


### PR DESCRIPTION
Atualmente, em alguns modelos, é usado uma espécie de endereçamento, onde as informações são preenchidas no campo entrevista, e é informado abaixo dos dados do usuário no documento.
![image](https://user-images.githubusercontent.com/54121787/132562656-57bd6caf-5bb5-4eda-958c-9586423848c5.png)

Após a atualização para o FlyingSalcer, esses campos estava entrando em conflito com a assinatura gerada do sistema, e acabava sobrescrevendo as informações de endereçamento.

Como ambas ficavam dentro da macro Rodapé, foi criado então uma nova macro rodapeEnderecamento, onde separamos o que é o rodapé e o endereçamento, para justamente não haver mais esse conflito.
![image](https://user-images.githubusercontent.com/54121787/132563249-ea64283d-646a-488e-8cf0-0fec003377cc.png)

Conforme a imagem acima, os dados de endereçamento fica abaixo dos dados do usuário e acima da assinatura gerada do sistema.
![image](https://user-images.githubusercontent.com/54121787/132564364-4b7efccc-a7dc-4435-9249-f9fb7001ae43.png)

