### PR TITLE
RM101240 - Definição Acompanhamento - Unidade Acesso Externo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/AcessoConsulta.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/AcessoConsulta.java
@@ -1,6 +1,9 @@
 package br.gov.jfrj.siga.ex.bl;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -9,6 +12,8 @@ import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExDocumento;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.logic.ExLotacaoEstaVinculadoPorPerfil;
+import br.gov.jfrj.siga.ex.logic.ExPessoaEstaVinculadaPorPerfil;
 import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
 
 public class AcessoConsulta {
@@ -60,6 +65,17 @@ public class AcessoConsulta {
 						return true;
 					} 
 				}
+			}
+		}
+		
+		List<ExDocumento> listaTodosOsPais = new ArrayList<ExDocumento>();
+		listaTodosOsPais.addAll(doc.getTodosOsPaisDasVias());
+		
+		for (ExDocumento exDocumento : listaTodosOsPais) {
+			if((new ExPessoaEstaVinculadaPorPerfil(exDocumento, titular).eval()
+					|| new ExLotacaoEstaVinculadoPorPerfil(exDocumento, lotaTitular).eval()) 
+					&& this.pattern.matcher(exDocumento.getDnmAcesso()).find()) {
+				return true;
 			}
 		}
 		


### PR DESCRIPTION
Implementação da seguinte regra: 
- Todos usuários que estão cadastrados em Unidades a qual está marcada como tipo Acesso Externo, podem acessar documento filho em documento pai com Definição de Acompanhamento