### PR TITLE
RM84216: Correção da rotina migração de scripts com FlyWay

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/SigaFlyway.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/util/SigaFlyway.java
@@ -46,6 +46,11 @@ public class SigaFlyway {
 			Context envContext = (Context) initContext.lookup("java:");
 			DataSource ds = (DataSource) envContext.lookup(dataSource);
 			Flyway flyway = Flyway.configure().dataSource(ds).locations(location).placeholderReplacement(false).load();
+			
+			if ("true".equals(System.getProperty("siga.flyway.mysql.repair", "true"))) {
+				flyway.repair();
+			}
+			
 			flyway.migrate();
 		}
 	}


### PR DESCRIPTION
Ao corrigir um script que já foi aplicado na base, o SIGA não sobe quando ligada a migrate do flyway devido ao conflito de checksums dos scripts, como no exemplo abaixo:

`14:54:12,627 ERROR [org.jboss.as.controller.management-operation] (Controller Boot Thread) WFLYCTL0013: Falha na operação ("deploy") - endereço ([("deployment" => "siga.war")]) - falha na descrição: {"WFLYCTL0080: Falha de serviços" => {"jboss.deployment.unit.\"siga.war\".component.SigaStarter.START" => "java.lang.IllegalStateException: WFLYEE0042: Falha ao construir a instância do componente
    Caused by: java.lang.IllegalStateException: WFLYEE0042: Falha ao construir a instância do componente
    Caused by: javax.ejb.EJBException: org.flywaydb.core.api.FlywayException: Validate failed: 
Migration checksum mismatch for migration version 73.0
-> Applied to database : 783906997
-> Resolved locally    : 1714366840

    Caused by: org.flywaydb.core.api.FlywayException: Validate failed: 
Migration checksum mismatch for migration version 73.0
-> Applied to database : 783906997
-> Resolved locally    : 1714366840
"}}`

Para resolver, foi acrescentado no passo antes da migrate o flyway repair para checar e refazer os checksums caso haja conflito, como no exemplo abaixo:

`14:58:18,914 INFO  [org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory] (ServerService Thread Pool -- 72) Repairing Schema History table for version 73.0 (Description: Estrutura Publicacao Portal Transparencia, Type: SQL, Checksum: 1714366840)  ...
`

Caso não haja conflitos a se resolver, ele segue para migrate, como no exemplo:

`14:58:25,120 INFO  [org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory] (Thread-126) Repair of failed migration in Schema History table `siga`.`flyway_schema_history` not necessary. No failed migration detected.
14:58:25,370 INFO  [org.flywaydb.core.internal.command.DbRepair] (Thread-126) Successfully repaired schema history table `siga`.`flyway_schema_history` (execution time 00:00.264s).`


Isso não corrige a estrutura do banco que já está feita, mas evita que novas instalações sejam criadas com um script errado.

Segue 4 scripts que foram necessários aplicar para corrigir a estrutura até o momento:
[01-correcao-hierarquia-cp-servico-exportacao.txt](https://github.com/projeto-siga/siga/files/7261899/01-correcao-hierarquia-cp-servico-exportacao.txt)
[02-correcao-scriptv85-criacao-servico-alt.txt](https://github.com/projeto-siga/siga/files/7261900/02-correcao-scriptv85-criacao-servico-alt.txt
[05-correcao-datetime-cptoken.txt](https://github.com/projeto-siga/siga/files/7261910/05-correcao-datetime-cptoken.txt)
)
[04-marcador-documento-analisado.txt](https://github.com/projeto-siga/siga/files/7261901/04-marcador-documento-analisado.txt)


