### PR TITLE
RM104974 - Exibição" duplicada do usuário após alteração de órgão / unidade

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1340,7 +1340,24 @@ public class CpBL {
 				if(pessoaAnt.getDataFimPessoa() != null) {
 					pessoa.setDataFimPessoa(pessoaAnt.getDataFimPessoa());
 				}
+				CpIdentidade ident = null;
+				
+				if(!pessoa.getOrgaoUsuario().equivale(pessoaAnt.getOrgaoUsuario())) {
+					ident = new CpIdentidade();
+					CpIdentidade identAnt = new CpIdentidade();
+					identAnt = CpDao.getInstance().consultaIdentidadeCadastrante(pessoaAnt.getSesbPessoa() + pessoaAnt.getMatricula(), true);
+					PropertyUtils.copyProperties(ident, identAnt);
+					ident.setCpOrgaoUsuario(pessoa.getOrgaoUsuario());
+					ident.setNmLoginIdentidade(pessoa.getSesbPessoa() + pessoa.getMatricula());
+					ident.setDtCriacaoIdentidade(data);
+					ident.setId(null);
+					CpDao.getInstance().gravarComHistorico(ident, identAnt, data , identidadeCadastrante);
+				}
 				CpDao.getInstance().gravarComHistorico(pessoa, pessoaAnt, data , identidadeCadastrante);
+				if(ident != null) {
+					ident.setDpPessoa(pessoa);
+					CpDao.getInstance().gravar(ident);
+				}
 			} else {
 				pessoa.setHisIdcIni(identidadeCadastrante);
 				CpDao.getInstance().gravar(pessoa);


### PR DESCRIPTION
Ao alterar a pessoa de órgão pelo cadastro de pessoas a matrícula antiga fica listada no componente abaixo
![image](https://user-images.githubusercontent.com/34543208/158874659-8a065ed7-89ce-45ea-a333-a6b267a798bd.png)
Para que isso não aconteça foi versionado a identidade.