### PR TITLE
GOVSP58859 - Alteração de nomenclatura pessoa/usuário e lotação/unidade nos marcadores

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -254,6 +254,10 @@ public class Prop {
 		 * Se false, não permite.
 		 * */
 		provider.addPublicProperty("/siga.marcadores.permite.data.retroativa", "true");
+		/* Cadastro de marcadores: Indica a quantidade de marcadores permitidos para uma unidade. 
+		 * - Default: 10 marcadores.
+		 * */
+		provider.addPublicProperty("/siga.marcadores.qtd.maxima.por.unidade", "10");		
 		/* Tela de Pesquisa, combos de espécies e modelos: 
 		 * - True: Confere se a espécie tem modelos no combo da tela de pesquisa.  
 		 * - False ou inexistente: Não confere, evitando leitura dos modelos.

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1458,10 +1458,11 @@ public class CpBL {
 			if (m.getIdFinalidade() == CpMarcadorFinalidadeEnum.PASTA_PADRAO) 
 				cpp++;
 		}
-		
+		Integer qtdMaxPorUnidade = Prop.getInt("/siga.marcadores.qtd.maxima.por.unidade");
 		if (idFinalidade.getIdTpMarcador() == CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO && id == null 
-				&& c > 10) 
-			throw new AplicacaoException ("Atingiu o limite de 10 marcadores possíveis para " + msgLotacao);
+				&& c > qtdMaxPorUnidade) 
+			throw new AplicacaoException ("Atingiu o limite de " + qtdMaxPorUnidade.toString() 
+				+ " marcadores possíveis para " + msgLotacao);
 		
 		if (idFinalidade == CpMarcadorFinalidadeEnum.PASTA_PADRAO && id == null && cpp > 0) 
 			throw new AplicacaoException ("Só é permitido criar uma pasta padrão");

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorFinalidadeEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorFinalidadeEnum.java
@@ -15,80 +15,99 @@ public enum CpMarcadorFinalidadeEnum implements IEnumWithId {
 			CpTipoMarcadorEnum.TIPO_MARCADOR_SISTEMA, null, null, null, null, null, null, false, false),
 	//
 	GERAL(2, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral",
-			"Marcador que pode ser definido por qualquer pessoa e estará visível para quem receber o documento",
+			"Marcador que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " e estará visível para quem receber o documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, false, true),
 	//
 	GERAL_AGENDADA(3, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral Agendada",
-			"Marcador que pode ser definido por qualquer pessoa e estará visível, a partir de uma data definida, para quem receber o documento",
+			"Marcador que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " e estará visível, a partir de uma data definida, para quem receber o documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoDataEnum.DESATIVADA,
 			CpMarcadorTipoExibicaoEnum.MENOR_DATA, CpMarcadorTipoInteressadoEnum.ATENDENTE,
 			CpMarcadorTipoTextoEnum.OPCIONAL, false, false),
 	//
 	GERAL_PRAZOS(4, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral com Prazos",
-			"Marcador que pode ser definido por qualquer pessoa e estará visível, a partir de uma data definida, para quem receber o documento, contendo a informação sobre a proximidade de um prazo",
+			"Marcador que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " e estará visível, a partir de uma data definida, para quem receber o documento, contendo a informação sobre a proximidade de um prazo",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoDataEnum.OBRIGATORIA,
 			CpMarcadorTipoExibicaoEnum.MENOR_DATA, CpMarcadorTipoInteressadoEnum.ATENDENTE,
 			CpMarcadorTipoTextoEnum.OPCIONAL, false, false),
 	//
 	GERAL_DIRECIONADA(5, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral Direcionada",
-			"Marcador que pode ser definido por qualquer pessoa e estará visível para uma lotação ou pessoa  definida, independente da localização do documento",
+			"Marcador que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+			+ " e estará visível para uma " + SigaMessages.getMessage("usuario.lotacao") + " ou " 
+				+ SigaMessages.getMessage("usuario.pessoa") + " definida, independente da localização do documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.GERAL,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.LOTACAO_OU_PESSOA, CpMarcadorTipoTextoEnum.OPCIONAL, false, true),
 	//
 	GERAL_AGENDADA_DIRECIONADA(7, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral Agendada Direcionada",
-			"Marcador que pode ser definido por qualquer pessoa e estará visível, a partir de uma data definida, para uma lotação ou pessoa definida, independente da localização do documento",
+			"Marcador que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " e estará visível, a partir de uma data definida, para uma " + SigaMessages.getMessage("usuario.lotacao") + " ou " 
+				+ SigaMessages.getMessage("usuario.pessoa") + " definida, independente da localização do documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.GERAL,
 			CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoDataEnum.DESATIVADA,
 			CpMarcadorTipoExibicaoEnum.MENOR_DATA, CpMarcadorTipoInteressadoEnum.LOTACAO_OU_PESSOA,
 			CpMarcadorTipoTextoEnum.OPCIONAL, false, false),
 	//
 	GERAL_LIMITE_XOR(6, CpMarcadorFinalidadeGrupoEnum.GERAL, "Geral Com Data Limite e Mutuamente Exclusiva",
-			"Marcador, mutuamente exclusivo, que pode ser definido por qualquer pessoa e estará visível, com data limite, para quem receber com o documento. Apenas um marcador desse tipo pode ser definido para um mesmo documento",
+			"Marcador, mutuamente exclusivo, que pode ser definido por qualquer " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " e estará visível, com data limite, para quem receber com o documento. Apenas um marcador desse tipo pode ser definido para um mesmo documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_GERAL, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoExibicaoEnum.IMEDIATA,			
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, true, false),
 	//
 	LOCAL(100, CpMarcadorFinalidadeGrupoEnum.LOCAL, "Local",
-			"Marcador que pode ser definido por pessoa da minha lotação e estará visível para quem receber qualquer via do documento",
+			"Marcador que pode ser definido por " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " da minha " + SigaMessages.getMessage("usuario.lotacao") 
+				+ " e estará visível para quem receber qualquer via do documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, false, true),
 	//
 	LOCAL_AGENDADA(101, CpMarcadorFinalidadeGrupoEnum.LOCAL, "Local Agendada",
-			"Marcador que pode ser definido por pessoa da minha lotação e estará visível, a partir de uma data definida, para quem receber qualquer via do documento",
+			"Marcador que pode ser definido por " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " da minha " + SigaMessages.getMessage("usuario.lotacao") 
+				+ " e estará visível, a partir de uma data definida, para quem receber qualquer via do documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.TODAS_AS_VIAS_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, false, false),
 	//
 	LOCAL_DIRECIONADA(102, CpMarcadorFinalidadeGrupoEnum.LOCAL, "Local Direcionada",
-			"Marcador que pode ser definido por pessoa da minha lotação e estará visível para uma lotação ou pessoa definida, independente da localização do documento",
+			"Marcador que pode ser definido por " + SigaMessages.getMessage("usuario.pessoa") + " da minha " + SigaMessages.getMessage("usuario.lotacao") 
+				+ " e estará visível para uma " + SigaMessages.getMessage("usuario.lotacao") + " ou " + SigaMessages.getMessage("usuario.pessoa") 
+				+ " definida, independente da localização do documento",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.GERAL,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.LOTACAO_OU_PESSOA, CpMarcadorTipoTextoEnum.OPCIONAL, false, true),
 	//
-	PASTA(200, CpMarcadorFinalidadeGrupoEnum.PASTA, "Pasta", "Organizar o acervo em andamento na minha lotação",
+	PASTA(200, CpMarcadorFinalidadeGrupoEnum.PASTA, "Pasta", "Organizar o acervo em andamento na minha " + SigaMessages.getMessage("usuario.lotacao"),
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.VIA_ESPECIFICA_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, true, true),
 	//
-	PASTA_PADRAO(201, CpMarcadorFinalidadeGrupoEnum.PASTA, "Pasta Padrão", "Pasta atribuída automaticamente ao documento tramitado para a minha lotação.",
+	PASTA_PADRAO(201, CpMarcadorFinalidadeGrupoEnum.PASTA, "Pasta Padrão", "Pasta atribuída automaticamente ao documento tramitado para a minha " 
+				+ SigaMessages.getMessage("usuario.lotacao"),
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.VIA_ESPECIFICA_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.ATENDENTE, CpMarcadorTipoTextoEnum.OPCIONAL, true, true),
 	//
 	LISTA(300, CpMarcadorFinalidadeGrupoEnum.LISTA, "Lista",
-			"Marcador que pode ser definido por pessoa da minha lotação para agrupar documentos de interesse de Pessoa ou Lotação definida",
+			"Marcador que pode ser definido por " + SigaMessages.getMessage("usuario.pessoa") + " da minha " + SigaMessages.getMessage("usuario.lotacao") 
+			+ " para agrupar documentos de interesse de " + SigaMessages.getMessage("usuario.pessoa") 
+			+ " ou " + SigaMessages.getMessage("usuario.lotacao") +  " definida",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.VIA_ESPECIFICA_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.IMEDIATA,
 			CpMarcadorTipoInteressadoEnum.LOTACAO_OU_PESSOA, CpMarcadorTipoTextoEnum.OPCIONAL, false, false),
 	//
 	LISTA_AGENDADA(301, CpMarcadorFinalidadeGrupoEnum.LISTA, "Lista Agendada",
-			"Marcador que pode ser definido por pessoa da minha lotação para agrupar documentos de interesse de Pessoa ou Lotação definida, a partir de uma data definida",
+			"Marcador que pode ser definido por " + SigaMessages.getMessage("usuario.pessoa") + " da minha " + SigaMessages.getMessage("usuario.lotacao")
+				+ " para agrupar documentos de interesse de " + SigaMessages.getMessage("usuario.pessoa") + " ou " + SigaMessages.getMessage("usuario.lotacao") 
+				+ " definida, a partir de uma data definida",
 			CpTipoMarcadorEnum.TIPO_MARCADOR_LOTACAO, CpMarcadorTipoAplicacaoEnum.VIA_ESPECIFICA_OU_ULTIMO_VOLUME,
 			CpMarcadorTipoDataEnum.OBRIGATORIA, CpMarcadorTipoDataEnum.DESATIVADA, CpMarcadorTipoExibicaoEnum.MENOR_DATA,
 			CpMarcadorTipoInteressadoEnum.LOTACAO_OU_PESSOA, CpMarcadorTipoTextoEnum.OPCIONAL, false, false);

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorTipoInteressadoEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorTipoInteressadoEnum.java
@@ -13,9 +13,9 @@ public enum CpMarcadorTipoInteressadoEnum implements IEnumWithId {
 	//
 	LOTACAO(3, SigaMessages.getMessage("usuario.lotacao")),
 	//
-	PESSOA_OU_LOTACAO(4, SigaMessages.getMessage("usuario.pessoa") + " ou " + SigaMessages.getMessage("usuario.lotação")),
+	PESSOA_OU_LOTACAO(4, SigaMessages.getMessage("usuario.pessoa") + " ou " + SigaMessages.getMessage("usuario.lotacao")),
 	//
-	LOTACAO_OU_PESSOA(5, SigaMessages.getMessage("usuario.lotação") + " ou " + SigaMessages.getMessage("usuario.pessoa"));
+	LOTACAO_OU_PESSOA(5, SigaMessages.getMessage("usuario.lotacao") + " ou " + SigaMessages.getMessage("usuario.pessoa"));
 
 	private final Integer id;
 	private final String descricao;

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorTipoInteressadoEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorTipoInteressadoEnum.java
@@ -3,18 +3,19 @@ package br.gov.jfrj.siga.cp.model.enm;
 import java.util.ArrayList;
 import java.util.List;
 
+import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.cp.converter.IEnumWithId;
 
 public enum CpMarcadorTipoInteressadoEnum implements IEnumWithId {
 	ATENDENTE(1, "Atendente"),
 	//
-	PESSOA(2, "Pessoa"),
+	PESSOA(2, SigaMessages.getMessage("usuario.pessoa")),
 	//
-	LOTACAO(3, "Lotacao"),
+	LOTACAO(3, SigaMessages.getMessage("usuario.lotacao")),
 	//
-	PESSOA_OU_LOTACAO(4, "Pessoa ou lotação"),
+	PESSOA_OU_LOTACAO(4, SigaMessages.getMessage("usuario.pessoa") + " ou " + SigaMessages.getMessage("usuario.lotação")),
 	//
-	LOTACAO_OU_PESSOA(5, "Lotação ou pessoa");
+	LOTACAO_OU_PESSOA(5, SigaMessages.getMessage("usuario.lotação") + " ou " + SigaMessages.getMessage("usuario.pessoa"));
 
 	private final Integer id;
 	private final String descricao;

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
@@ -46,18 +46,18 @@
 									name="interessado" v-model="interessado" id="interessado"
 									class="form-control">
 									<option v-if="marcador.interessado.includes('PESSOA')"
-										value="pessoa">Pessoa</option>
+										value="pessoa"><fmt:message key="usuario.pessoa"/></option>
 									<option v-if="marcador.interessado.includes('LOTACAO')"
-										value="lotacao">Lotacao</option>
+										value="lotacao"><fmt:message key="usuario.lotacao"/></option>
 								</select>
 							</div>
 							<div v-if="exibirLotacao" class="form-group">
-								<label for="marcador">Lotacao</label>
+								<label for="marcador"><fmt:message key="usuario.lotacao"/></label>
 								<siga:selecao tema='simple' titulo="Lotação:"
 									propriedade="lotaSubscritor" modulo="siga" />
 							</div>
 							<div v-if="exibirPessoa" class="form-group">
-								<label for="marcador">Pessoa</label>
+								<label for="marcador"><fmt:message key="usuario.pessoa"/></label>
 								<siga:selecao tema='simple' titulo="Matrícula:"
 									propriedade="subscritor" modulo="siga" />
 							</div>


### PR DESCRIPTION
### Nomenclatura pessoa/usuário e lotação/unidade
No cadastro de marcadores, as descrições contendo as palavras pessoa foram transformadas em usuários e lotações passaram a ser unidade conforme padrão do GOVSP.

**Combo de escolha da finalidade do marcador:**
Default:
![image](https://user-images.githubusercontent.com/49542320/134597284-c24f548b-cb0c-4c9a-b788-c63b142ec057.png)

Para o governo de SP:
![image](https://user-images.githubusercontent.com/49542320/134597431-af736a2d-f6bc-4d10-b941-7bdc1773e694.png)

**Na definição de marcador no documento (botão "Definir Marcador"**
Default:
![image](https://user-images.githubusercontent.com/49542320/134598351-e7d549ad-8da4-4de6-8dec-9ea94c2fff96.png)

Para o governo de SP:
![image](https://user-images.githubusercontent.com/49542320/134598277-38aba0cf-1f19-4da4-b69b-8c4a5dc975cc.png)

### Quantidade Máxima de Marcadores por Lotação
Criada uma propriedade do sistema (siga.marcadores.qtd.maxima.por.unidade) para ser possível mais de 10 marcadores por lotação. Se não for informada o default continua sendo 10.


