### PR TITLE
PCRJ-2224-1 Excluir marcadores inativos ao atualizar marcas

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -792,39 +792,54 @@ public class ExMarcadorBL {
 	}
 
 	private void acrescentarMarca(Long idMarcador, Date dt, DpPessoa pess, DpLotacao lota, Date dtFim) {
-		ExMarca mar = new ExMarca();
-		mar.setExMobil(mob);
-		mar.setCpMarcador(ExDao.getInstance().consultar(idMarcador, CpMarcador.class, false));
-		if (pess != null)
-			mar.setDpPessoaIni(pess.getPessoaInicial());
-		if (lota != null) {
-			AcessoConsulta ac = new AcessoConsulta(0L, lota.getIdInicial(), 0L, lota.getOrgaoUsuario().getId());
-			if (ac.podeAcessar(mob.doc(), null, lota))
-				mar.setDpLotacaoIni(lota.getLotacaoInicial());
-		}
-		mar.setDtIniMarca(dt);
+		
+		CpMarcador cpMarcador = ExDao.getInstance().consultar(idMarcador, CpMarcador.class, false);
+		if ( cpMarcador != null && cpMarcador.isAtivo() ) {
+			
+			ExMarca mar = new ExMarca();
+			mar.setExMobil(mob);
+			mar.setCpMarcador(cpMarcador);
+			
+			if (pess != null)
+				mar.setDpPessoaIni(pess.getPessoaInicial());
+			if (lota != null) {
+				AcessoConsulta ac = new AcessoConsulta(0L, lota.getIdInicial(), 0L, lota.getOrgaoUsuario().getId());
+				if (ac.podeAcessar(mob.doc(), null, lota))
+					mar.setDpLotacaoIni(lota.getLotacaoInicial());
+			}
+			mar.setDtIniMarca(dt);
 
-		if (dtFim != null)
-			mar.setDtFimMarca(dtFim);
-		set.add(mar);
+			
+			if (dtFim != null)
+				mar.setDtFimMarca(dtFim);
+			set.add(mar);
+		}
+		
 	}
 
 	private void acrescentarMarcaTransferencia(Long idMarcador, Date dtIni, Date dtFim, DpPessoa pess, DpLotacao lota,
 			ExMovimentacao mov) {
-		ExMarca mar = new ExMarca();
-		mar.setExMobil(mob);
-		mar.setCpMarcador(ExDao.getInstance().consultar(idMarcador, CpMarcador.class, false));
-		mar.setExMovimentacao(mov);
-		if (pess != null)
-			mar.setDpPessoaIni(pess.getPessoaInicial());
-		if (lota != null) {
-			AcessoConsulta ac = new AcessoConsulta(0L, lota.getIdInicial(), 0L, lota.getOrgaoUsuario().getId());
-			if (ac.podeAcessar(mob.doc(), null, lota))
-				mar.setDpLotacaoIni(lota.getLotacaoInicial());
+		
+		CpMarcador cpMarcador =ExDao.getInstance().consultar(idMarcador, CpMarcador.class, false);
+		if ( cpMarcador != null && cpMarcador.isAtivo() ) {
+			
+			ExMarca mar = new ExMarca();
+			mar.setExMobil(mob);
+			mar.setCpMarcador(cpMarcador);
+			mar.setExMovimentacao(mov);
+			
+			if (pess != null)
+				mar.setDpPessoaIni(pess.getPessoaInicial());
+			if (lota != null) {
+				AcessoConsulta ac = new AcessoConsulta(0L, lota.getIdInicial(), 0L, lota.getOrgaoUsuario().getId());
+				if (ac.podeAcessar(mob.doc(), null, lota))
+					mar.setDpLotacaoIni(lota.getLotacaoInicial());
+			}
+
+			mar.setDtIniMarca(dtIni);
+			mar.setDtFimMarca(dtFim);
+			set.add(mar);
 		}
-		mar.setDtIniMarca(dtIni);
-		mar.setDtFimMarca(dtFim);
-		set.add(mar);
 	}
 
 	public ExMovimentacao contemTransferenciaRetorno(ExMovimentacao mov, ExMobil mob) {


### PR DESCRIPTION
O pull request anterior somente impede que um marcador inativo seja apresentado no documento.
 Veja na img abaixo que a marca continua : "..Assinado, **Teste**
![2224-documento-alteracao](https://user-images.githubusercontent.com/78379805/165803686-1a3e3caa-fcfe-4d30-b593-1189a35d8d93.PNG)

No BD o registro de cp_marca não foi excluído.
Alteramos o metodo calcular marcas, a fim de exclui-lo definitivamente da cp_marca.
Veja img abaixo, como ficou o documento.
![2224-marca-retirada-apos-atualizar-marcas](https://user-images.githubusercontent.com/78379805/165803503-37a16af8-48c6-4767-bc83-4d0ce7ad868c.PNG)
No BD - cp_marca após atualizar marcas
![2224-registro-excluido-cpmarca](https://user-images.githubusercontent.com/78379805/165805205-3cfcaec9-e5db-4626-a38a-5df43f6634dd.PNG)

É necessário executar a opção de atualizar marcas do documento.
![2224-atualizar-marca](https://user-images.githubusercontent.com/78379805/165806440-f0b6700b-36ae-411d-883d-71a1450c6cc2.PNG)

