### PR TITLE
PCRJ-1171 correcao no default.ftl para modelos com varios editores

### DIFF
--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -1374,42 +1374,47 @@ CKEDITOR.replace( '${var}',
 								CKEDITOR.config.scayt_sLang = 'pt_BR';
 								CKEDITOR.config.stylesSet = 'siga_ckeditor_styles';
 								
-								CKEDITOR.stylesSet.add('siga_ckeditor_styles', [{
-								        name: 'Título',
-								        element: 'h1',
-								        styles: {
-								            'text-align': 'justify',
-								            'text-indent': '2cm'
-								        }
-								    },
-								    {
-								        name: 'Subtítulo',
-								        element: 'h2',
-								        styles: {
-								            'text-align': 'justify',
-								            'text-indent': '2cm'
-								        }
-								    },
-								    {
-								        name: 'Com recuo',
-								        element: 'p',
-								        styles: {
-								            'text-align': 'justify',
-								            'text-indent': '2cm'
-								        }
-								    },
-								    {
-								        name: 'Marcador',
-								        element: 'span',
-								        styles: {
-								        	'background-color' : '#FFFF00'
-								        }
-								    },
-								    {
-								        name: 'Normal',
-								        element: 'span'
-								    }
-								]);
+								if (CKEDITOR.stylesSet.get('siga_ckeditor_styles') == null) {
+								
+									CKEDITOR.stylesSet.add('siga_ckeditor_styles', [{
+									        name: 'Título',
+									        element: 'h1',
+									        styles: {
+									            'text-align': 'justify',
+									            'text-indent': '2cm'
+									        }
+									    },
+									    {
+									        name: 'Subtítulo',
+									        element: 'h2',
+									        styles: {
+									            'text-align': 'justify',
+									            'text-indent': '2cm'
+									        }
+									    },
+									    {
+									        name: 'Com recuo',
+									        element: 'p',
+									        styles: {
+									            'text-align': 'justify',
+									            'text-indent': '2cm'
+									        }
+									    },
+									    {
+									        name: 'Marcador',
+									        element: 'span',
+									        styles: {
+									        	'background-color' : '#FFFF00'
+									        }
+									    },
+									    {
+									        name: 'Normal',
+									        element: 'span'
+									    }
+									]);
+								
+								};
+								
 								CKEDITOR.config.toolbar = 'SigaToolbar';
 								
 								CKEDITOR.config.toolbar_SigaToolbar = [{


### PR DESCRIPTION
Correção do erro apresentado na issue #2013

Observamos que os modelos fazem varias chamadas a macro Editor ( Default.ftl ) e que a siga_ckeditor_styles estava sendo criada varias vezes.

Solução:
criar siga_ckeditor_styles  somente se não existir.

if (CKEDITOR.stylesSet.get('siga_ckeditor_styles') == null) {