### PR TITLE
feature/gov/103225-problema-ao-acessar-tutoriais-no-spsp

### DIFF
--- a/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
@@ -234,7 +234,7 @@ ${meta}
 									        var src = 'https://vimeopro.com/fcav/spsempapel';
 									        $('#tutorialModal').modal('show');
 									        $('#tutorialModal iframe').attr('src', src);
-									        $(".modal-backdrop").removeClass();  
+									        $(".modal-backdrop").css("z-index", "0");
 									    });
 									
 									    $('#tutorialModal button').click(function () {

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
@@ -234,6 +234,7 @@ ${meta}
 									        var src = 'https://vimeopro.com/fcav/spsempapel';
 									        $('#tutorialModal').modal('show');
 									        $('#tutorialModal iframe').attr('src', src);
+									        $(".modal-backdrop").removeClass();  
 									    });
 									
 									    $('#tutorialModal button').click(function () {


### PR DESCRIPTION
Posicionando o background por baixo do modal de acesso ao tutorial.
Antes o background estava por cima do modal de acesso ao tutorial, e isso impossibilitava o usuário acessar os vídeos:
![m](https://user-images.githubusercontent.com/73559672/155998716-2f7b9231-b151-4218-91de-74be00fa7a21.PNG)

Solução:
![000003](https://user-images.githubusercontent.com/73559672/155999066-a420aa7c-fa43-4319-9096-7b1a6c8948c8.PNG)

