### PR TITLE
PCRJ-2134 Nao disponibilizar link quadro quantitatico com qtd igual 0

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exGadget/execute.jsp
@@ -148,13 +148,30 @@
 										<span class="mr-1"><i
 											class="${listEstado[7].codigoFontAwesome}"></i></span>
 									</c:if>${listEstado[1]}
-								<td align="right" class="count"><siga:monolink
-										titulo="${titulo2}" texto="${listEstado[2]}"
-										href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovRespSel.id=${titular.idPessoa}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
-								<td align="right" class="count"><siga:monolink
-										titulo="${titulo3}" texto="${listEstado[3]}"
-										href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovLotaRespSel.id=${lotaTitular.idLotacao}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
-								</td>
+								
+								<td align="right" class="count">
+										<c:choose>
+											<c:when test="${listEstado[2]>0}">
+												<siga:monolink titulo="${titulo2}" texto="${listEstado[2]}"
+												href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovRespSel.id=${titular.idPessoa}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
+											</c:when>
+											<c:otherwise>
+												 ${listEstado[2]} 
+											</c:otherwise>
+										</c:choose>
+								<td align="right" class="count">
+										<c:choose>
+											<c:when test="${listEstado[3]>0}">
+												<siga:monolink titulo="${titulo3}" texto="${listEstado[3]}"
+												href="${pageContext.request.contextPath}/app/expediente/doc/listar?ultMovIdEstadoDoc=${listEstado[0]}&ultMovLotaRespSel.id=${lotaTitular.idLotacao}&orgaoUsu=0&idTipoFormaDoc=${idTpFormaDoc}&ordem=${ordem}&visualizacao=${visualizacao}" />
+											</c:when>
+											<c:otherwise>
+												 ${listEstado[3]} 
+											</c:otherwise>
+										</c:choose>
+								 </td>
+
+								
 							</tr>
  					</c:if>
 				</c:forEach>


### PR DESCRIPTION
Veja na img do quadro quantitativo,  que um link para pesquisa de documentos é disponibilizado mesmo qnd  quantidade  ZERO.
![2134-cria-link-zero](https://user-images.githubusercontent.com/78379805/165826521-9e774d8f-34d7-4c06-a99a-a5b3b34674e8.PNG)
Esse link dispara 2 consultas ao BD e apresenta o resultado na tela de pesquisa de documentos.
Acreditamos ser desnecessário o link e  alteramos o código para disponibilizar o link, somente quando a quantidade > 0.
![2134-sem-link-qnd-qtd-zero](https://user-images.githubusercontent.com/78379805/165826526-3476951f-deff-45ff-9c02-3b5d99f6ee9f.PNG)
