### PR TITLE
PCRJ-659 Erro verificacao autenticacao anexos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
@@ -56,6 +56,7 @@ import br.gov.jfrj.siga.base.AcaoVO;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.SigaMessages;
+import br.gov.jfrj.siga.base.util.Texto;
 import br.gov.jfrj.siga.base.util.Utils;
 import br.gov.jfrj.siga.bluc.service.BlucService;
 import br.gov.jfrj.siga.bluc.service.ValidateRequest;
@@ -1269,29 +1270,36 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 		}
 	}
 
-	public String assertAssinaturaValida() throws Exception {
+	public String assertAssinaturaValida(boolean retornaNome) throws Exception {
 		long l = getExTipoMovimentacao().getId();
 		switch ((int) l) {
 		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA:
 		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_COM_SENHA:
 			return assertAssinaturaComSenhaValida(this.getExDocumento().getPdf(), this.getAuditHash(),
-					this.getDtIniMov());
+					this.getDtIniMov(), retornaNome);
 		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_MOVIMENTACAO_COM_SENHA:
 			return assertAssinaturaComSenhaValida(this.getExMovimentacaoRef().getConteudoBlobpdf(), this.getAuditHash(),
-					this.getDtIniMov());
+					this.getDtIniMov(), retornaNome);
 		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO:
-		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_DOCUMENTO:
 			return assertAssinaturaDigitalValida(this.getExDocumento().getPdf(), this.getConteudoBlobMov(),
-					this.getDtIniMov());
+					this.getDtIniMov(), retornaNome);
+			
+		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_DOCUMENTO:
+			return assertAssinaturaDigitalValida(this.getExMovimentacaoRef().getConteudoBlobpdf(), this.getConteudoBlobMov(),
+					this.getDtIniMov(), retornaNome);
 		case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_MOVIMENTACAO:
 			return assertAssinaturaDigitalValida(this.getExMovimentacaoRef().getConteudoBlobpdf(),
-					this.getConteudoBlobMov(), this.getDtIniMov());
+					this.getConteudoBlobMov(), this.getDtIniMov(), retornaNome);
 		default:
 			throw new AplicacaoException("Não é Assinatura");
 		}
 	}
+	
+	public String assertAssinaturaValida() throws Exception {
+		return this.assertAssinaturaValida(false);
+	}
 
-	private String assertAssinaturaComSenhaValida(byte[] pdf, String jwt, Date dtMov) throws Exception {
+	private String assertAssinaturaComSenhaValida(byte[] pdf, String jwt, Date dtMov, boolean retornaNome) throws Exception {
 		if (dtMov == null || dtMov.before(Prop.getData("data.validar.assinatura.com.senha")))
 			return "OK.";
 		
@@ -1318,10 +1326,18 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 		byte[] sha256Pdf = BlucService.calcSha256(pdf);
 		if (!Arrays.equals(sha256Audit, sha256Pdf))
 			throw new AplicacaoException("Inválido (sha256 diferente)");
-		return "OK (sha256)";
+		
+		String sNome =  (String)  payload.get("name");
+		
+		if (sNome != null) {
+			sNome = Texto.maiusculasEMinusculas(sNome);
+		}
+		
+		return retornaNome ? sNome : "OK (sha256)";
 	}
 
-	private String assertAssinaturaDigitalValida(byte[] pdf, byte[] cms, Date dtMov) throws Exception {
+	private String assertAssinaturaDigitalValida(byte[] pdf, byte[] cms, Date dtMov,boolean retornaNome) throws Exception {
+		
 		if (dtMov == null || dtMov.before(Prop.getData("data.validar.assinatura.digital")))
 			return "OK.";
 		
@@ -1339,11 +1355,16 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 		String sNome = validateresp.getCn();
 
 		Service.throwExceptionIfError(sNome);
+		
+		if (sNome != null) {
+			sNome = Texto.maiusculasEMinusculas(sNome);
+		}
 
 		String sCPF = validateresp.getCertdetails().get("cpf0");
 		Service.throwExceptionIfError(sCPF);
 
-		return "OK (" + validateresp.getPolicy() + " v" + validateresp.getPolicyversion() + ")";
+		String retorno = retornaNome ? sNome : "OK" ;
+		return retorno +" (" + validateresp.getPolicy() + " v" + validateresp.getPolicyversion() + ")";
 	}
 	
 	public boolean isResp(DpPessoa titular, DpLotacao lotaTitular) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6613,6 +6613,7 @@ public class ExBL extends CpBL {
 		}
 	}
 
+	@Deprecated
 	public String verificarAssinatura(byte[] conteudo, byte[] assinatura, String mimeType, Date dtAssinatura)
 			throws Exception {
 		BlucService bluc = Service.getBlucService();

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6613,46 +6613,6 @@ public class ExBL extends CpBL {
 		}
 	}
 
-	@Deprecated
-	public String verificarAssinatura(byte[] conteudo, byte[] assinatura, String mimeType, Date dtAssinatura)
-			throws Exception {
-		BlucService bluc = Service.getBlucService();
-
-		// Chamar o BluC para validar a assinatura
-		//
-		ValidateRequest validatereq = new ValidateRequest();
-		validatereq.setEnvelope(bluc.bytearray2b64(assinatura));
-		validatereq.setSha1(bluc.bytearray2b64(bluc.calcSha1(conteudo)));
-		validatereq.setSha256(bluc.bytearray2b64(bluc.calcSha256(conteudo)));
-		validatereq.setTime(dtAssinatura);
-		validatereq.setCrl("true");
-		ValidateResponse validateresp = assertValid(bluc, validatereq);
-
-		String sNome;
-		Long lCPF;
-
-		sNome = validateresp.getCn();
-
-		Service.throwExceptionIfError(sNome);
-
-		if (sNome != null) {
-			sNome = Texto.maiusculasEMinusculas(sNome);
-		}
-
-		String sCPF = validateresp.getCertdetails().get("cpf0");
-		Service.throwExceptionIfError(sCPF);
-
-		lCPF = Long.valueOf(sCPF);
-
-		if (validateresp.getPolicy() == null)
-			return sNome;
-
-		if (validateresp.getPolicyversion() == null)
-			return sNome + " (" + validateresp.getPolicy() + ")";
-
-		return sNome + " (" + validateresp.getPolicy() + " v" + validateresp.getPolicyversion() + ")";
-	}
-
 	public void gravarModelo(ExModelo modNovo, ExModelo modAntigo, Date dt, CpIdentidade identidadeCadastrante)
 			throws AplicacaoException {
 		if ("template-file/jsp".equals(modNovo.getConteudoTpBlob())) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAutenticacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAutenticacaoController.java
@@ -201,6 +201,7 @@ public class ExAutenticacaoController extends ExController {
  					false);
 			
 			switch ( mov.getExTipoMovimentacao().getId().intValue()) {
+			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_COM_SENHA:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_COM_SENHA:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_MOVIMENTACAO_COM_SENHA:
 				fileName = arq.getReferencia() + "_" + mov.getIdMov() + ".jwt";
@@ -211,6 +212,7 @@ public class ExAutenticacaoController extends ExController {
 				bytes = mov.getAuditHash().getBytes(StandardCharsets.UTF_8);
 				break;
 				
+			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_CONFERENCIA_COPIA_DOCUMENTO:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_DOCUMENTO:
 			case (int) ExTipoMovimentacao.TIPO_MOVIMENTACAO_ASSINATURA_DIGITAL_MOVIMENTACAO:
 				fileName = arq.getReferencia() + "_" + mov.getIdMov() + ".p7s";

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4455,12 +4455,6 @@ public class ExMovimentacaoController extends ExController {
 		final ExMovimentacao mov = builder.getMov();
 
 		try {
-//			final String s = Ex
-//					.getInstance()
-//					.getBL()
-//					.verificarAssinatura(doc.getConteudoBlobPdf(),
-//							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
-//							mov.getDtIniMov());
 			
 			final String s = mov.assertAssinaturaValida(true);
 			
@@ -4486,12 +4480,6 @@ public class ExMovimentacaoController extends ExController {
 		final ExMovimentacao movRef = mov.getExMovimentacaoRef();
 
 		try {
-//			final String s = Ex
-//					.getInstance()
-//					.getBL()
-//					.verificarAssinatura(movRef.getConteudoBlobpdf(),
-//							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
-//							mov.getDtIniMov());
 			
 			final String s = mov.assertAssinaturaValida(true);
 			

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -4455,12 +4455,15 @@ public class ExMovimentacaoController extends ExController {
 		final ExMovimentacao mov = builder.getMov();
 
 		try {
-			final String s = Ex
-					.getInstance()
-					.getBL()
-					.verificarAssinatura(doc.getConteudoBlobPdf(),
-							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
-							mov.getDtIniMov());
+//			final String s = Ex
+//					.getInstance()
+//					.getBL()
+//					.verificarAssinatura(doc.getConteudoBlobPdf(),
+//							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
+//							mov.getDtIniMov());
+			
+			final String s = mov.assertAssinaturaValida(true);
+			
 			getRequest().setAttribute("assinante", s);
 
 			result.use(Results.page()).forwardTo(
@@ -4483,12 +4486,15 @@ public class ExMovimentacaoController extends ExController {
 		final ExMovimentacao movRef = mov.getExMovimentacaoRef();
 
 		try {
-			final String s = Ex
-					.getInstance()
-					.getBL()
-					.verificarAssinatura(movRef.getConteudoBlobpdf(),
-							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
-							mov.getDtIniMov());
+//			final String s = Ex
+//					.getInstance()
+//					.getBL()
+//					.verificarAssinatura(movRef.getConteudoBlobpdf(),
+//							mov.getConteudoBlobMov2(), mov.getConteudoTpMov(),
+//							mov.getDtIniMov());
+			
+			final String s = mov.assertAssinaturaValida(true);
+			
 			getRequest().setAttribute("assinante", s);
 
 			result.use(Results.page()).forwardTo(


### PR DESCRIPTION
ver #2007 
Dois metodos eram utilizados para validar assinatura:
ExMovimentação.asserAssinaturaValida()  e  ExBl.verificarAssinatura()

Foi feito um refactor para a utilização de somente um metodo de validação de assinatura.
ExMovimentação.asserAssinaturaValida() 

o  ExBl.verificarAssinatura()  foi excluido do codigo.