### PR TITLE
GOVSP102671 - Limite dos itens da mesa 2

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -52,6 +52,7 @@ public class Mesa2 {
 		public String grupoOrdem;
 		public boolean grupoCollapsed;
 		public boolean grupoHide;
+		public boolean grupoAtingiuLimite;
 		public List<MesaItem> grupoDocs;
 		public List<Integer> grupoMarcadores;
 	}
@@ -369,6 +370,7 @@ public class Mesa2 {
 			boolean usuarioPosse, List<Integer> marcasAIgnorar) throws Exception {
 //		long tempoIni = System.nanoTime();
 		Date dtNow = dao.consultarDataEHoraDoServidor();
+		final int qtdMaxGrupo = 1000;
 
 		List<Object[]> l = dao.listarMobilsPorMarcas(titular,
 				lotaTitular, exibeLotacao, ordemCrescenteData, marcasAIgnorar);
@@ -418,7 +420,8 @@ public class Mesa2 {
 								marcador = (CpMarcador) reference[1];
 								if (!map.containsKey(mobil)) {
 									// Mobil ainda nao foi incluido no grupo, inclui
-									if (listIdMobil.size() < gItem.grupoQtd) {
+									if (listIdMobil.size() < gItem.grupoQtd 
+											&& listIdMobil.size() < qtdMaxGrupo) {
 										DocDados docDados = new DocDados();
 										MeM mm = new MeM();
 										mm.marca = marca;
@@ -459,6 +462,11 @@ public class Mesa2 {
 						}
 						iMobs = iMobsFim;
 					}
+					if (map.size() < qtdMaxGrupo)
+						gItem.grupoAtingiuLimite = false;
+					else
+						gItem.grupoAtingiuLimite = true;
+					
 					gItem.grupoDocs = Mesa2.listarReferencias(TipoDePainelEnum.UNIDADE, map, titular,
 							titular.getLotacao(), dtNow, gItem.grupoOrdem, trazerAnotacoes, ordemCrescenteData, 
 							usuarioPosse, marcasAIgnorar);

--- a/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
@@ -304,6 +304,13 @@
 										</template>
 									</tbody>
 								</table>
+								<div class="row" v-if="g.grupoAtingiuLimite">
+									<div class="col col-12">
+										<p class="alert alert-warning alert-dismissible fade show">Atingiu a quantidade máxima 
+										permitida para visualização de documentos deste grupo. Por favor utilize o <a 
+										href='/siga/app/principal?redirecionar=false'>Quadro Quantitativo</a> ou a Pesquisa.</p>
+									</div>
+								</div>
 								<div class="row">
 									<div class="col col-md-9 mb-2">
 										<div class="text-center" v-if="carregando">
@@ -313,7 +320,7 @@
 									<div class="col-6 col-md-3 mb-2">
 										<div class="float-right d-flex">
 											<button	type="button" class="btn btn-primary btn-sm"
-													v-if="g.grupoDocs != undefined && g.grupoCounterAtivo > g.grupoDocs.length" 
+													v-if="g.grupoDocs != undefined && g.grupoCounterAtivo > g.grupoDocs.length && !g.grupoAtingiuLimite" 
 													:class="{disabled: carregando}" @click="pageDownGrupo(g.grupoNome);">
 												Mais<i v-if="!carregando" class="ml-2 fas fa-chevron-circle-down"></i>
 												<div v-if="carregando" class="spinner-border" role="status"></div>


### PR DESCRIPTION
Havia lentidão na mesa de alguns usuários com muitos documentos listados. Foi limitada em 1000 a quantidade por grupo para minimizar o problema. Nesta situação, a seguinte mensagem é mostrada:


![image](https://user-images.githubusercontent.com/49542320/155387011-303159c7-1bb1-4673-97ea-ea104861a2a6.png)


