### PR TITLE
GOVSP95397 Erro no cancelamento de documento com filho desentranhado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -2477,7 +2477,11 @@ public class ExBL extends CpBL {
 				final Object[] aMovimentacao = set.toArray();
 				for (int i = 0; i < set.size(); i++) {
 					final ExMovimentacao movimentacao = (ExMovimentacao) aMovimentacao[i];
-					if (!movimentacao.isCancelada()) {
+					if (!movimentacao.isCancelada()
+						&& movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.CANCELAMENTO_JUNTADA
+						&& movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.CANCELAMENTO_DE_MOVIMENTACAO
+						&& !(movimentacao.getExTipoMovimentacao() == ExTipoDeMovimentacao.JUNTADA 
+							&& movimentacao.getExMobil().sofreuMov(ExTipoDeMovimentacao.CANCELAMENTO_JUNTADA))) {
 						Ex.getInstance().getBL().cancelar(cadastrante, lotaCadastrante, movimentacao.getExMobil(),
 								movimentacao, null, cadastrante, cadastrante, "");
 					}


### PR DESCRIPTION
Ao cancelar um documento com documento filho juntado e desentranhado estava tentando cancelar movimentação de juntada do documento filho e causava o erro abaixo:

java.lang.RuntimeException: Erro ao cancelar o documento.
	at br.gov.jfrj.siga.ex.bl.ExBL.cancelarDocumento(ExBL.java:2454)
	at br.gov.jfrj.siga.vraptor.ExDocumentoController.cancelarDocumento(ExDocumentoController.java:2063)
	at br.gov.jfrj.siga.vraptor.AccessAuthInterceptor.intercept(AccessAuthInterceptor.java:53)
	at br.gov.jfrj.siga.vraptor.SigaInterceptor.intercept(SigaInterceptor.java:34)
	at br.gov.jfrj.siga.vraptor.AplicacaoExceptionInterceptor.intercept(AplicacaoExceptionInterceptor.java:47)
	at br.gov.jfrj.siga.util.ExInterceptor.intercept(ExInterceptor.java:75)
	at br.gov.jfrj.siga.vraptor.SigaTransacionalInterceptor.intercept(SigaTransacionalInterceptor.java:83)
Caused by: br.gov.jfrj.siga.base.AplicacaoException: não é permitido cancelar esta movimentação. - Proibido porque não pode cancelar movimentação por configuração
	at br.gov.jfrj.siga.ex.bl.ExCompetenciaBL.afirmar(ExCompetenciaBL.java:80)
	at br.gov.jfrj.siga.ex.bl.ExCompetenciaBL.afirmar(ExCompetenciaBL.java:166)
	at br.gov.jfrj.siga.ex.bl.ExBL.cancelar(ExBL.java:2811)
	at br.gov.jfrj.siga.ex.bl.ExBL.cancelarMovimentacoesReferencia(ExBL.java:2481)
	at br.gov.jfrj.siga.ex.bl.ExBL.cancelarDocumento(ExBL.java:2450)
	
Ocorria porque os cancelamentos de movimentações de referência não consideravam se o documento já estava desentranhado.

Alterado para não cancelar desentranhamentos ou juntadas já desentranhadas.
Cancelamentos de movimentações também passam a ser ignorados (somente para as movimentações de referência).