### PR TITLE
RM83330 - Documento apensado em documento juntado não é carregado na tramitação

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -2633,6 +2633,13 @@ public class ExBL extends CpBL {
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA_EXTERNA:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_RECEBIMENTO:
 				set = mob.getMobilEApensosExcetoVolumeApensadoAoProximo();
+				Set<ExMobil> setJuntados = mob.getJuntadosRecursivo();
+				
+				for (ExMobil exMobil : setJuntados) {
+					set.addAll(exMobil.getMobilEApensosExcetoVolumeApensadoAoProximo());
+				}
+				set.removeAll(setJuntados);
+
 				break;
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_DESPACHO_TRANSFERENCIA:
@@ -4905,6 +4912,13 @@ public class ExBL extends CpBL {
 		boolean fTranferencia = lotaResponsavel != null || responsavel != null;
 
 		SortedSet<ExMobil> set = mob.getMobilEApensosExcetoVolumeApensadoAoProximo();
+		
+		Set<ExMobil> setJuntados = mob.getJuntadosRecursivo();
+		
+		for (ExMobil exMobil : setJuntados) {
+			set.addAll(exMobil.getMobilEApensosExcetoVolumeApensadoAoProximo());
+		}
+		set.removeAll(setJuntados);
 
 		Date dtUltReceb = null;
 


### PR DESCRIPTION
1) Criei um documento expediente "1", finalizei e assinei.

2) Criei um documento expediente "2", finalizei e assinei.

3) Criei um documento expediente "3", finalizei e assinei.

4) Criei um documento expediente "4", finalizei e assinei.

5) Apensei o documento "2" no documento "1".

6) Apensei o documento "4" no documento "3".

7) Juntei o documento "3" ao documento "1".

-----------------------------------------------------
Ficou dessa forma:

» Documento "1" (pai)
»»» Documento "2" (apensado no "1")
»»» Documento "3" (juntado no "1")
»»»»» Documento "4" (apensado no "3")
-----------------------------------------------------

8) Tramitei o documento "1" para outro usuário.

RESULTADO OK:

- O documento "2" que estava apensado foi carregado paralelamente ao documento "1", ou seja, os dois apareceram na mesa do destino.
- O documento "3" que estava juntado foi carregado dentro do documento "1".

ERRO:

- O documento "4" que estava apensado ao documento "3" não foi carregado para o destino.

CORREÇÃO:

Da mesma forma que o documento "2" apensado ao pai foi carregado para o destino, o documento "4" que é apensado ao filho também deve ser.