### PR TITLE
Verificando se a data de assinatura é nula e atribuindo a mesma tanto assinando com senha ou com certificado.

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -1671,6 +1671,12 @@ public class ExBL extends CpBL {
 				// }
 	
 				mov.setDescrMov(assinante.getNomePessoa() + ":" + assinante.getSigla() + " [Digital]");
+				
+				if (doc.getDtPrimeiraAssinatura() == null) {
+					doc.setDtPrimeiraAssinatura(CpDao.getInstance().dt());  
+					Ex.getInstance().getBL().gravar(cadastrante, titular, mov.getLotaTitular(), doc);
+				}
+				
 				gravarMovimentacao(mov);
 	
 				concluirAlteracaoDocComRecalculoAcesso(mov);
@@ -1927,6 +1933,11 @@ public class ExBL extends CpBL {
 				String cpf = Long.toString(assinante.getCpfPessoa());
 				acrescentarHashDeAuditoria(mov, sha256, autenticando, assinante.getNomePessoa(), cpf, null);
 	
+				if (doc.getDtPrimeiraAssinatura() == null) {
+					doc.setDtPrimeiraAssinatura(CpDao.getInstance().dt());  
+					Ex.getInstance().getBL().gravar(cadastrante, titular, mov.getLotaTitular(), doc);
+				}
+				
 				gravarMovimentacao(mov);
 	
 				concluirAlteracaoDocComRecalculoAcesso(mov);


### PR DESCRIPTION
Corrigindo problema sobre a data de assinatura ao assinar em lote. Usuário assinando em lote não era atualizada a data de assinatura. Peguei o mesmo contexto do método aAssinar() da classe exMovimentacaoController.java junto o que foi debatido na reunião com o TRF2 para resolver esse problema. Segue a evidência da solução: 

**Documento antes de assinar em lote**
![doc-em-lote-antes-de-assinar](https://user-images.githubusercontent.com/73559672/147570550-1c2af832-0ae4-4b20-9396-0f7193322fd9.PNG)

**Assinando documento em lote**
![doc-em-lote](https://user-images.githubusercontent.com/73559672/147570608-5b571cd9-8fa6-4da1-aceb-f641c99b40f4.PNG)

**Documento após assinar em lote**
![doc-em-lote-assinado](https://user-images.githubusercontent.com/73559672/147570644-190819e9-ecb6-4273-888e-b12418de903d.PNG)

