### PR TITLE
RM87145 - Corrige fluxo de Inativação/Ativação e Edição

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpCargo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpCargo.java
@@ -25,6 +25,7 @@
 package br.gov.jfrj.siga.dp;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.Date;
 
 import javax.persistence.Entity;
@@ -211,6 +212,20 @@ public class DpCargo extends AbstractDpCargo implements Serializable,
 	public void setHisAtivo(Integer hisAtivo) {
 		// TODO Auto-generated method stub
 		
+	}
+	
+	/**
+	 * Retorna o Cargo atual (última) no historico deste Cargo
+	 * 
+	 * @return DpCargo
+	 * @throws SQLException
+	 */
+	public DpCargo getCargoAtual() {
+
+		if (this.getDataFim() != null)
+			return CpDao.getInstance().consultarPorIdInicialDpCargoAtual(this.getIdCargoIni());
+
+		return this;
 	}
 
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpFuncaoConfianca.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/DpFuncaoConfianca.java
@@ -25,6 +25,7 @@
 package br.gov.jfrj.siga.dp;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.Date;
 
 import javax.persistence.Entity;
@@ -228,5 +229,20 @@ public class DpFuncaoConfianca extends AbstractDpFuncaoConfianca implements
 	public void setHisAtivo(Integer hisAtivo) {
 		// TODO Auto-generated method stub
 		
+	}
+	
+	
+	/**
+	 * Retorna a Função de Confiança atual (última) no historico desta Função de Confiança
+	 * 
+	 * @return DpFuncaoConfianca
+	 * @throws SQLException
+	 */
+	public DpFuncaoConfianca getFuncaoConfiancaAtual() {
+
+		if (this.getDataFim() != null)
+			return CpDao.getInstance().consultarPorIdInicialDpFuncaoConfiancaAtual(this.getIdFuncaoIni());
+
+		return this;
 	}
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -25,6 +25,7 @@ package br.gov.jfrj.siga.dp.dao;
 
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2756,8 +2757,8 @@ public class CpDao extends ModeloDao {
 			Query sql = em().createNamedQuery("consultarQtdeDocCriadosPossePorDpLotacao");
 
 			sql.setParameter("idLotacao", idLotacao);
-			List result = sql.getResultList();
-			final int l = ((BigDecimal) sql.getSingleResult()).intValue();
+			
+			final Integer l = ((Number) sql.getSingleResult()).intValue(); //Number pq no MySQL NativeQuery retorna BigInteger e no Oracle BigDecimal
 			return l;
 		} catch (final NullPointerException e) {
 			return null;

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -351,6 +351,13 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 							"Já existe outro usuário ativo com estes dados: Órgão, Cargo, Função, Unidade e CPF");
 				}
 				
+				DpLotacao lotacaoAtual = dpPessoa.getLotacao().getLotacaoAtual();				
+				if ((lotacaoAtual == null) || (lotacaoAtual != null && lotacaoAtual.getDataFim() != null)) {
+					throw new AplicacaoException(
+							"Não é possível ativar pessoa. Lotação inexistente ou inativada.");
+				}
+				pessoa.setLotacao(lotacaoAtual);
+				
 				DpCargo cargoAtual= new DpCargo();				
 				cargoAtual = CpDao.getInstance().consultarPorIdInicialDpCargoAtual(pessoaAnt.getCargo().getIdCargoIni());
 				if ((cargoAtual == null) || (cargoAtual != null && cargoAtual.getDataFim() != null)) {
@@ -372,7 +379,6 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				
 				pessoa.setNomePessoa(pessoaAnt.getNomePessoa());
 				pessoa.setCpfPessoa(pessoaAnt.getCpfPessoa());
-				pessoa.setLotacao(pessoaAnt.getLotacao());
 				pessoa.setOrgaoUsuario(pessoaAnt.getOrgaoUsuario());
 				pessoa.setDataNascimento(pessoaAnt.getDataNascimento());
 				pessoa.setMatricula(pessoaAnt.getMatricula());
@@ -438,17 +444,20 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				if (pessoa.getDataNascimento() != null) {
 					result.include("dtNascimento", pessoa.getDtNascimentoDDMMYYYY());
 				}
-				if (pessoa.getCargo() != null) {
-					result.include("idCargo", pessoa.getCargo().getId());
-				}
+				
 				if (pessoa.getNomeExibicao() != null) {
 					result.include("nomeExibicao", pessoa.getNomeExibicao());
 				}
+				
+				if (pessoa.getCargo() != null) {
+					result.include("idCargo", pessoa.getCargo().getCargoAtual().getId());
+				}
+
 				if (pessoa.getFuncaoConfianca() != null) {
-					result.include("idFuncao", pessoa.getFuncaoConfianca().getId());
+					result.include("idFuncao", pessoa.getFuncaoConfianca().getFuncaoConfiancaAtual().getId());
 				}
 				if (pessoa.getLotacao() != null) {
-					result.include("idLotacao", pessoa.getLotacao().getId());
+					result.include("idLotacao", pessoa.getLotacao().getLotacaoAtual().getId());
 				}
 				
 				if(pessoa.getUfIdentidade() != null) {


### PR DESCRIPTION
Sistema permitia inativar uma pessoa, depois inativar uma Lotação, depois ativar a Pessoa com Lotação Inativa. Colocada verificação na Ativação similar os Cargo e Função de Confiança.

Na edição da Pessoa, trocado os ids dos objetos pelo o Atual, para que nos combos sejam apresentados os objetos selecionados. Ocorria um dessincronismo quando lotaçao, função ou cargo eram novamente ativos e a pessoa estava inativa, porque o versionamento só versiona objetos ativos. Então em caso de ativação sistema consultará o objeto atual