### PR TITLE
PCRJ-2370-Correção acesso  as  opcoes menu: arquivar intermediario lote - permissao arq.permanente lote

### DIFF
--- a/sigaex/src/main/webapp/paginas/menus/menu.jsp
+++ b/sigaex/src/main/webapp/paginas/menus/menu.jsp
@@ -88,7 +88,7 @@
 			</c:catch>
 			<c:catch>
 				<c:if
-					test="${f:podeArquivarPermanentePorConfiguracao(titular,lotaTitular)}">
+					test="${f:podeArquivarIntermediarioPorConfiguracao(titular,lotaTitular)}">
 					<li><a class="dropdown-item"
 						href="/sigaex/app/expediente/mov/arquivar_intermediario_lote">Arquivar
 							Intermediário em Lote</a></li>


### PR DESCRIPTION
A opção de menu/Arquivar Intermediario em Lote não estava sendo inibida ao configurar NÃO PODE.
![2370-menu](https://user-images.githubusercontent.com/78379805/165768601-42b75aaf-8656-4052-aea4-fa5a3fc32f33.PNG)
![2370-configuracao](https://user-images.githubusercontent.com/78379805/165769433-e274ab57-da87-46e1-9aaa-19e1f9052524.PNG)


