### PR TITLE
Feature/pcrj 2147 otimizar consulta quadro quantitativo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMarca.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMarca.java
@@ -45,7 +45,8 @@ import br.gov.jfrj.siga.dp.CpMarca;
 		"               mard.idFinalidade, "+
 		"               mard.ordem, "+
 		"               mard.idCor, "+
-		"               mard.idIcone "+
+		"               mard.idIcone , "+
+		"               tpForma.idTipoFormaDoc "+
 		"        FROM   ExMarca marca "+
 		"               JOIN marca.cpMarcador marcador "+
 		"               JOIN CpMarcador mard on (mard.hisIdIni = marcador.hisIdIni and mard.hisAtivo = 1)"+
@@ -57,13 +58,13 @@ import br.gov.jfrj.siga.dp.CpMarca;
 		"               AND ( ( marca.dpPessoaIni.idPessoa = :idPessoaIni ) "+
 		"                      OR ( marca.dpLotacaoIni.idLotacao = :idLotacaoIni ) ) "+
 		"               AND marca.cpTipoMarca.idTpMarca = 1 "+
-		"               AND (tpForma.idTipoFormaDoc = :idTipoForma)"+
 		"        GROUP  BY mard.idMarcador, "+
 		"                  mard.descrMarcador, "+
 		"                  mard.idFinalidade, "+
 		"                  mard.ordem, "+
 		"                  mard.idCor, "+
-		"                  mard.idIcone "+
+		"                  mard.idIcone, "+
+		"                  tpForma.idTipoFormaDoc "+
 		"ORDER  BY mard.idFinalidade, "+
 		"          mard.ordem, "+
 		"          mard.descrMarcador")

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -938,19 +938,29 @@ public class ExDao extends CpDao {
 		return query.getResultList();
 	}
 
-	public List consultarPaginaInicial(DpPessoa pes, DpLotacao lot,
-			Integer idTipoForma) {
+	public List consultarPaginaInicial(DpPessoa pes, DpLotacao lot , Integer idTipoForma ) {
+		 
+		List listEstadosReduzida = new ArrayList<Object[]>();
+		
+		for (Object o : consultarPaginaInicial( pes,  lot  )) {
+			if (Long.valueOf(idTipoForma) ==   ((Object[]) o)[8]  )  {
+				listEstadosReduzida.add(o);
+			}
+		} 
+		 
+		return listEstadosReduzida;
+	}
+	
+	public List consultarPaginaInicial(DpPessoa pes, DpLotacao lot ) {
 		try {
-			Query sql = em().createNamedQuery(
-					"consultarPaginaInicial");
+			Query sql = em().createNamedQuery("consultarPaginaInicial");
 			
 			Date dt = super.consultarDataEHoraDoServidor();
 			Date amanha = new Date(dt.getTime() + 24*60*60*1000L);
 			sql.setParameter("amanha", amanha, TemporalType.DATE);
 			sql.setParameter("idPessoaIni", pes.getIdPessoaIni());
-			sql.setParameter("idLotacaoIni", lot.getIdLotacaoIni());
-			sql.setParameter("idTipoForma", Long.valueOf(idTipoForma));
-
+			sql.setParameter("idLotacaoIni", lot.getIdLotacaoIni()); 
+			
 			List result = sql.getResultList();
 			
 			result.sort(new Comparator() {

--- a/siga/src/main/webapp/WEB-INF/page/principal/principal.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/principal/principal.jsp
@@ -58,6 +58,7 @@
 			<c:if
 				test="${f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;DOC:Módulo de Documentos')}">
 				<div class="col col-sm-12 col-md-6">
+				<div id="mesaDocumentos">
 					<div class="card bg-light mb-3">
 						<div class="card-header"><a href="/sigaex/app/expediente/doc/listar?primeiraVez=sim&idTipoFormaDoc=1">Expedientes</a></div>
 						<div class="card-body">
@@ -75,7 +76,7 @@
 							</div>
 						</div>
 					</div>
-
+				</div>
 					<div class="mt-2">
 						<a class="btn btn-primary float-right btn-sm ml-2"
 							href="javascript: window.location.href='/sigaex/app/expediente/doc/editar'"
@@ -84,7 +85,7 @@
 							class="btn btn-primary float-right btn-sm ml-2"
 							href="javascript: window.location.href='/sigaex/app/expediente/doc/listar?primeiraVez=sim'"
 							title="Pesquisar expedientes e processos administrativos">
-							Pesquisar</a>
+							<fmt:message key = "documento.pesquisar"/></a>
 							<a
 							class="btn btn-primary float-right btn-sm ml-2"
 							href="javascript: window.location.href='/sigaex/app/mesa'"
@@ -94,6 +95,7 @@
 
 				</div>
 			</c:if>
+
 			<c:if
 				test="${f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA:Sistema Integrado de Gestão Administrativa;WF:Módulo de Workflow') or f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;SR') or f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;GC:Módulo de Gestão de Conhecimento') or f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;TP:Módulo de Transportes')}">
 				<div class="col col-sm-12 col-md-6">

--- a/siga/src/main/webapp/javascript/principal.js
+++ b/siga/src/main/webapp/javascript/principal.js
@@ -7,8 +7,8 @@ $(function() {
 		    modules: {
 		        sigaex: {
 		        	name: "sigaex",
-		        	url: "/sigaex/app/expediente/gadget?idTpFormaDoc=1&apenasQuadro=true",
-		          viewId: "left"
+		        	url: "/sigaex/app/expediente/gadget?apenasQuadro=true",
+		          viewId: "mesaDocumentos"
 		        },
 		        sigawf: {
 		        	name: "sigawf",
@@ -30,11 +30,6 @@ $(function() {
 		        	url: "/sigatp/app/application/gadget",
 		          viewId: "rightbottom3"
 		        },
-		        processos: {
-		        	name: "processos",
-		        	url: "/sigaex/app/expediente/gadget?idTpFormaDoc=2",
-		          viewId: "leftbottom"
-		        }
 		    },
 
 		    render: function(target, text){

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
@@ -33,6 +33,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
+
 import br.com.caelum.vraptor.Controller;
 import br.com.caelum.vraptor.Get;
 import br.com.caelum.vraptor.Result;
@@ -62,10 +64,16 @@ public class ExGadgetController extends ExController {
 	public void execute(final String idTpMarcadorExcluir,     boolean apenasQuadro)
 			throws Exception {
 		 
+		
+		String ignoradosQuadroQuantitativo = "7,8,9,10,11,12,13,16,18,20,21,22,26,32,50,51,62,63,64";
+		
+		String idTpMarcadorExcluidos = (StringUtils.isNotBlank(idTpMarcadorExcluir) ? idTpMarcadorExcluir+"," : "" )+ ignoradosQuadroQuantitativo;
+		
+				
 		List listEstados = dao().consultarPaginaInicial(getTitular(), getLotaTitular() );
 
-		if (idTpMarcadorExcluir != null) {
-			final String as[] = idTpMarcadorExcluir.split(",");
+		if (idTpMarcadorExcluidos != null) {
+			final String as[] = idTpMarcadorExcluidos.split(",");
 			final Set<Integer> excluir = new HashSet<Integer>();
 
 			for (final String s : as) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
@@ -63,32 +63,32 @@ public class ExGadgetController extends ExController {
 	@Get("app/expediente/gadget")
 	public void execute(final String idTpMarcadorExcluir,     boolean apenasQuadro)
 			throws Exception {
-		 
-		
-		String ignoradosQuadroQuantitativo = "7,8,9,10,11,12,13,16,18,20,21,22,26,32,50,51,62,63,64";
-		
-		String idTpMarcadorExcluidos = (StringUtils.isNotBlank(idTpMarcadorExcluir) ? idTpMarcadorExcluir+"," : "" )+ ignoradosQuadroQuantitativo;
-		
-				
-		List listEstados = dao().consultarPaginaInicial(getTitular(), getLotaTitular() );
 
-		if (idTpMarcadorExcluidos != null) {
+		List listEstados = dao().consultarPaginaInicial(getTitular(), getLotaTitular() );
+		
+		if (listEstados.size()>0){
+		
+			String idTpMarcadorIgnoradosQuadroQuantitativo = "7,8,9,10,11,12,13,16,18,20,21,22,26,32,50,51,62,63,64";
+			String idTpMarcadorExcluidos = (StringUtils.isNotBlank(idTpMarcadorExcluir) ? idTpMarcadorExcluir+"," : "" )+ idTpMarcadorIgnoradosQuadroQuantitativo;
+		
 			final String as[] = idTpMarcadorExcluidos.split(",");
-			final Set<Integer> excluir = new HashSet<Integer>();
+			final Set<Long> excluir = new HashSet<Long>();
 
 			for (final String s : as) {
-				excluir.add(Integer.valueOf(s));
+				excluir.add(Long.valueOf(s));
 			}
+		
 			final List listEstadosReduzida = new ArrayList<Object[]>();
+			
 			for (Object o : listEstados) {
-				if (!excluir.contains((Integer) ((Object[]) o)[0])) {
+				if (!excluir.contains(  ((Object[]) o)[0] 	)
+				   ) {
 					listEstadosReduzida.add(o);
 				}
 			}
+
 			listEstados = listEstadosReduzida;
 		}
-
-		
 
 		if (super.getTitular() == null) {
 			throw new AplicacaoException("Titular nulo, verificar se usuário está ativo no RH");
@@ -106,7 +106,7 @@ public class ExGadgetController extends ExController {
 		result.include("documentoVia", new ExMobilSelecao());
 		result.include("apenasQuadro", apenasQuadro);
 	}
-
+	
 	@Get("/public/app/testes/gadgetTest")
 	public void test(final String matricula, final Integer idTpFormaDoc) throws Exception {
 		if (matricula == null) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExGadgetController.java
@@ -59,12 +59,10 @@ public class ExGadgetController extends ExController {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Get("app/expediente/gadget")
-	public void execute(final String idTpMarcadorExcluir, final Integer idTpFormaDoc, boolean apenasQuadro)
+	public void execute(final String idTpMarcadorExcluir,     boolean apenasQuadro)
 			throws Exception {
-		if (idTpFormaDoc == null || idTpFormaDoc.equals(0)) {
-			throw new AplicacaoException("Código do tipo de marca (Processos ou Expedientes) não foi informado");
-		}
-		List listEstados = dao().consultarPaginaInicial(getTitular(), getLotaTitular(), idTpFormaDoc);
+		 
+		List listEstados = dao().consultarPaginaInicial(getTitular(), getLotaTitular() );
 
 		if (idTpMarcadorExcluir != null) {
 			final String as[] = idTpMarcadorExcluir.split(",");
@@ -91,10 +89,12 @@ public class ExGadgetController extends ExController {
 		super.getRequest().setAttribute("_cadastrante", super.getTitular().getSigla() + "@"
 				+ super.getLotaTitular().getOrgaoUsuario().getSiglaOrgaoUsu() + super.getLotaTitular().getSigla());
 
+		List <Integer> listIdTpFormaDoc = new ArrayList<Integer>() {{add(1); add(2);}};
+		
 		result.include("listEstados", listEstados);
 		result.include("titular", this.getTitular());
 		result.include("lotaTitular", this.getLotaTitular());
-		result.include("idTpFormaDoc", idTpFormaDoc);
+		result.include("listIdTpFormaDoc", listIdTpFormaDoc);
 		result.include("documentoVia", new ExMobilSelecao());
 		result.include("apenasQuadro", apenasQuadro);
 	}
@@ -116,10 +116,8 @@ public class ExGadgetController extends ExController {
 			return;
 		}
 
-		final Integer id = (idTpFormaDoc == null || idTpFormaDoc == 0 ? 1 : idTpFormaDoc);
-
 		setTitular(pes);
 		setLotaTitular(pes.getLotacao());
-		this.execute(null, id, Boolean.FALSE);
+		this.execute(null,  Boolean.FALSE);
 	}
 }

--- a/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
@@ -5,6 +5,7 @@
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
 <%@ taglib uri="/WEB-INF/tld/func.tld" prefix="f"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions"  prefix="fn"%>
 
 <script type="text/javascript">
 	submitOk = function() {
@@ -17,128 +18,159 @@
 	}
 </script>
 
-<c:if test="${idTpFormaDoc == 1}">
-	<div id="sigaex"></div>
-</c:if>
-<c:if test="${idTpFormaDoc == 2}">
-	<div id="processos"></div>
-</c:if>
-<table class="table-hover" style="width: 100%">
-	<c:forEach var="listEstado" items="${listEstados}">
-		<c:if test="${listEstado[4].grupo.nome != descr}">
-			<thead>
-				<tr>
-					<th width="50%" style="text-align: left; <c:if test="${not empty descr}">padding-top: 0.5em;</c:if>">${listEstado[4].grupo.nome}</th>
-					<th width="25%" style="text-align: right"><c:if
-							test="${empty descr}">
-							<fmt:message key="quadro.atendente" />
-						</c:if></th>
-					<th width="25%" style="text-align: right"><c:if
-							test="${empty descr}">
-							<fmt:message key="usuario.lotacao" />
-						</c:if></th>
-				</tr>
-			</thead>
-		</c:if>
-		<c:set var="descr" value="${listEstado[4].grupo.nome}" />
-		<c:if
-			test="${listEstado[0] != 9 && listEstado[0] != 8  && listEstado[0] != 10 
-			&& listEstado[0] != 11 && listEstado[0] != 12 
-			&& listEstado[0] != 13 && listEstado[0] != 16
-			&& listEstado[0] != 18 && listEstado[0] != 20 
-			&& listEstado[0] != 21 && listEstado[0] != 22 
-			&& listEstado[0] != 26 && listEstado[0] != 32
-			&& listEstado[0] != 62 && listEstado[0] != 63 && listEstado[0] != 64
-			&& listEstado[0] != 7 && listEstado[0] != 50 && listEstado[0] != 51}">
+<c:set var="descr" value="${listEstado[4].descricao}" />
 
-			<c:set var="titulo1" value="" />
-			<c:set var="titulo2" value="" />
-			<c:set var="titulo3" value="" />
-			<c:set var="ordem" value="0" />
-			<c:set var="visualizacao" value="0" />
-			<c:choose>
-				<c:when test="${listEstado[0]==1}">
-					<c:set var="titulo1"
-						value="Documentos que estão em estado temporário(rascunho) e ainda podem ser editados." />
-					<c:set var="titulo2"
-						value="Documentos que estão em estado temporário(rascunho) e ainda podem ser editados." />
-					<c:set var="titulo3" value="${titulo1}" />
-				</c:when>
-				<c:when test="${listEstado[0]==2}">
-					<c:set var="titulo1"
-						value="Documentos que já foram assinados ou tiveram a assinatura manual registrada. Também contém os documentos que já foram recebidos pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}." />
-					<c:set var="titulo2"
-						value="Documentos que já foram assinados ou tiveram a assinatura manual registrada. Também contém os documentos que já foram recebidos pelo usuário ${titular.nomePessoa}." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-					<c:set var="visualizacao" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==3}">
-					<c:set var="titulo1"
-						value="Documentos não eletrônicos transferidos para a ${lotaTitular.nomeLotacao} ou para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
-					<c:set var="titulo2"
-						value="Documentos não eletrônicos transferidos para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==14}">
-					<c:set var="titulo1"
-						value="Documentos eletrônicos transferidos para a ${lotaTitular.nomeLotacao} ou para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
-					<c:set var="titulo2"
-						value="Documentos eletrônicos transferidos para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==15}">
-					<c:set var="titulo1"
-						value="Documentos que foram finalizados mas ainda não foram assinados." />
-					<c:set var="titulo2"
-						value="Documentos que foram finalizados mas ainda não foram assinados." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==23}">
-					<c:set var="titulo1"
-						value="Documentos não eletrônicos que foram transferidos, pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
-					<c:set var="titulo2"
-						value="Documentos não eletrônicos que foram transferidos, pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==24}">
-					<c:set var="titulo1"
-						value="Documentos eletrônicos que foram transferidos, pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
-					<c:set var="titulo2"
-						value="Documentos eletrônicos que foram transferidos, pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
-					<c:set var="titulo3" value="${titulo1}" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==25}">
-					<c:set var="titulo1"
-						value="Documentos pendentes de assinatura cujo subscritor é o usuário ${titular.nomePessoa}." />
-					<c:set var="titulo2" value="${titulo1}" />
-					<c:set var="titulo3" value="" />
-					<c:set var="ordem" value="1" />
-				</c:when>
-				<c:when test="${listEstado[0]==31}">
-					<c:set var="visualizacao" value="1" />
-				</c:when>
-			</c:choose>
-			<tr>
-				<td
-					style="text-align: left; padding-left: 1em; color: ${'#'}${listEstado[6].descricao}">
-					<c:if test="${not empty listEstado[7]}">
-						<span class="mr-1"><i
-							class="${listEstado[7].codigoFontAwesome}"></i></span>
-					</c:if>${listEstado[1]}
-				<td align="right" class="count"><siga:monolink
-						titulo="${titulo2}" texto="${listEstado[2]}"
-						href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovRespSel.id=${titular.idPessoa}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
-				<td align="right" class="count"><siga:monolink
-						titulo="${titulo3}" texto="${listEstado[3]}"
-						href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovLotaRespSel.id=${lotaTitular.idLotacao}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
-				</td>
-			</tr>
-		</c:if>
-	</c:forEach>
-</table>
+<c:set var="situacao"><fmt:message key="quadro.situacao" /></c:set>
+
+<c:forEach var="idTpFormaDoc" items="${listIdTpFormaDoc}">
+
+	<div class="card bg-light mb-3">
+		<div class="card-header"><a href="/sigaex/app/expediente/doc/listar?primeiraVez=sim&idTipoFormaDoc=${idTpFormaDoc}">${idTpFormaDoc == 1 ? "Expedientes" : "Processos Administrativos"} </a></div>
+		<div class="card-body">
+	
+			<c:if test="${idTpFormaDoc == 1}">
+				<div id="sigaex"></div>
+			</c:if>
+			<c:if test="${idTpFormaDoc == 2}">
+				<div id="processos"></div>
+			</c:if>
+		
+		
+			<table class="table-hover" style="width: 100%">
+				<c:forEach var="listEstado" items="${listEstados}">
+					<c:if test="${listEstado[8] == idTpFormaDoc}">
+						<c:if test="${listEstado[4].grupo.nome != descr}">
+							<thead>
+								<tr>
+									<th width="50%" style="text-align: left; padding-top: 0.5em;">
+									    <c:choose>
+										    <c:when test="${!fn:startsWith(situacao,'???')}">
+										        ${situacao}
+										    </c:when>    
+										
+										    <c:otherwise>
+										         	 ${listEstado[4].descricao}
+										    </c:otherwise>
+										</c:choose>
+									</th>
+				
+				 
+									<th width="25%" style="text-align: right"><c:if
+											test="${empty descr}">
+											<fmt:message key="quadro.atendente" />
+										</c:if></th>
+									<th width="25%" style="text-align: right"><c:if
+											test="${empty descr}">
+											<fmt:message key="usuario.lotacao" />
+										</c:if></th>
+								</tr>
+							</thead>
+						</c:if>
+						<c:set var="descr" value="${listEstado[4].grupo.nome}" />
+						<c:if
+							test="${listEstado[0] != 9 && listEstado[0] != 8  && listEstado[0] != 10 
+							&& listEstado[0] != 11 && listEstado[0] != 12 
+							&& listEstado[0] != 13 && listEstado[0] != 16
+							&& listEstado[0] != 18 && listEstado[0] != 20 
+							&& listEstado[0] != 21 && listEstado[0] != 22 
+							&& listEstado[0] != 26 && listEstado[0] != 32
+							&& listEstado[0] != 62 && listEstado[0] != 63 && listEstado[0] != 64
+							&& listEstado[0] != 7 && listEstado[0] != 50 && listEstado[0] != 51}">
+				
+							<c:set var="titulo1" value="" />
+							<c:set var="titulo2" value="" />
+							<c:set var="titulo3" value="" />
+							<c:set var="ordem" value="0" />
+							<c:set var="visualizacao" value="0" />
+							<c:choose>
+								<c:when test="${listEstado[0]==1}">
+									<c:set var="titulo1"
+										value="Documentos que estão em estado temporário(rascunho) e ainda podem ser editados." />
+									<c:set var="titulo2"
+										value="Documentos que estão em estado temporário(rascunho) e ainda podem ser editados." />
+									<c:set var="titulo3" value="${titulo1}" />
+								</c:when>
+								<c:when test="${listEstado[0]==2}">
+									<c:set var="titulo1"
+										value="Documentos que já foram assinados ou tiveram a assinatura manual registrada. Também contém os documentos que já foram recebidos pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}." />
+									<c:set var="titulo2"
+										value="Documentos que já foram assinados ou tiveram a assinatura manual registrada. Também contém os documentos que já foram recebidos pelo usuário ${titular.nomePessoa}." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+									<c:set var="visualizacao" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==3}">
+									<c:set var="titulo1"
+										value="Documentos não eletrônicos transferidos para a ${lotaTitular.nomeLotacao} ou para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
+									<c:set var="titulo2"
+										value="Documentos não eletrônicos transferidos para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==14}">
+									<c:set var="titulo1"
+										value="Documentos eletrônicos transferidos para a ${lotaTitular.nomeLotacao} ou para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
+									<c:set var="titulo2"
+										value="Documentos eletrônicos transferidos para o usuário ${titular.nomePessoa} que estão aguardando recebimento." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==15}">
+									<c:set var="titulo1"
+										value="Documentos que foram finalizados mas ainda não foram assinados." />
+									<c:set var="titulo2"
+										value="Documentos que foram finalizados mas ainda não foram assinados." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==23}">
+									<c:set var="titulo1"
+										value="Documentos não eletrônicos que foram transferidos, pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
+									<c:set var="titulo2"
+										value="Documentos não eletrônicos que foram transferidos, pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==24}">
+									<c:set var="titulo1"
+										value="Documentos eletrônicos que foram transferidos, pela lotação ${lotaTitular.nomeLotacao} ou pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
+									<c:set var="titulo2"
+										value="Documentos eletrônicos que foram transferidos, pelo usuário ${titular.nomePessoa}, para outra lotação/pessoa mas ainda não foram recebidos." />
+									<c:set var="titulo3" value="${titulo1}" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==25}">
+									<c:set var="titulo1"
+										value="Documentos pendentes de assinatura cujo subscritor é o usuário ${titular.nomePessoa}." />
+									<c:set var="titulo2" value="${titulo1}" />
+									<c:set var="titulo3" value="" />
+									<c:set var="ordem" value="1" />
+								</c:when>
+								<c:when test="${listEstado[0]==31}">
+									<c:set var="visualizacao" value="1" />
+								</c:when>
+							</c:choose>
+							<tr>
+								<td
+									style="text-align: left; padding-left: 1em; color: ${'#'}${listEstado[6].descricao}">
+									<c:if test="${not empty listEstado[7]}">
+										<span class="mr-1"><i
+											class="${listEstado[7].codigoFontAwesome}"></i></span>
+									</c:if>${listEstado[1]}
+								<td align="right" class="count"><siga:monolink
+										titulo="${titulo2}" texto="${listEstado[2]}"
+										href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovRespSel.id=${titular.idPessoa}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
+								<td align="right" class="count"><siga:monolink
+										titulo="${titulo3}" texto="${listEstado[3]}"
+										href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovLotaRespSel.id=${lotaTitular.idLotacao}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
+								</td>
+							</tr>
+						</c:if>
+					</c:if>
+				</c:forEach>
+			</table>
+		</div>
+	</div>
+	
+	<c:set var="descr" value="${listEstado[4].descricao}" />
+</c:forEach>

--- a/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
@@ -67,16 +67,7 @@
 							</thead>
 						</c:if>
 						<c:set var="descr" value="${listEstado[4].grupo.nome}" />
-						<c:if
-							test="${listEstado[0] != 9 && listEstado[0] != 8  && listEstado[0] != 10 
-							&& listEstado[0] != 11 && listEstado[0] != 12 
-							&& listEstado[0] != 13 && listEstado[0] != 16
-							&& listEstado[0] != 18 && listEstado[0] != 20 
-							&& listEstado[0] != 21 && listEstado[0] != 22 
-							&& listEstado[0] != 26 && listEstado[0] != 32
-							&& listEstado[0] != 62 && listEstado[0] != 63 && listEstado[0] != 64
-							&& listEstado[0] != 7 && listEstado[0] != 50 && listEstado[0] != 51}">
-				
+						 
 							<c:set var="titulo1" value="" />
 							<c:set var="titulo2" value="" />
 							<c:set var="titulo3" value="" />
@@ -165,8 +156,7 @@
 										href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovLotaRespSel.id=${lotaTitular.idLotacao}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
 								</td>
 							</tr>
-						</c:if>
-					</c:if>
+ 					</c:if>
 				</c:forEach>
 			</table>
 		</div>


### PR DESCRIPTION
Atualmente ao acessar o quadro quantitativo (tela principal) são disparadas 2 consultas ao BD.
- obter os expedientes do usuario e lotação
- obter os processos do usuario e lotação
Note que a unica diferença é o tipo de forma de documento:
 1- expediente  2-processo administrativo
 
O tempo de execução de cada consulta é baixo, mas a quantidade de execuções é alta.
 

A proposta é reduzir a qtd de acesso ao BD, a fim de reduzir o tempo total exec.
Unica consulta que retorne Processos e Expedientes.


 
