### PR TITLE
RM95484 - Alteração de método para evitar chamadas de exclusão

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3006,6 +3006,14 @@ public class ExBL extends CpBL {
 			iniciarAlteracao();
 
 			final ExMovimentacao mov = dao().consultar(idMov, ExMovimentacao.class, false);
+			
+			if (mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.ANOTACAO &&
+					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_DE_COSIGNATARIO &&
+					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.ANEXACAO &&
+					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_EM_EDITAL_DE_ELIMINACAO) {
+				throw new AplicacaoException("Não é permitido excluir a movimentação!");
+			}
+			
 			// ExTipoDeMovimentacao.ANEXACAO
 			// movDao.excluir(mov);
 			excluirMovimentacao(mov);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3007,10 +3007,7 @@ public class ExBL extends CpBL {
 
 			final ExMovimentacao mov = dao().consultar(idMov, ExMovimentacao.class, false);
 			
-			if (mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.ANOTACAO &&
-					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_DE_COSIGNATARIO &&
-					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.ANEXACAO &&
-					mov.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_EM_EDITAL_DE_ELIMINACAO) {
+			if (mov != null && !ExTipoDeMovimentacao.listaTipoMovimentacoesExcluiveisFisicamente().contains(mov.getExTipoMovimentacao())) {
 				throw new AplicacaoException("Não é permitido excluir a movimentação!");
 			}
 			

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeMovimentacao.java
@@ -1,5 +1,8 @@
 package br.gov.jfrj.siga.ex.model.enm;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.cp.model.enm.CpTipoDeMovimentacao;
 import br.gov.jfrj.siga.cp.model.enm.ITipoDeMovimentacao;
@@ -236,5 +239,17 @@ public enum ExTipoDeMovimentacao implements ITipoDeMovimentacao {
 				|| id == ExTipoDeMovimentacao.RECEBIMENTO_TRANSITORIO
 				|| id == ExTipoDeMovimentacao.CONCLUSAO;
 	}
+	
+   public static Set<ExTipoDeMovimentacao> listaTipoMovimentacoesExcluiveisFisicamente() {
+         Set<ExTipoDeMovimentacao> listaTipoMovimentacoes  = new HashSet<ExTipoDeMovimentacao>();
+
+         listaTipoMovimentacoes.add(ANOTACAO);
+         listaTipoMovimentacoes.add(INCLUSAO_DE_COSIGNATARIO);
+         listaTipoMovimentacoes.add(ANEXACAO);
+         listaTipoMovimentacoes.add(INCLUSAO_EM_EDITAL_DE_ELIMINACAO);
+
+         return listaTipoMovimentacoes;
+
+    }
 
 }


### PR DESCRIPTION
Inclusão de verificação do tipo de movimentação no método excluirMovimentacao

Tipos de movimentações que podem ser excluídas:
ExTipoDeMovimentacao.ANOTACAO
ExTipoDeMovimentacao.INCLUSAO_DE_COSIGNATARIO 
ExTipoDeMovimentacao.ANEXACAO
ExTipoDeMovimentacao.INCLUSAO_EM_EDITAL_DE_ELIMINACAO) 