### PR TITLE
Adicionando modal informativo ao clicar no botao anotar

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -436,7 +436,7 @@ public class ExMobilVO extends ExVO {
 				Ex.getInstance().getComp()
 						.podeNotificar(titular, lotaTitular, mob));
 		
-		addAcao(AcaoVO.builder().nome("_Anotar").icone("note_add").acao("/app/expediente/mov/anotar")
+		addAcao(AcaoVO.builder().nome("_Anotar").icone("note_add").modal("anotacaoObservacaoModal")
 				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeAnotar(mob, titular, lotaTitular)).build());
 		
 		addAcao(AcaoVO.builder().nome("Definir " + SigaMessages.getMessage("documento.marca")).icone("folder_star").modal("definirMarcaModal")

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
@@ -96,6 +96,38 @@
 	</div>
 </div>
 
+<div class="modal fade" id="anotacaoObservacaoModal" tabindex="-1"
+	role="dialog" aria-labelledby="anotarModalLabel" aria-hidden="true">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="anotarModalLabel" style="font-weight: bold;">
+					Anotar
+				</h5>
+				<button type="button" class="close" data-dismiss="modal"
+					aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
+			<div class="modal-body" style="padding-top: 70px; padding-bottom: 60px;">
+					<input type="hidden" name="sigla" value="${m.sigla}" />
+					<div class="form-group">
+						<div class="form-group">
+							<p style="font-size: 13px; color: #9e9e9e;"><span style="font-size: 14px; font-weight: bold;">ATENÇÃO: </span>Anotações cadastradas não 
+							constituem o documento, são apenas  lembretes ou avisos 
+							para os usuários com acesso ao documento, podendo ser 
+							excluídas a qualquer tempo.</p>
+						</div>
+					</div>
+			</div>
+			<div class="modal-footer">
+				<a href="${linkTo[ExMovimentacaoController].aAnotar()}?sigla=${mob.sigla}" 
+					style="background: #007bff; border-radius: 5px; width: 52px; height: 40px; color: white; text-align: center; padding-top: 8px;">Ok</a>
+			</div>
+		</div>
+	</div>
+</div>
+
 <script type="text/javascript" src="/sigaex/javascript/vue.min.js"></script>
 
 


### PR DESCRIPTION
O modal informativo tem o objetivo de melhorar a experiência do usuário fazendo que ele consiga compreender o objetivo do botão “Anotar” e minimize a utilização das anotações para dar ciência aos documentos.