### PR TITLE
PCRJ-2136 Bug validacao ext. arq.auxiliar ignora caixa alta

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -534,10 +534,11 @@ public class ExMovimentacaoController extends ExController {
 		
 		String fileExtension = arquivo.getFileName().substring(arquivo.getFileName().lastIndexOf("."));
 		
-		if (Prop.get("arquivosAuxiliares.extensoes.excecao").contains(fileExtension)) {
+		if ( StringUtils.containsIgnoreCase(Prop.get("arquivosAuxiliares.extensoes.excecao"), fileExtension) ) {
 			throw new AplicacaoException(
 					"Extensão " + fileExtension + " inválida para inclusão do arquivo.");
 		}
+
 		
 		validarTamanhoArquivoAnexado(arquivo);
 		


### PR DESCRIPTION
Existe esta configuração
"sigaex.arquivosAuxiliares.extensoes.excecao": ".bat,.exe,.sh,.dll,.pdf",
não está considerando caixa alta, desta forma passa o arquivo com formato .PDF.