### PR TITLE
Implementa BuscarFechadas na Consulta por Sigla Pessoa e Lotação

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
@@ -62,6 +62,12 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ "      and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu))"
 				+ "      or (:siglaOrgaoLotacao is not null and lot.siglaLotacao = upper(:siglaOrgaoLotacao)))"
 				+ "	     and lot.dataFimLotacao = null"),
+		@NamedQuery(name = "consultarPorSiglaInclusiveFechadasDpLotacao", query = "select lotacao from DpLotacao lotacao where"
+				+ "      ((lotacao.siglaLotacao = upper(:siglaLotacao)"
+				+ "      and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lotacao.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu))"
+				+ "      or (:siglaOrgaoLotacao is not null and lotacao.siglaLotacao = upper(:siglaOrgaoLotacao)))"
+				+ "		 and exists (select 1 from DpLotacao lAux where lAux.idLotacaoIni = lotacao.idLotacaoIni"
+				+ "			group by lAux.idLotacaoIni having max(lAux.dataInicioLotacao) = lotacao.dataInicioLotacao)"),
 		@NamedQuery(name = "consultarPorSiglaDpLotacaoComLike", query = "select lot from DpLotacao lot where"
 				+ "        upper(lot.siglaLotacao) like upper('%' || :siglaLotacao || '%') "
 				+ "        and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
@@ -51,6 +51,9 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 		@NamedQuery(name = "consultarPorIdDpPessoa", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoa"),
 		@NamedQuery(name = "consultarPorIdInicialDpPessoa", query = "select pes from DpPessoa pes where pes.idPessoaIni = :idPessoaIni and pes.dataFimPessoa = null"),
 		@NamedQuery(name = "consultarPorSiglaDpPessoa", query = "select pes from DpPessoa pes where pes.matricula = :matricula and pes.sesbPessoa = :sesb and pes.dataFimPessoa = null"),
+		@NamedQuery(name = "consultarPorSiglaInclusiveFechadasDpPessoa", query = "select pes from DpPessoa pes where pes.matricula = :matricula and pes.sesbPessoa = :sesb "
+									+ " 	and exists (select 1 from DpPessoa pAux where pAux.idPessoaIni = pes.idPessoaIni "
+									+ "	 group by pAux.idPessoaIni having max(pAux.dataInicioPessoa) = pes.dataInicioPessoa)"),
 		@NamedQuery(name = "consultarPessoaAtualPelaInicial", query = "from DpPessoa pes "
 				+ "		where pes.idPessoaIni = :idPessoaIni "
 				+ "		and exists (select 1 from DpPessoa pAux where pAux.idPessoaIni = :idPessoaIni"

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -734,10 +734,16 @@ public class CpDao extends ModeloDao {
 			return null;
 		}
 	}
-
-	@SuppressWarnings("unchecked")
+	
 	public DpLotacao consultarPorSigla(final DpLotacao o) {
-		final Query query = em().createNamedQuery("consultarPorSiglaDpLotacao");
+		return consultarPorSigla(o, false);
+	}
+	
+	public DpLotacao consultarPorSigla(final DpLotacao o, final boolean buscarFechadas) {
+		final Query query = buscarFechadas ? 
+					em().createNamedQuery("consultarPorSiglaInclusiveFechadasDpLotacao") :
+					em().createNamedQuery("consultarPorSiglaDpLotacao");
+		
 		query.setParameter("siglaLotacao", o.getSiglaLotacao());
 		if (o.getOrgaoUsuario() != null) {
 			// O argumento siglaOrgaoLotacao preve a situação onde a sigla pesquisada contem um prefixo coincidente à 
@@ -828,15 +834,15 @@ public class CpDao extends ModeloDao {
 			CpOrgaoUsuario cpOrgaoUsu = consultar(flt.getIdOrgaoUsu(), CpOrgaoUsuario.class, false);
 			o.setOrgaoUsuario(cpOrgaoUsu);
 		}
-		DpLotacao lotacao = consultarPorSigla(o);
+		DpLotacao lotacao = consultarPorSigla(o,flt.isBuscarFechadas());
 		if(lotacao == null && flt.getSigla() != null) {
 			o.setSigla(flt.getSigla().replaceFirst("-", ""));
-			lotacao = consultarPorSigla(o);
+			lotacao = consultarPorSigla(o,flt.isBuscarFechadas());
 		}
 		if (lotacao == null) {
 			o.setSiglaLotacao(flt.getSigla());
 			o.setOrgaoUsuario(null);
-			return consultarPorSigla(o);
+			return consultarPorSigla(o,flt.isBuscarFechadas());
 		}
 		return lotacao;
 	}
@@ -1024,16 +1030,16 @@ public class CpDao extends ModeloDao {
 		return l;
 	}
 
-	@SuppressWarnings("unchecked")
 	public DpPessoa consultarPorSigla(final DpPessoa o) {
+		return consultarPorSigla(o, false);
+	}
+	public DpPessoa consultarPorSigla(final DpPessoa o, final boolean buscarFechadas) {
 		try {
-			final Query query = em().createNamedQuery("consultarPorSiglaDpPessoa");
+			final Query query = buscarFechadas ?
+					em().createNamedQuery("consultarPorSiglaInclusiveFechadasDpPessoa") :
+					em().createNamedQuery("consultarPorSiglaDpPessoa");
 			query.setParameter("sesb", o.getSesbPessoa());
 			query.setParameter("matricula", o.getMatricula());
-			/*
-			 * if (o.getOrgaoUsuario().getIdOrgaoUsu() != null) query.setParameter("idOrgaoUsu",
-			 * o.getOrgaoUsuario().getIdOrgaoUsu()); else query.setParameter("idOrgaoUsu", 0);
-			 */
 
 			final List<DpPessoa> l = query.getResultList();
 			if (l.size() != 1)
@@ -1043,7 +1049,7 @@ public class CpDao extends ModeloDao {
 			return null;
 		}
 	}
-
+	
 	/**
 	 * retorna a pessoa pelo sesb+matricula
 	 * 
@@ -1552,11 +1558,9 @@ public class CpDao extends ModeloDao {
 	public Selecionavel consultarPorSigla(final DpPessoaDaoFiltro flt) {
 		final DpPessoa o = new DpPessoa();
 		o.setSigla(flt.getSigla());
-		/*
-		 * CpOrgaoUsuario cpOrgao = new CpOrgaoUsuario();
-		 * cpOrgao.setIdOrgaoUsu(flt.getIdOrgaoUsu()); o.setOrgaoUsuario(cpOrgao);
-		 */
-		return consultarPorSigla(o);
+		
+		return consultarPorSigla(o, flt.isBuscarFechadas());
+
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Conforme demonstrado comportamento na reunião do dia 21/01/2022, o sistema não estava respeitando a busca de pessoas e lotações quando setado no componente selecionável o buscarFechadas=true.

Query não refletia o DaoFiltro, onde era setada a informação que desejava buscar o objeto por Sigla inclusive Fechado (com Data Fim), mas na Query havia a condição explícita para dataFim = null (somente ativas)

Criada 2 queries no padrão (**consultarPorSiglaInclusiveFechadasDpLotacao** e **consultarPorSiglaInclusiveFechadasDpPessoa**) e implementado os métodos no CpDAO para utilizar a query conforme o parâmetro do filtro.