### PR TITLE
GOVSP58859 - Nome do botão Cancelar passa a ser Exclusão de Marcação

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -59,6 +59,8 @@ import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERE
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.TIPO_MOVIMENTACAO_VINCULACAO_PAPEL;
 import static br.gov.jfrj.siga.ex.ExTipoMovimentacao.hasDespacho;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -224,10 +226,18 @@ public class ExMovimentacaoVO extends ExVO {
 				descricao += ", prazo final: " + Data.formatDataETempoRelativo(mov.getDtParam2());
 			if (mov.getObs() != null && mov.getObs().trim().length() > 0)
 				descricao += ", obs: " + mov.getObs();
-			addAcao(AcaoVO.builder().nome("Cancelar").nameSpace("/app/expediente/mov")
-					.acao("cancelar_movimentacao_gravar").params("sigla", mov.mob().getCodigoCompacto())
-					.params("id", mov.getIdMov().toString()).post(true)
-					.exp(new ExPodeCancelarMarcacao(mov, titular, lotaTitular)).build());
+			String descrUrl = "";
+			try {
+				descrUrl = URLEncoder.encode("Exclusão de marcação: " + mov.getMarcador().getDescrMarcador(), "iso-8859-1");
+			} catch (UnsupportedEncodingException e) {
+				throw new AplicacaoException("Erro ao converter", 0, e);
+			}
+			if (!mov.isCancelada())
+				addAcao(AcaoVO.builder().nome("Exclusão de Marcação").nameSpace("/app/expediente/mov")
+						.acao("cancelar_movimentacao_gravar").params("sigla", mov.mob().getCodigoCompacto())
+						.params("id", mov.getIdMov().toString())
+						.params("descrMov", descrUrl).post(true)
+						.exp(new ExPodeCancelarMarcacao(mov, titular, lotaTitular)).build());
 		}
 
 		if (idTpMov == TIPO_MOVIMENTACAO_REFERENCIA) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -233,7 +233,7 @@ public class ExMovimentacaoVO extends ExVO {
 				throw new AplicacaoException("Erro ao converter", 0, e);
 			}
 			if (!mov.isCancelada())
-				addAcao(AcaoVO.builder().nome("Exclusão de Marcação").nameSpace("/app/expediente/mov")
+				addAcao(AcaoVO.builder().nome("Excluir Marcador").nameSpace("/app/expediente/mov")
 						.acao("cancelar_movimentacao_gravar").params("sigla", mov.mob().getCodigoCompacto())
 						.params("id", mov.getIdMov().toString())
 						.params("descrMov", descrUrl).post(true)

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -634,7 +634,8 @@
 										</c:choose>
 										<c:choose>
 											<c:when test="${marca.exMovimentacao.podeCancelar(titular, lotaTitular)}">
-												<td style="padding-left:.25em; padding-right: 0"><a href="javascript:postToUrl('/sigaex/app/expediente/mov/cancelar_movimentacao_gravar?id=${marca.exMovimentacao.idMov}&sigla=${marca.exMovimentacao.exMobil.sigla}')" title="${marca.exMovimentacao.expliquePodeCancelar(titular, lotaTitular)}"><i class="far fa-trash-alt"></i></a></td>
+												<td style="padding-left:.25em; padding-right: 0"><a href="javascript:postToUrl('/sigaex/app/expediente/mov/cancelar_movimentacao_gravar?id=${marca.exMovimentacao.idMov}&sigla=${marca.exMovimentacao.exMobil.sigla}&descrMov=' + encodeURIComponent('Exclusão de marcador: ${marca.cpMarcador.descrMarcador}'))" 
+													title="${marca.exMovimentacao.expliquePodeCancelar(titular, lotaTitular)}"><i class="far fa-trash-alt"></i></a></td>
 											</c:when>
 											<c:otherwise>
 												<td style="padding-left:.25em; padding-right: 0"><a title="${marca.exMovimentacao.expliquePodeCancelar(titular, lotaTitular)}"><i class="far fa-trash-alt text-secondary"></i></a></td>


### PR DESCRIPTION
Nas movimentações do documento (tela de histórico), o botão "Cancelar" foi alterado para "Exclusão de Marcação" e a descrição da movimentação passou a informar qual marcador foi cancelado.

Antes:
![image](https://user-images.githubusercontent.com/49542320/134599087-7c892396-dc4d-4bdc-a66f-00d7f4c09a05.png)


![image](https://user-images.githubusercontent.com/49542320/134599109-ea9e5453-ef4d-42ee-9212-7e2e64255235.png)

Depois:
![image](https://user-images.githubusercontent.com/49542320/134599180-7e4a567c-60d0-463b-8202-30a5ce656583.png)

![image](https://user-images.githubusercontent.com/49542320/134599214-865f2fa6-99b2-402b-bde0-d543535735b0.png)

