### PR TITLE
Permite escolher modelo padrao  novo documento

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -260,6 +260,8 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 		addPublicProperty("ws.siafem.url.namespace", null);
 		addPublicProperty("ws.siafem.service.localpart", null);
 		addPublicProperty("ws.siafem.service.localpartsoap", null);
+		
+		addPublicProperty("documento.novo.modelo.padrao", "Memorando");
 	}
 
 	@Override

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -554,7 +554,7 @@ public class ExDocumentoController extends ExController {
 				
 				if (modeloDefault == null) {
 					for (ExModelo mod : exDocumentoDTO.getModelos()) {
-						if ("Memorando".equals(mod.getNmMod())) {
+						if (Prop.get("documento.novo.modelo.padrao").equalsIgnoreCase(mod.getNmMod())) {
 							modeloDefault = mod;
 							break;
 						}


### PR DESCRIPTION
Permite escolher modelo padrão na criação do novo documento.
Será necessário configurar a property "documento.novo.modelo.padrao", que hoje o valor está definido como Memorando.