### PR TITLE
RM74955: módulo WF: apresentação das iniciais seguidas pelo sobrenome…

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpPessoa.java
@@ -537,6 +537,26 @@ public class DpPessoa extends AbstractDpPessoa implements Serializable,
 		return nomeAbreviado;
 	}
 
+	public String getSobrenomeEIniciais() {
+		if (getNomePessoa() == null)
+			return "";
+		String a[] = getNomePessoa().split(" ");
+
+		String nomeAbreviado = "";
+		for (int i = 0; i < a.length; i++) {
+			String n = a[i];
+			
+			if (n.trim().length() != 0) {
+				if (i == a.length -1)
+					nomeAbreviado += n.substring(0, 1).toUpperCase() + n.substring(1).toLowerCase();
+				else if (!"|DA|DE|DO|DAS|DOS|E|".contains("|" + n + "|"))
+					nomeAbreviado += n.substring(0, 1) + ".";
+			}
+		}
+		return nomeAbreviado;
+	}
+
+	
 	public Long getHisIdIni() {
 		return getIdPessoaIni();
 	}

--- a/siga-wf/src/main/java/br/gov/jfrj/siga/wf/util/WfResp.java
+++ b/siga-wf/src/main/java/br/gov/jfrj/siga/wf/util/WfResp.java
@@ -20,7 +20,7 @@ public class WfResp implements Responsible {
 	@Override
 	public String getInitials() {
 		if (pessoa != null)
-			return pessoa.getSigla();
+			return pessoa.getSobrenomeEIniciais();
 		if (lotacao != null)
 			return lotacao.getSiglaCompleta();
 		return null;


### PR DESCRIPTION
Módulo WF: apresentação das iniciais seguidas pelo sobrenome ao invés da matrícula do usuário nas etapas do fluxo.

Antes:
![fluxo](https://user-images.githubusercontent.com/90341086/142626534-e60aa1cb-060b-4d30-9745-bd5e7f393771.PNG)

Depois:
![fluxo_modificado](https://user-images.githubusercontent.com/90341086/142626550-6185bd90-4277-4944-9f20-d896813a6aec.PNG)

