### PR TITLE
Corrigindo problema do Ver/Assinar em encerramento de volume e desentranhamento.

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -314,7 +314,7 @@ public class ExMovimentacaoVO extends ExVO {
 									.exp(new ExPodeAutenticarMovimentacao(mov, titular, lotaTitular)).build());
 
 					} else if (!(mov.isAssinada() && mov.mob().isEmTransito(titular, lotaTitular))) {
-						addAcao(AcaoVO.builder().nome("Ver/Assinar").nameSpace("/app/expediente/mov").acao("exibir").params("sigla", mov.mob().getCodigoCompacto()).params("id", mov.getIdMov().toString())
+						addAcao(AcaoVO.builder().nome(mov.isAssinada() ? "Ver" : "Ver/Assinar").nameSpace("/app/expediente/mov").acao("exibir").params("sigla", mov.mob().getCodigoCompacto()).params("id", mov.getIdMov().toString())
 								.params("popup", "true")
 								.exp(new CpPodeSempre()).build());
 					}


### PR DESCRIPTION
Mesmo assinando ao clicar no Ver/Assinar era retornado na tela novamente o Ver/Assinar mesmo o usuário tendo assinado.

Evidência da correção:
![verassinar001](https://user-images.githubusercontent.com/73559672/159794162-f62a625d-d46c-45fa-beae-e905f3db7b35.PNG)

![verassinar002](https://user-images.githubusercontent.com/73559672/159794178-ec0c1edf-f02d-45e5-8aa4-aad6cf49b32e.PNG)

