### PR TITLE
RM58859 - Marca não exibia lotação no quadro de marcadores se não estava autorizada a ver o documento

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -619,9 +619,24 @@
 										<c:if test="${marca.cpMarcador.idFinalidade.idTpInteressado != 'ATENDENTE'}">
 											- <c:if test="${not empty pessoaAtual}"><siga:selecionado isVraptor="true" sigla="${pessoaAtual.nomeAbreviado}"
 											descricao="${pessoaAtual.descricao} - ${pessoaAtual.sigla}"
-											pessoaParam="${pessoaAtual.siglaCompleta}" /></c:if><c:if test="${not empty lotacaoAtual}"><c:if test="${not empty pessoaAtual}">/</c:if><siga:selecionado isVraptor="true" sigla="${marca.dpLotacaoIni.lotacaoAtual.sigla}"
-											descricao="${marca.dpLotacaoIni.lotacaoAtual.descricaoAmpliada}"
-											lotacaoParam="${marca.dpLotacaoIni.lotacaoAtual.siglaCompleta}" /></c:if>
+											pessoaParam="${pessoaAtual.siglaCompleta}" /></c:if>
+											<c:choose>
+												<c:when test="${not empty lotacaoAtual}">
+													<c:if test="${not empty pessoaAtual}">/</c:if>
+													<siga:selecionado isVraptor="true" sigla="${marca.dpLotacaoIni.lotacaoAtual.sigla}"
+														descricao="${marca.dpLotacaoIni.lotacaoAtual.descricaoAmpliada}"
+														lotacaoParam="${marca.dpLotacaoIni.lotacaoAtual.siglaCompleta}" />
+												</c:when>
+												<c:otherwise>
+													<c:if test="${empty pessoaAtual}">
+														<siga:selecionado 
+															isVraptor="true" 
+															sigla="${marca.exMovimentacao.lotaSubscritor.sigla} (Sem acesso ao documento - A marca não será mostrada)"
+															descricao="${marca.exMovimentacao.lotaSubscritor.descricaoAmpliada}"
+															lotacaoParam="${marca.exMovimentacao.lotaSubscritor.siglaCompleta}" />
+													</c:if>												
+												</c:otherwise>
+											</c:choose>
 										</c:if>
 										</td>
 										<c:choose>


### PR DESCRIPTION
Se um documento era marcado com um marcador local direcionado para uma lotação não autorizada a visualizar o documento, a indicação no quadro de marcadores ficava sem nada, apenas com um hífen.

![image](https://user-images.githubusercontent.com/49542320/134611921-b31a85a6-59a3-4ec0-8a4f-0ab53449a6dd.png)

![image](https://user-images.githubusercontent.com/49542320/134612057-041bcc8c-0351-4661-bed4-a19a6e063074.png)

Passa a obter direto da movimentação a lotação nesse caso, mostrando uma mensagem informativa:
![image](https://user-images.githubusercontent.com/49542320/134612212-7b01200d-dee8-4e36-84b6-40abdaf15a64.png)

