### PR TITLE
Criação de função para remover grupos duplicados na exibição da tela de mesa em SP

### DIFF
--- a/siga/src/main/webapp/javascript/mesa2.js
+++ b/siga/src/main/webapp/javascript/mesa2.js
@@ -539,11 +539,24 @@ function carregaFromJson(json, appMesa) {
 			}
 		}
 	}
+	
+	appMesa.grupos = removerGruposDuplicados(appMesa.grupos);
 	sessionStorage.setItem(
 		'mesa' + getUser(), JSON.stringify(appMesa.grupos));
 	atualizaGrupos(appMesa.grupos);
 	appMesa.primeiraCarga = false;
 	appMesa.carregando = false;
+}
+
+function removerGruposDuplicados(values) {
+	let concatArray = values.map(eachValue => {
+		return Object.values(eachValue).join('')
+	});
+	let filterValues = values.filter((value, index) => {
+		return concatArray.indexOf(concatArray[index]) === index
+
+	});
+	return filterValues;
 }
 
 function getUser() {


### PR DESCRIPTION
Foi aberto o RM78219 informando que eventualmente quando o sistema apresenta algum tipo de lentidão em SP, a tela de mesa virtual apresenta grupos duplicados. Tentamos nos últimos dias simular o problema em ambiente de desenvolvimento de forma natural, e não obtivemos sucesso. Sendo assim, simulamos um cenário e criamos uma função para tratar esses casos. 

Basicamente, a função remove os objetos json duplicados. Abaixo segue os prints de testes "mockados".

Simulação de erro
![error_duplicados](https://user-images.githubusercontent.com/15185675/142871150-2ccd1a66-0b05-4a07-b825-7da4b90e88ed.JPG)

Remoção de duplicados após execução da função
![error_duplicados_correcao](https://user-images.githubusercontent.com/15185675/142871279-cd7b3981-f877-4e68-ba85-e5c3cabf32aa.JPG)

