### PR TITLE
feature/gov/98157-retirar-mensagem-inapropriada

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -345,7 +345,7 @@
 															<siga:link title="${acao.nomeNbsp}" pre="${acao.pre}"
 																pos="${acao.pos}"
 																url="${pageContext.request.contextPath}${acao.url}"
-																test="${acao.pode}" explicacao="${acao.explicacao}" popup="${acao.popup}"
+																test="${acao.pode}" popup="${acao.popup}"
 																confirm="${acao.msgConfirmacao}" ajax="${acao.ajax}"
 																idAjax="${mov.idMov}" classe="${acao.classe}" post="${acao.post}" />
 															<c:if test="${assinadopor and mov.exTipoMovimentacao == 'ANEXACAO'}"> ${mov.complemento}

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -345,7 +345,7 @@
 															<siga:link title="${acao.nomeNbsp}" pre="${acao.pre}"
 																pos="${acao.pos}"
 																url="${pageContext.request.contextPath}${acao.url}"
-																test="${acao.pode}" popup="${acao.popup}"
+																test="${acao.pode}" explicacao="${exibirExplicacao ? acao.explicacao : ''}" popup="${acao.popup}"
 																confirm="${acao.msgConfirmacao}" ajax="${acao.ajax}"
 																idAjax="${mov.idMov}" classe="${acao.classe}" post="${acao.post}" />
 															<c:if test="${assinadopor and mov.exTipoMovimentacao == 'ANEXACAO'}"> ${mov.complemento}


### PR DESCRIPTION
Adicionando a validação exibirExplicacao para poder ocultar essa mensagem explicativa: 
![mensagem inapropriada_retirar](https://user-images.githubusercontent.com/73559672/155558006-dd0ea550-7020-4abe-a7ee-3e7d19b61b2d.jpg)

