### PR TITLE
PCRJ-2224-Apresentar no documento somente marcador - ativo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -568,14 +568,16 @@ public class ExDocumentoVO extends ExVO {
 			SortedSet<ExMarca> setSistema = new TreeSet<>();
 			SortedSet<ExMarca> set = cadaMobil.getExMarcaSet();
 			for (ExMarca m : set) {
-				if ((m.getDtIniMarca() == null || !m.getDtIniMarca().after(now))
-						&& (m.getDtFimMarca() == null || m.getDtFimMarca().after(now))) {
-					if (m.getCpMarcador().getIdFinalidade().getIdTpMarcador() == CpTipoMarcadorEnum.TIPO_MARCADOR_SISTEMA)
-						setSistema.add(m);
-					if (m.getCpMarcador().getIdFinalidade().getIdTpMarcador() != CpTipoMarcadorEnum.TIPO_MARCADOR_SISTEMA && (cadaMobil == mob || cadaMobil.isGeral())) 
-						getMarcasDoMobil().add(m);
+				if (m.getCpMarcador().isAtivo()){
+					if ((m.getDtIniMarca() == null || !m.getDtIniMarca().after(now))
+							&& (m.getDtFimMarca() == null || m.getDtFimMarca().after(now))) {
+						if (m.getCpMarcador().getIdFinalidade().getIdTpMarcador() == CpTipoMarcadorEnum.TIPO_MARCADOR_SISTEMA)
+							setSistema.add(m);
+						if (m.getCpMarcador().getIdFinalidade().getIdTpMarcador() != CpTipoMarcadorEnum.TIPO_MARCADOR_SISTEMA && (cadaMobil == mob || cadaMobil.isGeral())) 
+							getMarcasDoMobil().add(m);
+					}
+					marcas.add(new ExMarcaVO(m, titular, lotaTitular));
 				}
-				marcas.add(new ExMarcaVO(m, titular, lotaTitular));
 			}
 			getMarcasDeSistemaPorMobil().put(cadaMobil, setSistema);
 			marcasPorMobil.put(cadaMobil, set);


### PR DESCRIPTION
Apresentar no documento somente marcador ativa.
- Criei marcador "teste" de pasta:
![2224-cadastro-marcado](https://user-images.githubusercontent.com/78379805/165793785-46a6028e-1198-4c0b-a4d4-485b865046fd.PNG)
- Quadro quantitativo  e documento com o marcador
![2224-qdro-marcado](https://user-images.githubusercontent.com/78379805/165793812-0e1e829b-8120-4024-b10e-ce59bc2eaf59.PNG)
![2224-documento-marcado](https://user-images.githubusercontent.com/78379805/165793800-3f1adec2-d653-401c-97ad-2a682cdaab90.PNG)

- O marcador foi excluído e sumiu do quadro quantitativo, mas continua aparecendo no  documento.
![2224-documento-depois-exclusao-marcado](https://user-images.githubusercontent.com/78379805/165793796-48a4b542-ccee-4e66-ba30-c530a49afd6b.PNG)
 
 
 **Após a correção do código**
![2224-documento-alteracao](https://user-images.githubusercontent.com/78379805/165793791-98a370f5-ce68-4972-8af5-43355282305e.PNG)