### PR TITLE
RM88749 - Aumento do campo do número do expediente na pesquisa

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -624,7 +624,7 @@
 						</div>
 							<div class="form-group col-md-3">
 								<label for="numExpediente">Número</label>
-							    <input type="text" size="7" name="numExpediente" value="${numExpediente}" maxlength="6" class="form-control" />
+							    <input type="text" size="10" name="numExpediente" value="${numExpediente}" maxlength="10" class="form-control" />
 							</div>
 					</div>
 					<div class="form-row">


### PR DESCRIPTION
Atualmente o campo Número do Expediente na pesquisa está limitado em 6 caracteres. Foi aumentado para 10.
![image](https://user-images.githubusercontent.com/49542320/140532135-8b4dc98a-c933-40d1-a86c-e8fe94d04a38.png)
