### PR TITLE
Corrigindo problema ao buscar unidade por sigla

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
@@ -80,7 +80,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 		// prefixar aconsulta com com JFRJSG, deve retornar apenas RJ-SG.
 		@NamedQuery(name = "consultarPorFiltroDpLotacao", query = "from DpLotacao lot "
 				+ "  where "
-				+ "     ( (upper(lot.siglaLotacao) like upper(:nome || '%') or upper(lot.nomeLotacaoAI) like upper('%' || :nome || '%')) "
+				+ "     ( (upper(lot.siglaLotacao) like upper(:sigla || '%') or upper(lot.nomeLotacaoAI) like upper('%' || :nome || '%')) "
 				+ "	       and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"
 				+ "          or ( :nome != null and (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu) and (upper(concat(lot.orgaoUsuario.acronimoOrgaoUsu, lot.siglaLotacao)) like upper(:nome || '%')"
 				+ "          or upper(concat(lot.orgaoUsuario.siglaOrgaoUsu, lot.siglaLotacao)) like upper(:nome || '%'))))"
@@ -94,7 +94,7 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ "	order by lot.nomeLotacao"),
 		@NamedQuery(name = "consultarPorFiltroDpLotacaoInclusiveFechadas", query = "from DpLotacao lotacao"
 				+ "  where (:idOrgaoUsu = null or :idOrgaoUsu = 0L or lotacao.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"
-				+ "		and ((upper(lotacao.nomeLotacaoAI) like upper('%' || :nome || '%')) or (upper(lotacao.siglaLotacao) like upper('%'  || :nome || '%')))"
+				+ "		and ((upper(lotacao.nomeLotacaoAI) like upper('%' || :nome || '%')) or (upper(lotacao.siglaLotacao) like upper('%'  || :sigla || '%')))"
 				+ "		and exists (select 1 from DpLotacao lAux where lAux.idLotacaoIni = lotacao.idLotacaoIni"
 				+ "			group by lAux.idLotacaoIni having max(lAux.dataInicioLotacao) = lotacao.dataInicioLotacao)"
 				+ "  order by upper(nomeLotacaoAI)"),

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -708,7 +708,7 @@ public class CpDao extends ModeloDao {
 	public List<DpLotacao> consultarPorFiltro(final DpLotacaoDaoFiltro o, final int offset, final int itemPagina) {
 		try {
 			final Query query;
-
+			
 			if (!o.isBuscarFechadas())
 				query = em().createNamedQuery("consultarPorFiltroDpLotacao");
 			else
@@ -720,7 +720,7 @@ public class CpDao extends ModeloDao {
 				query.setMaxResults(itemPagina);
 			}
 			query.setParameter("nome", o.getNome() == null ? "" : o.getNome().replace(' ', '%'));
-
+			query.setParameter("sigla", o.getSigla() == null ? "" : o.getSigla().replace(' ', '%'));
 			if (o.getIdOrgaoUsu() != null)
 				query.setParameter("idOrgaoUsu", o.getIdOrgaoUsu());
 			else

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -240,8 +240,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 			}
 			dpLotacao.setIdOrgaoUsu(idOrgaoUsu);
 			dpLotacao.setNome(Texto.removeAcento(nome));
+			dpLotacao.setSigla(nome);
 			dpLotacao.setBuscarFechadas(Boolean.TRUE);
-			setItens(CpDao.getInstance().consultarPorFiltro(dpLotacao, paramoffset, 15));
+			setItens(CpDao.getInstance().consultarPorFiltro(dpLotacao, paramoffset, 15));  
 			result.include("itens", getItens());
 			result.include("tamanho", dao().consultarQuantidade(dpLotacao));
 

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
@@ -52,7 +52,7 @@ function sbmt(offset) {
 					</div>
 					<div class="col-md-4">
 						<div class="form-group">
-							<label>Nome</label>
+							<label>Nome/sigla</label>
 							<input type="text" id="nome" name="nome" value="${nome}" maxlength="100" class="form-control"/>
 						</div>
 					</div>


### PR DESCRIPTION
Usuário não estava conseguindo buscar unidade com caracteres especiais pela sigla, pois isso só estava funcionando por nome. Segue evidências:
![evidencia-001](https://user-images.githubusercontent.com/73559672/154133823-01374957-9a1d-487f-85ca-046cdf8e57e2.PNG)

![evidencia-002](https://user-images.githubusercontent.com/73559672/154133839-96851632-ff33-4b3b-b6d9-c2a1d431bb1c.PNG)

![evidencia-003](https://user-images.githubusercontent.com/73559672/154133856-0e2972e7-0a47-4e75-809b-7b15e2be8060.PNG)

