### PR TITLE
Atendendo ao RM74955, o responsável pela etapa apresentado no fluxo p…

### DIFF
--- a/siga-wf/src/main/java/br/gov/jfrj/siga/wf/util/WfResp.java
+++ b/siga-wf/src/main/java/br/gov/jfrj/siga/wf/util/WfResp.java
@@ -19,10 +19,11 @@ public class WfResp implements Responsible {
 
 	@Override
 	public String getInitials() {
-		if (pessoa != null)
-			return pessoa.getSigla();
 		if (lotacao != null)
 			return lotacao.getSiglaCompleta();
+		if (pessoa != null)
+			return pessoa.getSigla();
+		
 		return null;
 	}
 


### PR DESCRIPTION
Atendendo ao RM74955, o responsável pela etapa apresentado no fluxo passa a ser a lotação e não mais o usuário

![MicrosoftTeams-image](https://user-images.githubusercontent.com/90341086/138100647-63207de5-bbb7-435f-b3ca-ea4011b92d9d.png)

![image](https://user-images.githubusercontent.com/90341086/138099830-08ea36ee-d9c6-4ea8-9831-b3281cfc6cc1.png)
