### PR TITLE
GOVSP: Adição de Regra para Subscritor poder Juntar

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeJuntar.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeJuntar.java
@@ -59,8 +59,11 @@ public class ExPodeJuntar extends CompositeExpressionSupport {
 
 				Not.of(new ExEstaEmTransito(mob, titular, lotaTitular)),
 
-				new ExPodeMovimentar(mob, titular, lotaTitular),
-
+				Or.of(  And.of(new ExTemMobilPai(mob.doc()), 
+							   new ExESubscritorOuCossignatario(mob.doc(), titular)),
+						
+						new ExPodeMovimentar(mob, titular, lotaTitular)),
+				
 				Or.of(
 
 						Not.of(new ExEstaPendenteDeAssinatura(mob.doc())),


### PR DESCRIPTION
Mesmo não sendo o finalizador do documento Filho.

Regra se soma ao restante:
E [ (documento filho possui um documento pai e usuário autenticado é o subscritor do documento) OU (pode movimentar o documento filho) ]

Lembrando que ainda há a necessidade de tramitar o documento pai ao subscritor ou lotação do subscritor para satisfazer o podeSerJuntado.

Caso queira juntar independente de estar ou não com o documento pai, deve ser alterado o podeSerJuntado.

A regra implementada elimina a necessidade de mandar o documento TMP para o subscritor finalizar e assinar. Documento agora pode estar finalizado em outra área que juntará desde que satisfeita as demais regras


Sem REGRA: DOCUMENTO FINALIZADO em área distinta do Subscritor NÃO JUNTA
![image](https://user-images.githubusercontent.com/20362170/145282450-4b7434de-e897-4f46-a542-1533ea87ba8c.png)
![image](https://user-images.githubusercontent.com/20362170/145282501-f1b8a5ff-cb3d-42a3-af82-9f8d15c5979d.png)


Com REGRA: DOCUMENTO FINALIZADO em área distinta do Subscritor JUNTA
![image](https://user-images.githubusercontent.com/20362170/145282618-b39206ab-c448-4f46-ab74-578b316e8b50.png)
![image](https://user-images.githubusercontent.com/20362170/145282643-c9577dab-01b5-4476-b370-1f7cf13eb299.png)
