### PR TITLE
GOVSP58859 - Histórico de marcadores com colunas iguais à lista

### DIFF
--- a/siga/src/main/webapp/WEB-INF/page/cpMarcador/historico.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/cpMarcador/historico.jsp
@@ -1,9 +1,12 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	buffer="64kb"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://localhost/libstag" prefix="f"%>
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
 
+
 <siga:pagina titulo="Forma">
+	<c:set var="grupoDefault" scope="session" value="${f:resource('/siga.marcadores.grupo.default')}" />
 	<!-- main content -->
 	<div class="container-fluid">
 		<div class="card bg-light mb-3">
@@ -19,12 +22,10 @@
 							<th scope="col">Responsável pela alteração</th>
 							<th scope="col">Marcador</th>
 							<th scope="col">Tipo Marcador</th>
-							<th scope="col">Aplicação</th>
-							<th scope="col">Data Planejada</th>
-							<th scope="col">Data Limite</th>
-							<th scope="col">Opção Exibição</th>
-							<th scope="col">Texto</th>
-							<th scope="col">Interessado</th>
+							<th scope="col">Finalidade</th>
+							<c:if test="${empty grupoDefault}">
+								<th scope="col">Grupo ${grupoDefault}</th>
+							</c:if>
 							<th scope="col">Ativo</th>
 						</tr>
 					</thead>
@@ -37,12 +38,10 @@
 								<td title="${marcador.descrDetalhada}"><i class='${marcador.idIcone.codigoFontAwesome}' style='color: #${marcador.idCor.descricao}'>
 									</i> ${marcador.descrMarcador}</td>
 								<td>${marcador.idFinalidade.idTpMarcador.descricao}</td>
-								<td>${marcador.idFinalidade.idTpAplicacao.descricao}</td>
-								<td>${marcador.idFinalidade.idTpDataPlanejada.descricao}</td>
-								<td>${marcador.idFinalidade.idTpDataLimite.descricao}</td>
-								<td>${marcador.idFinalidade.idTpExibicao.descricao}</td>
-								<td>${marcador.idFinalidade.idTpTexto.descricao}</td>
-								<td>${marcador.idFinalidade.idTpInteressado.descricao}</td>
+								<td>${marcador.idFinalidade.descricao}</td>
+								<c:if test="${empty grupoDefault}">
+									<td>${marcador.idGrupo.nome}</td>
+								</c:if>
 								<td>${marcador.hisAtivo eq 1? 'Sim' : 'Não'}</td>
 							</tr>
 						</c:forEach>

--- a/siga/src/main/webapp/WEB-INF/page/cpMarcador/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/cpMarcador/lista.jsp
@@ -1,11 +1,13 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	buffer="64kb"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://localhost/libstag" prefix="f"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
 <jsp:useBean id="now" class="java.util.Date" />
 
 <siga:pagina titulo="Lista Marcadores">
+	<c:set var="grupoDefault" scope="session" value="${f:resource('/siga.marcadores.grupo.default')}" />
 	<form name="frm" action="listar" class="form" method="GET">
 		<input type="hidden" name="paramoffset" value="0" /> <input
 			type="hidden" name="p.offset" value="0" />
@@ -20,11 +22,13 @@
 						<thead class="${thead_color}">
 							<tr>
 								<th class="text-left w-10">Categoria</th>
-								<th class="text-left w-35">Marcador</th>
+								<th class="text-left w-20">Marcador</th>
 								<th class="text-left w-10">Tipo</th>
-								<th class="text-left w-10">Finalidade</th>
-								<th class="text-left w-10">Grupo</th>
-								<th colspan="2" class="text-right w-15">Op&ccedil;&otilde;es</th>
+								<th class="text-left w-30">Finalidade</th>
+								<c:if test="${empty grupoDefault}">
+									<th class="text-left w-10">Grupo</th>
+								</c:if>
+								<th colspan="2" class="text-right w-20">Op&ccedil;&otilde;es</th>
 							</tr>
 						</thead>
 
@@ -33,7 +37,7 @@
 								<tr>
 									<fmt:formatDate var="dtIni" value="${marcador.hisDtIni}" type='date' pattern="dd/MM/yyyy" />
 									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-10">${marcador.idFinalidade.grupo.nome}</td>
-									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-30"><span
+									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-20"><span
 										class="badge badge-pill badge-secondary tagmesa btn-xs"
 										title="${marcador.descrDetalhada}"> <i
 											class="${marcador.idIcone.codigoFontAwesome}"
@@ -43,9 +47,11 @@
 										${marcador.hisDtIni gt now? '<br /><small>(Será ativado em '.concat(dtIni).concat(')</small>'):''}
 									</td>
 									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-10">${marcador.idFinalidade.nome}</td>
-									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-10">${marcador.idFinalidade.descricao}</td>
-									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-10">${marcador.idGrupo.nome}</td>
-									<td class="text-left w-10">
+									<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-30">${marcador.idFinalidade.descricao}</td>
+									<c:if test="${empty grupoDefault}">
+										<td class="${marcador.hisDtIni gt now? 'disabled':''} text-left w-10">${marcador.idGrupo.nome}</td>
+									</c:if>
+									<td class="text-left w-20">
 										<div class="">
 											<button type="button" id="btn-excluir"
 												class="enabled btn btn-outline-secondary btn-sm p-1 m-1 float-right"


### PR DESCRIPTION
No cadastro de marcadores, a tela de histórico das alterações dos marcadores não estava de acordo com as colunas da lista da tela inicial. 
Antes:
![image](https://user-images.githubusercontent.com/49542320/134600121-92c5cd52-e2b0-4b7a-aa52-1bfff8b258ae.png)

Depois:
![image](https://user-images.githubusercontent.com/49542320/134601534-c80a0c49-2117-4fef-8394-92a711e6895c.png)

Na lista da página principal do cadastro, a coluna Grupo passa a não aparecer se o grupo default for informado nas propriedades do sistema (/siga.marcadores.grupo.default).

![image](https://user-images.githubusercontent.com/49542320/134600178-ec0fd3be-8479-4237-9971-aef27a8896d9.png)
