### PR TITLE
PCRJ-Erro  ao acessar a pagina principal

### DIFF
--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
@@ -59,10 +59,12 @@ public class PrincipalController extends SigaController {
 	public void principal(Boolean exibirAcessoAnterior, Boolean redirecionar) throws Exception {
 		if (redirecionar == null || redirecionar) {
 			String paginaInicialUrl = Prop.get("/siga.pagina.inicial.url");
-			if (paginaInicialUrl.contains("/mesa"))
-				paginaInicialUrl = paginaInicialUrl.replace("/mesa2", "/mesa") + SigaLibsEL.getMesaVersao(getTitular(), getLotaTitular());
-				
+			
 			if (paginaInicialUrl != null) {
+
+				if (paginaInicialUrl.contains("/mesa"))
+					paginaInicialUrl = paginaInicialUrl.replace("/mesa2", "/mesa") + SigaLibsEL.getMesaVersao(getTitular(), getLotaTitular());
+				
 				result.redirectTo(paginaInicialUrl + ((exibirAcessoAnterior != null && exibirAcessoAnterior) ? "?exibirAcessoAnterior=true" : ""));
 				return;
 			}


### PR DESCRIPTION
Erro ao acessar a pagina principal (quadro quantitativo).
![2370-1-erro](https://user-images.githubusercontent.com/78379805/165786786-5b01792c-b42c-48f1-94e4-a71df6b43a07.PNG)

Notamos q o mesmo ocorre quando  siga.pagina.inicial.url = null