### PR TITLE
feature/govsp/RM69773

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
@@ -118,7 +118,7 @@ public enum CpTipoDeConfiguracao implements ITipoDeConfiguracao {
 			new CpParamCfg[] { CpParamCfg.SITUACAO },
 			new CpSituacaoDeConfiguracaoEnum[] { CpSituacaoDeConfiguracaoEnum.PODE,
 					CpSituacaoDeConfiguracaoEnum.NAO_PODE },
-			CpSituacaoDeConfiguracaoEnum.PODE, true),
+			CpSituacaoDeConfiguracaoEnum.NAO_PODE, true),
 
 	UTILIZAR_COMPLEXO(400, "Utilizar Complexo Padrão",
 			"Selecione órgão, lotação, pessoa, cargo ou função comissionada que tem permissão para utilizar determinado complexo como padrão.",

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
@@ -110,7 +110,16 @@ public enum CpTipoDeConfiguracao implements ITipoDeConfiguracao {
 					CpSituacaoDeConfiguracaoEnum.NAO_PODE },
 			CpSituacaoDeConfiguracaoEnum.PODE, true), 
 
-	
+	UTILIZAR_PESQUISA_XJUS(212, "Utilizar X-JUS na Pesquisa Avançada",
+			"Utilizada para ativar pesquisa avançada via X-JUS.\n"
+					+ "PODE: Ativa.\n"
+					+ "NÃO PODE: Não ativa.",
+			new CpParamCfg[] { CpParamCfg.ORGAO, CpParamCfg.PESSOA, CpParamCfg.LOTACAO },
+			new CpParamCfg[] { CpParamCfg.SITUACAO },
+			new CpSituacaoDeConfiguracaoEnum[] { CpSituacaoDeConfiguracaoEnum.PODE,
+					CpSituacaoDeConfiguracaoEnum.NAO_PODE },
+			CpSituacaoDeConfiguracaoEnum.PODE, true),
+
 	UTILIZAR_COMPLEXO(400, "Utilizar Complexo Padrão",
 			"Selecione órgão, lotação, pessoa, cargo ou função comissionada que tem permissão para utilizar determinado complexo como padrão.",
 			new CpParamCfg[] {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/CarregadorPlugin.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/CarregadorPlugin.java
@@ -9,8 +9,8 @@ import java.util.ListIterator;
 import java.util.logging.Logger;
 
 import br.gov.jfrj.siga.base.Prop;
-import br.gov.jfrj.siga.hibernate.ext.IMontadorQuery;
 import br.gov.jfrj.siga.hibernate.ext.MontadorQuery;
+import br.gov.jfrj.siga.hibernate.query.ext.IMontadorQuery;
 
 /**
  * Classe que trata da lógica de carregamento da extensão de busca textual em outro classloader. 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -25,6 +25,7 @@
 package br.gov.jfrj.siga.hibernate;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -96,8 +97,8 @@ import br.gov.jfrj.siga.ex.bl.ExBL;
 import br.gov.jfrj.siga.ex.bl.Mesa2.GrupoItem;
 import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
 import br.gov.jfrj.siga.ex.util.MascaraUtil;
-import br.gov.jfrj.siga.hibernate.ext.IExMobilDaoFiltro;
-import br.gov.jfrj.siga.hibernate.ext.IMontadorQuery;
+import br.gov.jfrj.siga.hibernate.query.ext.IExMobilDaoFiltro;
+import br.gov.jfrj.siga.hibernate.query.ext.IMontadorQuery;
 import br.gov.jfrj.siga.model.Selecionavel;
 import br.gov.jfrj.siga.model.dao.ModeloDao;
 import br.gov.jfrj.siga.persistencia.ExClassificacaoDaoFiltro;
@@ -601,11 +602,8 @@ public class ExDao extends CpDao {
 			query.setParameter("classificacaoSelId", flt.getClassificacaoSelId());
 		}
 
-		if (flt.getDescrDocumento() != null
-
-		&& !flt.getDescrDocumento().trim().equals("")) {
-			query.setParameter("descrDocumento", "%"
-					+ flt.getDescrDocumento().toUpperCase() + "%");
+		if (flt.getDescrDocumento() != null && !flt.getDescrDocumento().trim().equals("") && flt.getListaIdDoc() == null) {
+			query.setParameter("descrDocumento", "%" + flt.getDescrDocumento().toUpperCase() + "%");
 		}
 
 		if (flt.getDtDoc() != null) {
@@ -2329,7 +2327,7 @@ public class ExDao extends CpDao {
 		}
 	}
 
-	public List<Long> consultarDocumentosPorSiglas(List<String> siglas) {
+	public List<BigDecimal> consultarDocumentosPorSiglas(List<String> siglas) {
 		String sql = "SELECT X.ID_DOC \n" + 
 				"FROM SIGA.EX_DOCUMENTO X, \n" + 
 				"	SIGA.EX_FORMA_DOCUMENTO Y,\n" + 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -681,7 +681,10 @@ public class ExDao extends CpDao {
 		}
 		
 		if (flt.getListaIdDoc() != null && !flt.getListaIdDoc().isEmpty()) {
-			query.setParameter("listaIdDoc", flt.getListaIdDoc());
+			for(int i = 0; i <= flt.getListaIdDoc().size()/1000; i++) {		
+				int toIndex =  (i + 1)*1000 > flt.getListaIdDoc().size() ? flt.getListaIdDoc().size() : (i + 1)*1000;
+				query.setParameter("listaIdDoc"+i, flt.getListaIdDoc().subList(i*1000, toIndex));
+			}
 		}
 	}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -681,6 +681,10 @@ public class ExDao extends CpDao {
 					ExModelo.class, false);
 			query.setParameter("hisIdIni", mod.getHisIdIni());
 		}
+		
+		if (flt.getListaIdDoc() != null && !flt.getListaIdDoc().isEmpty()) {
+			query.setParameter("listaIdDoc", flt.getListaIdDoc());
+		}
 	}
 
 	public List consultarPorFiltroOtimizado(final ExMobilDaoFiltro flt,
@@ -2323,6 +2327,21 @@ public class ExDao extends CpDao {
 		} catch (Exception ne) {
 			return null;
 		}
+	}
+
+	public List<Long> consultarDocumentosPorSiglas(List<String> siglas) {
+		String sql = "SELECT X.ID_DOC \n" + 
+				"FROM SIGA.EX_DOCUMENTO X, \n" + 
+				"	SIGA.EX_FORMA_DOCUMENTO Y,\n" + 
+				"	CORPORATIVO.CP_ORGAO_USUARIO Z\n" + 
+				"WHERE X.ID_FORMA_DOC  = Y.ID_FORMA_DOC \n" + 
+				"	AND X.ID_ORGAO_USU = Z.ID_ORGAO_USU\n" + 
+				"	AND Z.SIGLA_ORGAO_USU || Y.SIGLA_FORMA_DOC || X.ANO_EMISSAO || LPAD(X.NUM_EXPEDIENTE, 5, '0')\n" + 
+				"	 IN ( :siglas )";
+		final Query query = em().createNativeQuery(sql);
+		query.setParameter("siglas", siglas);
+		
+		return query.getResultList();
 	}
 	
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -186,7 +186,12 @@ public class MontadorQuery implements IMontadorQuery {
 		}
 		
 		if(flt.getListaIdDoc() != null && !flt.getListaIdDoc().isEmpty()) {
-			sbf.append(" and doc.idDoc IN :listaIdDoc");
+			sbf.append(" and (");
+			
+			for(int i=0; i <= flt.getListaIdDoc().size()/1000; i++)
+				sbf.append(" doc.idDoc IN :listaIdDoc" + i + " or");
+			
+			sbf.delete(sbf.length()-3, sbf.length()).append(")");
 		}
 
 		if (!apenasCount) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -19,6 +19,8 @@
 package br.gov.jfrj.siga.hibernate.ext;
 
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorEnum;
+import br.gov.jfrj.siga.hibernate.ext.IExMobilDaoFiltro;
+import br.gov.jfrj.siga.hibernate.ext.IMontadorQuery;
 
 public class MontadorQuery implements IMontadorQuery {
 
@@ -182,6 +184,10 @@ public class MontadorQuery implements IMontadorQuery {
 
 		if (flt.getIdMod() != null && flt.getIdMod() != 0) {
 			sbf.append(" and exMod.hisIdIni = :hisIdIni");
+		}
+		
+		if(flt.getListaIdDoc() != null && !flt.getListaIdDoc().isEmpty()) {
+			sbf.append(" and doc.idDoc in (:listaIdDoc)");
 		}
 
 		if (!apenasCount) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ext/MontadorQuery.java
@@ -19,8 +19,8 @@
 package br.gov.jfrj.siga.hibernate.ext;
 
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorEnum;
-import br.gov.jfrj.siga.hibernate.ext.IExMobilDaoFiltro;
-import br.gov.jfrj.siga.hibernate.ext.IMontadorQuery;
+import br.gov.jfrj.siga.hibernate.query.ext.IExMobilDaoFiltro;
+import br.gov.jfrj.siga.hibernate.query.ext.IMontadorQuery;
 
 public class MontadorQuery implements IMontadorQuery {
 
@@ -96,8 +96,7 @@ public class MontadorQuery implements IMontadorQuery {
 			sbf.append(" and doc.exClassificacao.hisIdIni = :classificacaoSelId");
 		}
 
-		if (flt.getDescrDocumento() != null
-				&& !flt.getDescrDocumento().trim().equals("")) {
+		if (flt.getDescrDocumento() != null && !flt.getDescrDocumento().trim().equals("") && flt.getListaIdDoc() == null) {
 			sbf.append(" and doc.descrDocumentoAI like :descrDocumento");
 		}
 
@@ -187,7 +186,7 @@ public class MontadorQuery implements IMontadorQuery {
 		}
 		
 		if(flt.getListaIdDoc() != null && !flt.getListaIdDoc().isEmpty()) {
-			sbf.append(" and doc.idDoc in (:listaIdDoc)");
+			sbf.append(" and doc.idDoc IN :listaIdDoc");
 		}
 
 		if (!apenasCount) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExMobilDaoFiltro.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExMobilDaoFiltro.java
@@ -25,7 +25,7 @@ import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
 import br.gov.jfrj.siga.ex.ExDocumento;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.hibernate.ExDao;
-import br.gov.jfrj.siga.hibernate.ext.IExMobilDaoFiltro;
+import br.gov.jfrj.siga.hibernate.query.ext.IExMobilDaoFiltro;
 import br.gov.jfrj.siga.model.dao.DaoFiltroSelecionavel;
 
 public class ExMobilDaoFiltro extends DaoFiltroSelecionavel implements

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExMobilDaoFiltro.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExMobilDaoFiltro.java
@@ -19,6 +19,7 @@
 package br.gov.jfrj.siga.persistencia;
 
 import java.util.Date;
+import java.util.List;
 
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
 import br.gov.jfrj.siga.ex.ExDocumento;
@@ -70,12 +71,16 @@ public class ExMobilDaoFiltro extends DaoFiltroSelecionavel implements
 	private Long idOrgaoUsu;
 
 	private Long idDoc;
+	
+	private List<Long> listaIdDoc;
 
 	private Long anoEmissao;
 
 	private Long classificacaoSelId;
 
 	private String descrDocumento;
+	
+	private String descrPesquisaXjus;
 
 	private String fullText;
 
@@ -147,6 +152,14 @@ public class ExMobilDaoFiltro extends DaoFiltroSelecionavel implements
 
 	public String getDescrDocumento() {
 		return descrDocumento;
+	}
+	
+	public String getDescrPesquisaXjus() {
+		return descrPesquisaXjus;
+	}
+
+	public void setDescrPesquisaXjus(String descrPesquisaXjus) {
+		this.descrPesquisaXjus = descrPesquisaXjus;
 	}
 
 	public Long getDestinatarioSelId() {
@@ -382,6 +395,14 @@ public class ExMobilDaoFiltro extends DaoFiltroSelecionavel implements
 		this.idMod = idMod;
 	}
 
+	public List<Long> getListaIdDoc() {
+		return listaIdDoc;
+	}
+
+	public void setListaIdDoc(final List<Long> listaIdDoc) {
+		this.listaIdDoc = listaIdDoc;
+	}
+
 	public boolean buscarPorCamposMarca() {
 		return (getUltMovIdEstadoDoc() != null && getUltMovIdEstadoDoc() != 0)
 				|| (getUltMovLotaRespSelId() != null && getUltMovLotaRespSelId() != 0)
@@ -416,4 +437,5 @@ public class ExMobilDaoFiltro extends DaoFiltroSelecionavel implements
 				|| (getAnoEmissao() != null && getAnoEmissao() != 0)
 				|| (getNumExpediente() != null && getNumExpediente() != 0);
 	}
+
 }

--- a/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/ext/IExMobilDaoFiltro.java
+++ b/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/ext/IExMobilDaoFiltro.java
@@ -19,6 +19,7 @@
 package br.gov.jfrj.siga.hibernate.ext;
 
 import java.util.Date;
+import java.util.List;
 
 public interface IExMobilDaoFiltro {
 
@@ -156,4 +157,8 @@ public interface IExMobilDaoFiltro {
 	public abstract boolean buscarPorCamposMarca();
 
 	public abstract boolean buscarPorCamposDoc();
+	
+	public abstract List<Long> getListaIdDoc();
+	
+	public abstract void setListaIdDoc(final List<Long> lista);
 }

--- a/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/query/ext/IExMobilDaoFiltro.java
+++ b/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/query/ext/IExMobilDaoFiltro.java
@@ -16,7 +16,7 @@
  *     You should have received a copy of the GNU General Public License
  *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************/
-package br.gov.jfrj.siga.hibernate.ext;
+package br.gov.jfrj.siga.hibernate.query.ext;
 
 import java.util.Date;
 import java.util.List;

--- a/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/query/ext/IMontadorQuery.java
+++ b/siga-ext/src/main/java/br/gov/jfrj/siga/hibernate/query/ext/IMontadorQuery.java
@@ -16,7 +16,7 @@
  *     You should have received a copy of the GNU General Public License
  *     along with SIGA.  If not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************/
-package br.gov.jfrj.siga.hibernate.ext;
+package br.gov.jfrj.siga.hibernate.query.ext;
 
 
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -35,6 +35,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,12 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletRequest;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.auth0.jwt.JWTSigner;
+
 import br.com.caelum.vraptor.Controller;
 import br.com.caelum.vraptor.Get;
 import br.com.caelum.vraptor.Path;
@@ -54,11 +61,13 @@ import br.com.caelum.vraptor.Post;
 import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.observer.download.Download;
 import br.com.caelum.vraptor.observer.download.InputStreamDownload;
+import br.com.caelum.vraptor.view.HttpResult;
 import br.com.caelum.vraptor.view.Results;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.Data;
 import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.RegraNegocioException;
+import br.gov.jfrj.siga.base.SigaHTTP;
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.TipoResponsavelEnum;
@@ -67,6 +76,7 @@ import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.model.CpOrgaoSelecao;
 import br.gov.jfrj.siga.cp.model.DpLotacaoSelecao;
 import br.gov.jfrj.siga.cp.model.DpPessoaSelecao;
+import br.gov.jfrj.siga.cp.model.enm.CpTipoDeConfiguracao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExClassificacao;
 import br.gov.jfrj.siga.ex.ExDocumento;
@@ -79,6 +89,7 @@ import br.gov.jfrj.siga.ex.ExTipoDocumento;
 import br.gov.jfrj.siga.ex.ExTipoFormaDoc;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.ExBL;
+import br.gov.jfrj.siga.ex.logic.ExPodePorConfiguracao;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.model.GenericoSelecao;
 import br.gov.jfrj.siga.model.Selecionavel;
@@ -498,7 +509,7 @@ public class ExMobilController extends
 		if (primeiraVez == null || !primeiraVez.equals("sim")) {
 			try {
 				validarFiltrosPesquisa(flt);
-
+				pesquisarXjus(flt);
 				listarItensPesquisa(flt, builder);				
 			} catch (RegraNegocioException | AplicacaoException e) {
 				result.include("msgPesqErro", e.getMessage());
@@ -578,6 +589,28 @@ public class ExMobilController extends
 			result.include("campos", campos);
 		}
 
+	}
+
+	private void pesquisarXjus(ExMobilDaoFiltro flt) {
+		if(flt.getDescrPesquisaXjus() == null || flt.getDescrPesquisaXjus().isEmpty() )
+			return;
+		
+		flt.setDescrDocumento(null);
+		
+		String filter = flt.getDescrPesquisaXjus();
+		
+		String acronimoOrgaoUsu = dao().consultarOrgaoUsuarioPorId(flt.getIdOrgaoUsu()).getAcronimoOrgaoUsu();
+				
+		String acl = "PUBLIC;O" + getTitular().getOrgaoUsuario().getId() + ";L"
+				+ getTitular().getLotacao().getIdInicial() + ";P"
+				+ getTitular().getIdInicial();
+		
+		try {
+			flt.setListaIdDoc(Ex.getInstance().getBL().pesquisarXjus(filter, acronimoOrgaoUsu, acl, 1, 1000));
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("Falha ao consultar XJUS: " + e.getMessage());			
+		}
 	}
 
 	private void listarItensPesquisa(final ExMobilDaoFiltro flt, final ExMobilBuilder builder) {
@@ -726,6 +759,9 @@ public class ExMobilController extends
 					.getIdInicial());
 		flt.setDescrDocumento(Texto
 				.removeAcentoMaiusculas(param("descrDocumento")));
+		if (new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_XJUS).eval()) {
+			flt.setDescrPesquisaXjus(flt.getDescrDocumento());			
+		}
 		String paramFullText = param("fullText");
 		if (paramFullText != null) {
 			paramFullText = paramFullText.trim();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -592,28 +592,51 @@ public class ExMobilController extends
 	}
 
 	private void pesquisarXjus(ExMobilDaoFiltro flt) {
+		if (!(new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_XJUS).eval())) {
+			flt.setDescrPesquisaXjus(null);
+			return;
+		}
+		
 		if(flt.getDescrPesquisaXjus() == null || flt.getDescrPesquisaXjus().isEmpty() )
 			return;
 		
-		flt.setDescrDocumento(null);
+		DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
 		
 		String filter = flt.getDescrPesquisaXjus();
-		
 		String acronimoOrgaoUsu = dao().consultarOrgaoUsuarioPorId(flt.getIdOrgaoUsu()).getAcronimoOrgaoUsu();
-				
+		String descEspecie = flt.getIdFormaDoc() == null || flt.getIdFormaDoc() == 0 ? null : dao().consultarExFormaPorId(flt.getIdFormaDoc()).getDescrFormaDoc();
+		String descModelo = flt.getIdMod() == null  || flt.getIdMod() == 0 ? null : dao().consultar(flt.getIdMod(), ExModelo.class, false).getDescMod();
+		String dataInicial = flt.getDtDoc() == null ? null : df.format(flt.getDtDoc());
+		String dataFinal = flt.getDtDocFinal() == null ? null : df.format(flt.getDtDocFinal());
 		String acl = "PUBLIC;O" + getTitular().getOrgaoUsuario().getId() + ";L"
 				+ getTitular().getLotacao().getIdInicial() + ";P"
 				+ getTitular().getIdInicial();
 		
 		try {
-			flt.setListaIdDoc(Ex.getInstance().getBL().pesquisarXjus(filter, acronimoOrgaoUsu, acl, 1, 1000));
+			List<Long> listaIdDoc = Ex.getInstance().getBL().pesquisarXjus(
+					filter, 
+					acronimoOrgaoUsu,
+					descEspecie,
+					descModelo,
+					dataInicial, 
+					dataFinal, 
+					acl, 
+					1, 
+					1000);
+			
+			flt.setListaIdDoc(listaIdDoc);
 		} catch (Exception e) {
 			e.printStackTrace();
-			throw new RuntimeException("Falha ao consultar XJUS: " + e.getMessage());			
+			result.include("msgCabecClass", "alert-warning");
+    		result.include("mensagemCabec", "Não foi possível utilizar a pesquisa via XJUS. A consulta foi realizada via Banco de Dados: " + e.getMessage());		
 		}
 	}
 
 	private void listarItensPesquisa(final ExMobilDaoFiltro flt, final ExMobilBuilder builder) {
+		//caso não tenha encontrado resultado do xjus não precisa realizar busca no BD
+		if(flt.getListaIdDoc() != null && flt.getListaIdDoc().isEmpty())
+			return;
+		
 		setItens(dao().consultarPorFiltroOtimizado(flt,
 				builder.getOffset(), getItemPagina() + (Prop.isGovSP() ? 1 : 0), getTitular(),
 				getLotaTitular()));
@@ -759,9 +782,9 @@ public class ExMobilController extends
 					.getIdInicial());
 		flt.setDescrDocumento(Texto
 				.removeAcentoMaiusculas(param("descrDocumento")));
-		if (new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_XJUS).eval()) {
-			flt.setDescrPesquisaXjus(flt.getDescrDocumento());			
-		}
+		
+		flt.setDescrPesquisaXjus(param("descrDocumento"));			
+		
 		String paramFullText = param("fullText");
 		if (paramFullText != null) {
 			paramFullText = paramFullText.trim();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -613,7 +613,11 @@ public class ExMobilController extends
 				+ getTitular().getIdInicial();
 		
 		try {
-			List<Long> listaIdDoc = Ex.getInstance().getBL().pesquisarXjus(
+			
+			List<Long> listaIdDoc = new ArrayList<>();
+			int page = 1;
+			do {
+				listaIdDoc.addAll(Ex.getInstance().getBL().pesquisarXjus(
 					filter, 
 					acronimoOrgaoUsu,
 					descEspecie,
@@ -621,14 +625,15 @@ public class ExMobilController extends
 					dataInicial, 
 					dataFinal, 
 					acl, 
-					1, 
-					1000);
+					page++, 
+					1000));
+			} while (listaIdDoc.size() >= 1000);
 			
 			flt.setListaIdDoc(listaIdDoc);
 		} catch (Exception e) {
 			e.printStackTrace();
 			result.include("msgCabecClass", "alert-warning");
-    		result.include("mensagemCabec", "Não foi possível utilizar a pesquisa via XJUS. A consulta foi realizada via Banco de Dados: " + e.getMessage());		
+    		result.include("mensagemCabec", "Não foi possível utilizar a pesquisa via XJUS. A consulta será realizada via Banco de Dados: " + e.getMessage());		
 		}
 	}
 


### PR DESCRIPTION
Incluída pesquisa via x-jus.

A pesquisa via x-jus pode ser habilitada via configuração (Situação default: Não Pode)
![image](https://user-images.githubusercontent.com/90341086/156794516-6ee10e39-e9df-4902-8aae-a285732ca93e.png)

A integração com x-jus foi incluída na funcionalidade existente de pesquisa avançada:
![image](https://user-images.githubusercontent.com/90341086/156794141-c6c66758-5a63-4a8b-8965-f0daae9a93a5.png)

Fluxo de pesquisa implementado:
Quando o usuário preenche o campo "Descrição", o sistema realiza a primeira etapa da pesquisa no ElasticSearch via x-jus.
Os documentos resultantes são então passados como filtro para a consulta no Banco de Dados. 
![xjus](https://user-images.githubusercontent.com/90341086/156797893-37be312b-8063-4ba2-bb0b-8fc735834382.jpg)

Em caso de indisponibilidade do x-jus, uma mensagem de alerta é apresentada ao usuário informando que a busca será realizada diretamente no banco de dados.
![image](https://user-images.githubusercontent.com/90341086/156795666-0954930d-957f-43dc-a727-2987c3387b68.png)


