### PR TITLE
Resolvendo problema de erro no combo de menu de configuracao

### DIFF
--- a/siga-vraptor-module/src/main/resources/META-INF/tags/cfg-edita.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/cfg-edita.tag
@@ -195,9 +195,11 @@
 					<div class="row">
 						<div class="col-sm-12">
 							<div class="form-group mb-0">
-								<input type="submit" value="Ok" class="btn btn-primary" /> <input
-									type="button" value="Cancelar"
-									onclick="javascript:history.back();" class="btn btn-primary" />
+								<input type="submit" value="Ok" class="btn btn-primary" /> 
+								
+								<input type="button" value="Cancelar"
+									onclick="javascript:window.location.href='listar?idTpConfiguracao=${tipoDeConfiguracao.id}&idOrgaoUsu=${idOrgaoUsu}'" 
+										class="btn btn-primary" />
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Ao apertar no botão de editar na tabela 'Acessar' da página 'Configurações Cadastradas' direciona para a página 'Cadastro de configuração' e após o usuário pressionar o botão Ok e em seguida ele volta novamente para a página 'Cadastro de configuração' e pressionar o botão Cancelar; não é setado no combo do menu da página 'Configurações Cadastradas' o tipo de configuração que está sendo trabalhado no momento.

Na classe cfg-edita.tag, na linha 199 o a propriedade onclick do elemento input estava usando um método javascrip history.back(); esse método tem o objetivo de carregar a URL anterior na lista do histórico. Talvez isso seja meio incerto para essa situação, pois não está explicitando a URL que precisa para chamar as regras que lista na tabela 'Acessar' conforme do que está setado na combo do menu da página 'Configuração Cadastrais'. Portanto, deixei explícito essa URL para não haver qualquer incompatibilidade, ficando assim: 
`<input type="button" value="Cancelar"
									onclick="javascript:window.location.href='listar?idTpConfiguracao=${tipoDeConfiguracao.id}&idOrgaoUsu=${idOrgaoUsu}'" 
										class="btn btn-primary" />`