### PR TITLE
PCRJ-1159 Correcao do relatorio de doc. setores subordinados

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -228,7 +228,8 @@ import br.gov.jfrj.siga.ex.BIE.ExBoletimDoc;
 				+ "					and doc.lotaCadastrante.idLotacaoIni = :idLotacaoInicial"
 				+ "					and doc.dtFinalizacao is not null"
 				+ "					and doc.dtFinalizacao between :dataInicial and :dataFinal"
-				+ "				order by  doc.dtFinalizacao") })
+				+ "				order by  doc.dtFinalizacao"),
+		@NamedQuery(name = "consultarExDocumentoId", query = "from ExDocumento doc	where  	doc.id=:idDoc" )})
 public abstract class AbstractExDocumento extends ExArquivo implements
 		Serializable {
 	


### PR DESCRIPTION
#1966 
 Não encontrei no projeto a consulta  " consultarExDocumentoId", que esta sendo chamada pela ExDao.

	public ExDocumento consultarExDocumentoPorId(
			Long idDoc) {
		Query q;

			q = em().createNamedQuery(
					"consultarExDocumentoId");
			q.setParameter("idDoc", idDoc);
	
		return (ExDocumento) q.getSingleResult();
	}	