### PR TITLE
PCRJ1394 Correção do calcular marcas de documentos sobrestado porém na situação aguardando andamento

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -65,7 +65,41 @@ public class ExMarcadorBL {
 		} else {
 			acrescentarMarcadores();
 		}
+		removerMarcasIncompativeis();
 	}
+
+
+	private void removerMarcasIncompativeis() {
+		
+		// this.removerMarcasIncompativeis(CpMarcadorEnum.ARQUIVADO, CpMarcadorEnum.EM_ANDAMENTO);
+		this.removerMarcasIncompativeis(CpMarcadorEnum.SOBRESTADO, CpMarcadorEnum.EM_ANDAMENTO);
+
+	}
+		
+	
+	private void removerMarcasIncompativeis(CpMarcadorEnum primario, CpMarcadorEnum secundario) {
+		
+		List<ExMarca> marcadoresIncompativeis = new ArrayList<ExMarca>();
+		
+		boolean isExistePrincipal = false;
+		
+		for (ExMarca m : set) {
+			if (m.getCpMarcador().getId() == primario.getId()) {
+				isExistePrincipal = true;
+			}
+			
+			if (m.getCpMarcador().getId() == secundario.getId()) {
+				marcadoresIncompativeis.add(m);
+			}
+		}
+		
+		if (isExistePrincipal) {
+			
+			set.removeAll(marcadoresIncompativeis);	
+		}
+		
+	}
+
 
 	/**
 	 * Calcula quais as marcas cada mobil terá com base nas movimentações que foram


### PR DESCRIPTION
Na atribuição da marca, esta é interceptada pra conferência e solução de possíveis conflitos. 
Ele repassa pra um método genérico onde serão tratados os conflitos individualmente.

Apos implementação do novo metodo para correção é necessário atualizar marcas
![PROCESSO_RIO-1394-tela3-atualizarmarca](https://user-images.githubusercontent.com/78379805/143450431-4c9f601b-e03d-4c05-8134-43dbdeed579f.PNG)

Apos a  atualização da marca 
![PROCESSO_RIO-1394-tela4-apos-atualizar-marcas](https://user-images.githubusercontent.com/78379805/143450537-458267b4-d0e8-4ce3-90f1-ede121c01ec8.PNG)

![PROCESSO_RIO-1394-tela5-mesa-apos-atualizarmarcas](https://user-images.githubusercontent.com/78379805/143450846-28f119ba-7b8c-46d8-839d-f41e5e5f1e4b.PNG)

