### PR TITLE
feature/gov/110842 Atribuir prazo para assinatura indisponível em documento cancelado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -63,6 +63,7 @@ import br.gov.jfrj.siga.ex.logic.ExPodeCapturarPDF;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarSubprocesso;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarVia;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarVolume;
+import br.gov.jfrj.siga.ex.logic.ExPodeDefinirPrazoAssinatura;
 import br.gov.jfrj.siga.ex.logic.ExPodeDesfazerConcelamentoDeDocumento;
 import br.gov.jfrj.siga.ex.logic.ExPodeDesfazerRestricaoDeAcesso;
 import br.gov.jfrj.siga.ex.logic.ExPodeDuplicar;
@@ -782,6 +783,11 @@ public class ExDocumentoVO extends ExVO {
 		
 		vo.addAcao(AcaoVO.builder().nome("Enviar ao SIAFEM").icone("email_go").nameSpace("/app/expediente/integracao").acao("integracaows")
 				.params("sigla", mob.getCodigoCompacto()).exp(And.of(new CpPodeBoolean(mostrarEnviarSiafem(doc), "pode mostrar Siafem"), new ExPodeEnviarSiafem(doc, titular, lotaTitular))).classe("once").build());
+	
+		if (!doc.isCancelado())
+			vo.addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
+			.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
+		
 	}
 
 	private boolean mostrarEnviarSiafem(ExDocumento doc) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -486,9 +486,6 @@ public class ExMobilVO extends ExVO {
 		addAcao(AcaoVO.builder().nome("Apensar").icone("link_add").nameSpace("/app/expediente/mov").acao("apensar")
 				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeApensar(mob, titular, lotaTitular)).classe("once").build());
 
-		addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
-				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
-
 		// Não aparece a opção de Cancelar Movimentação para documentos
 		// temporários
 		


### PR DESCRIPTION
Ocultando o botão que permite atribuir um prazo de assinatura quando o documento estiver cancelado. Segue evidência da solução: 
![001](https://user-images.githubusercontent.com/73559672/166319129-1e2a8d62-eb95-46a2-a224-899f422a6885.PNG)

![002](https://user-images.githubusercontent.com/73559672/166319200-ab4ea3eb-657b-426f-8354-bcc4786368b6.PNG)

