### PR TITLE
Corrigindo erro de duplicidade de registro de pessoa

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1259,8 +1259,6 @@ public class CpBL {
 		}
 		pessoa.setSesbPessoa(ou.getSigla());
 		
-
-
 		// ÓRGÃO / CARGO / FUNÇÃO DE CONFIANÇA / LOTAÇÃO e CPF iguais.
 		DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();
 		dpPessoa.setIdOrgaoUsu(pessoa.getOrgaoUsuario().getId());
@@ -1280,10 +1278,8 @@ public class CpBL {
 		
 		List<DpPessoa> listaPessoasMesmoCPF = new ArrayList<DpPessoa>();
 		DpPessoa pessoa2 = new DpPessoa();
-		
 	
 		listaPessoasMesmoCPF.addAll(CpDao.getInstance().listarCpfAtivoInativo(pessoa.getCpfPessoa()));
-		
 		
 		try {
 	//		dao().em().getTransaction().begin();
@@ -1361,7 +1357,10 @@ public class CpBL {
 			if(e.getCause() instanceof ConstraintViolationException &&
 					("CORPORATIVO.DP_PESSOA_UNIQUE_PESSOA_ATIVA".equalsIgnoreCase(((ConstraintViolationException)e.getCause()).getConstraintName()))) {
 				throw new RegraNegocioException("Ocorreu um problema no cadastro da pessoa");
-			} else {
+			} else if(e.getCause() instanceof ConstraintViolationException &&
+					("CORPORATIVO.SIGA_VALID_UNIQUE".equalsIgnoreCase(((ConstraintViolationException)e.getCause()).getConstraintName()))) {
+				throw new RegraNegocioException("Usuário já cadastrado com estes dados: Órgão, Cargo, Função, Unidade e CPF");
+			}else {
 		//	dao().em().getTransaction().rollback();
 				throw new AplicacaoException("Erro na gravação", 0, e);
 			}
@@ -1483,7 +1482,7 @@ public class CpBL {
 			marcadorAnt = dao().consultar(id, CpMarcador.class, false);
 			if (marcadorAnt != null) {
 				if (marcadorAnt.getDpLotacaoIni() != null &&
-						marcadorAnt.getDpLotacaoIni().getIdInicial() != cadastrante.getLotacao().getIdInicial())
+						!(marcadorAnt.getDpLotacaoIni().getIdInicial().equals(cadastrante.getLotacao().getIdInicial())))
 					throw new AplicacaoException ("Não é permitida a alteração de marcador de outra " + msgLotacao);
 
 				marcador.setHisIdIni(marcadorAnt.getHisIdIni());

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V113_0__Validando_informacoes_usuario.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V113_0__Validando_informacoes_usuario.sql
@@ -1,0 +1,5 @@
+--------------------------------------------------------------------------------------------------
+--	SCRIPT: EVITA A DUPLICIDADE DE PESSOAS COM O MESMO Órgão, Cargo, Função, Unidade e CPF.
+--------------------------------------------------------------------------------------------------
+CREATE INDEX user_index_for_un ON CORPORATIVO.DP_PESSOA (ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO, CPF_PESSOA, DATA_FIM_PESSOA);
+alter table CORPORATIVO.DP_PESSOA add constraint siga_valid_unique unique (ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO, CPF_PESSOA, DATA_FIM_PESSOA) ENABLE NOVALIDATE;

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V113_0__Validando_informacoes_usuario.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V113_0__Validando_informacoes_usuario.sql
@@ -1,5 +1,5 @@
---------------------------------------------------------------------------------------------------
+-- -----------------------------------------------------------------------------------------------
 --	SCRIPT: EVITA A DUPLICIDADE DE PESSOAS COM O MESMO Órgão, Cargo, Função, Unidade e CPF.
---------------------------------------------------------------------------------------------------
+-- -----------------------------------------------------------------------------------------------
 CREATE INDEX user_index_for_un ON CORPORATIVO.DP_PESSOA (ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO, CPF_PESSOA, DATA_FIM_PESSOA);
 alter table CORPORATIVO.DP_PESSOA add constraint siga_valid_unique unique (ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO, CPF_PESSOA, DATA_FIM_PESSOA) ENABLE NOVALIDATE;

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -624,6 +624,8 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 					orgaoIdentidade, ufIdentidade, dataExpedicaoIdentidade, nomeExibicao, enviarEmail);
 		} catch (RegraNegocioException e) {
 			result.include(SigaModal.ALERTA, e.getMessage());
+		} catch (Exception ex) {
+			result.include(SigaModal.ALERTA,  SigaModal.mensagem("Não é permitido cadastrar na mesma unidade, mais de um cargo para o mesmo CPF."));
 		}
 		
 		lista(0, null, "", "", null, null, null, "", null);


### PR DESCRIPTION
Para resolver esse problema de duplicidade precisei realizar validação no banco de dados na aplicação estava instável. Para isso precisei deixar as propriedades Órgão, Cargo, Função, Unidade e CPF o com valores exclusivos, para que em hipótese alguma essa combinação de propriedades possam ser duplicadas. Pensando nessa solução, apareceu outro problema: ao roda um script que faz com que essas propriedade possam possuir exclusividades, o banco me lançou um erro de "duplicate keys found". Ou seja, como já possuía chaves duplicadas na base de dados, como aplicar uma regra proibindo duplicidades? Bem, na documentação Oracle Sql tem um cara chamado ENABLE NOVALIDATE, ele permitiu o meu script aplicar essas restrições para futuros saves, e ignorou às que já estavam na base de dados.