### PR TITLE
feature/govsp/RM98171

### DIFF
--- a/siga-vraptor-module/src/main/resources/META-INF/tags/pagina.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/pagina.tag
@@ -9,6 +9,7 @@
 <%@ attribute name="onLoad"%>
 <%@ attribute name="desabilitarbusca"%>
 <%@ attribute name="desabilitarmenu"%>
+<%@ attribute name="iframe"%>
 <%@ attribute name="incluirJs"%>
 <%@ attribute name="compatibilidade"%>
 <%@ attribute name="desabilitarComplementoHEAD"%>
@@ -22,13 +23,24 @@
 
 <c:set var="titulo_pagina" scope="request">${titulo}</c:set>
 
-<siga:cabecalho titulo="${titulo}" popup="${popup}" meta="${meta}"
-	onLoad="${onLoad}" desabilitarbusca="${desabilitarbusca}"
-	desabilitarmenu="${desabilitarmenu}" incluirJs="${incluirJs}"
-	compatibilidade="${compatibilidade}"
-	desabilitarComplementoHEAD="${desabilitarComplementoHEAD}"
-	incluirBS="${incluirBS}" />
+
+<c:if test="${iframe == 'sim'}">
+	<c:if test="${empty incluirBS or incluirBS}" >
+	 	<link rel="stylesheet" href="/siga/bootstrap/css/bootstrap.min.css?v=4.1.1"	type="text/css" media="screen, projection" />
+	</c:if>
+</c:if>
+
+<c:if test="${iframe != 'sim'}">
+	<siga:cabecalho titulo="${titulo}" popup="${popup}" meta="${meta}"
+		onLoad="${onLoad}" desabilitarbusca="${desabilitarbusca}"
+		desabilitarmenu="${desabilitarmenu}" incluirJs="${incluirJs}"
+		compatibilidade="${compatibilidade}"
+		desabilitarComplementoHEAD="${desabilitarComplementoHEAD}"
+		incluirBS="${incluirBS}" />
+</c:if>
 
 <jsp:doBody />
 
-<siga:rodape popup="${popup}" incluirJs="${incluirJs}" incluirBS="${incluirBS}" />
+<c:if test="${iframe != 'sim'}">
+	<siga:rodape popup="${popup}" incluirJs="${incluirJs}" incluirBS="${incluirBS}" />
+</c:if>

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExArquivoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExArquivoController.java
@@ -90,8 +90,8 @@ public class ExArquivoController extends ExController {
 	@Get("/app/arquivo/exibir")
 	public Download aExibir(final String sigla, final boolean popup, final String arquivo, byte[] certificado,
 			String hash, final String HASH_ALGORITHM, final String certificadoB64, boolean completo,
-			final boolean semmarcas, final boolean volumes, final Long idVisualizacao, boolean exibirReordenacao) {
-		try {
+			final boolean semmarcas, final boolean volumes, final Long idVisualizacao, boolean exibirReordenacao, boolean iframe) throws Exception {
+		try {						
 			final String servernameport = getRequest().getServerName() + ":" + getRequest().getServerPort();
 			final String contextpath = getRequest().getContextPath();
 			final boolean pacoteAssinavel = (certificadoB64 != null);
@@ -121,7 +121,8 @@ public class ExArquivoController extends ExController {
 				completo = false;
 				estampar = false;
 			}
-			final ExMobil mob = Documento.getMobil(arquivo);
+			final ExMobil mob = Documento.getMobil(arquivo);	
+				
 			if (mob != null) {
 				mob.getMobilPrincipal().indicarSeDeveExibirDocumentoCompletoReordenado(exibirReordenacao);
 
@@ -204,7 +205,7 @@ public class ExArquivoController extends ExController {
 					hashreq.setTime(dt);
 					HashResponse hashresp = bluc.hash(hashreq);
 					if (hashresp.getErrormsg() != null)
-						throw new Exception(
+						throw new AplicacaoException(
 								"BluC não conseguiu produzir o pacote assinável. " + hashresp.getErrormsg());
 					byte[] sa = Base64.decode(hashresp.getHash());
 
@@ -221,7 +222,7 @@ public class ExArquivoController extends ExController {
 				Documento.getDocumentoHTML(baos, null, mob, mov, completo, volumes, contextpath, servernameport);
 				ab = baos.toByteArray();
 				if (ab == null) {
-					throw new Exception("HTML inválido!");
+					throw new AplicacaoException("HTML inválido!");
 				}
 			}
 			if (imutavel) {
@@ -255,7 +256,9 @@ public class ExArquivoController extends ExController {
 				return new InputStreamDownload(makeByteArrayInputStream((new byte[0]), false), TEXT_PLAIN,
 						"arquivo inválido");
 			}
-			throw new RuntimeException("erro na geração do documento.", e);
+			
+			result.include("iframe", iframe ? "sim" : "");
+			throw e;
 		}
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/erroGeral.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/erroGeral.jsp
@@ -54,7 +54,7 @@
 	</c:if>
 </c:catch>
 <c:catch var="catchException">
-	<siga:pagina titulo="Erro Geral" desabilitarbusca="sim"	desabilitarmenu="sim" desabilitarComplementoHEAD="sim">
+	<siga:pagina titulo="Erro Geral" desabilitarbusca="sim"	desabilitarmenu="sim" desabilitarComplementoHEAD="sim" iframe="${iframe}">
 		<c:set var="hasMessage" scope="request" value="${not empty exceptionStackGeral or not empty exceptionMsg}" />
 		<c:choose>
 			<c:when test="${exceptionApp}">
@@ -98,14 +98,16 @@
 				    	&nbsp;<strong>Versão </strong>SIGA <c:out value="${siga_version}" />
 				    </li>
 				  </ul>
-				  <div class="card-footer text-center pt-2">
-				   	<c:if test="${newWindow != 1}">
-						<input type="button" value="Voltar"	onclick="javascript:history.back();" class="btn btn-primary" />
-					</c:if>
-					<c:if test="${newWindow eq 1}">
-						<input type="button" value="Fechar"	onclick="javascript:window.close();" class="btn btn-primary" />
-					</c:if>
-				  </div>
+				  <c:if test="${iframe != 'sim'}">
+					  <div class="card-footer text-center pt-2">
+					   	<c:if test="${newWindow != 1}">
+							<input type="button" value="Voltar"	onclick="javascript:history.back();" class="btn btn-primary" />
+						</c:if>
+						<c:if test="${newWindow eq 1}">
+							<input type="button" value="Fechar"	onclick="javascript:window.close();" class="btn btn-primary" />
+						</c:if>
+					  </div>
+				  </c:if>
 				</div> 
 			</c:if> 
 		</div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
@@ -513,7 +513,7 @@
 <script>
 	var htmlAtual = '${arqsNum[0].referenciaHtmlCompletoDocPrincipal}';
 	var pdfAtual = '${arqsNum[0].referenciaPDFCompletoDocPrincipal}';	
-	var path = '/sigaex/app/arquivo/exibir?idVisualizacao=${idVisualizacao}';
+	var path = '/sigaex/app/arquivo/exibir?idVisualizacao=${idVisualizacao}&iframe=true';
 	
 	if ('${mob.doc.podeReordenar()}' === 'true' && '${podeExibirReordenacao}' === 'true') path += '&exibirReordenacao=true';			
 	path += '&arquivo=';			


### PR DESCRIPTION
1. Na tela de Visualização de Documento Completo estava sendo apresentado o stacktrace no lugar da mensagem de negócio, pois todas as exceções estavam sendo relançadas como RuntimeException.

2. Exceções estavam sendo apresentadas dentro do iframe com a página completa, com cabeçalho e rodapé. Foi inserida uma flag para informar quando a requisição vem de um iframe para que a exceção não contenha cabeçalho e rodapé.

Antes:
![antes_LI](https://user-images.githubusercontent.com/90341086/152178429-c35dab6a-db1a-4b4d-83f3-c27e599ebd38.jpg)

Depois:
![depois](https://user-images.githubusercontent.com/90341086/152178437-17e8bdbc-dbb6-42ce-a397-e07a97bbea06.PNG)

