### PR TITLE
Adicionando validação para assinar em lote com certificado digital ou senha

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -1413,6 +1413,10 @@ public class ExBL extends CpBL {
 		String sNome;
 		Long lCPF = null;
 
+		if (doc.getExMobilPai() != null) {
+			juntar = true;
+		}
+		
 		if (doc.isCancelado())
 			throw new AplicacaoException("não é possível assinar um documento cancelado.");
 
@@ -1750,6 +1754,10 @@ public class ExBL extends CpBL {
 		boolean fSubstituindoCosignatario = false;
 		final String formaAssinaturaSenha = senhaIsPIN ? "PIN" : "Senha";
 		final String concordanciaAssinaturaSenha = senhaIsPIN ? "o" : "a";
+		
+		if (doc.getExMobilPai() != null) {
+			juntar = true;
+		}
 		
 		if (matriculaSubscritor == null || matriculaSubscritor.isEmpty())
 			throw new AplicacaoException("Matrícula do Subscritor não foi informada.");


### PR DESCRIPTION
Falha: Não estava juntando automático quando o usuário assinava com certificado digital ou senha em lote.

**evidencia de funcionamento após implementação:**

![001](https://user-images.githubusercontent.com/73559672/140804240-95b4669a-d972-480a-bdff-a0ecc64cb7e1.PNG)
![002](https://user-images.githubusercontent.com/73559672/140804264-e6eaa459-edf6-4604-939d-6ef2d7f25bef.PNG)
![003](https://user-images.githubusercontent.com/73559672/140804277-e0c17929-0db1-4740-a007-1e0279d4e877.PNG)


