### PR TITLE
Feature/gov/110842 atribuir prazo para assinatura indisponivel em documento cancelado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeDefinirPrazoAssinatura.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeDefinirPrazoAssinatura.java
@@ -51,6 +51,8 @@ public class ExPodeDefinirPrazoAssinatura extends CompositeExpressionSupport {
 				new ExEstaFinalizado(mob.doc()),
 
 				new ExEstaPendenteDeAssinatura(mob.doc()),
+				
+				Not.of(new ExEstaCancelado(mob.doc())),
 
 				Not.of(new ExEMobilCancelado(mob)),
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -63,6 +63,7 @@ import br.gov.jfrj.siga.ex.logic.ExPodeCapturarPDF;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarSubprocesso;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarVia;
 import br.gov.jfrj.siga.ex.logic.ExPodeCriarVolume;
+import br.gov.jfrj.siga.ex.logic.ExPodeDefinirPrazoAssinatura;
 import br.gov.jfrj.siga.ex.logic.ExPodeDesfazerConcelamentoDeDocumento;
 import br.gov.jfrj.siga.ex.logic.ExPodeDesfazerRestricaoDeAcesso;
 import br.gov.jfrj.siga.ex.logic.ExPodeDuplicar;
@@ -782,6 +783,11 @@ public class ExDocumentoVO extends ExVO {
 		
 		vo.addAcao(AcaoVO.builder().nome("Enviar ao SIAFEM").icone("email_go").nameSpace("/app/expediente/integracao").acao("integracaows")
 				.params("sigla", mob.getCodigoCompacto()).exp(And.of(new CpPodeBoolean(mostrarEnviarSiafem(doc), "pode mostrar Siafem"), new ExPodeEnviarSiafem(doc, titular, lotaTitular))).classe("once").build());
+	
+		if (!doc.isCancelado())
+			vo.addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
+			.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
+		
 	}
 
 	private boolean mostrarEnviarSiafem(ExDocumento doc) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -783,10 +783,6 @@ public class ExDocumentoVO extends ExVO {
 		
 		vo.addAcao(AcaoVO.builder().nome("Enviar ao SIAFEM").icone("email_go").nameSpace("/app/expediente/integracao").acao("integracaows")
 				.params("sigla", mob.getCodigoCompacto()).exp(And.of(new CpPodeBoolean(mostrarEnviarSiafem(doc), "pode mostrar Siafem"), new ExPodeEnviarSiafem(doc, titular, lotaTitular))).classe("once").build());
-	
-		if (!doc.isCancelado())
-			vo.addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
-			.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
 		
 	}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -486,9 +486,6 @@ public class ExMobilVO extends ExVO {
 		addAcao(AcaoVO.builder().nome("Apensar").icone("link_add").nameSpace("/app/expediente/mov").acao("apensar")
 				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeApensar(mob, titular, lotaTitular)).classe("once").build());
 
-		addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
-				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
-
 		// Não aparece a opção de Cancelar Movimentação para documentos
 		// temporários
 		

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -486,6 +486,9 @@ public class ExMobilVO extends ExVO {
 		addAcao(AcaoVO.builder().nome("Apensar").icone("link_add").nameSpace("/app/expediente/mov").acao("apensar")
 				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeApensar(mob, titular, lotaTitular)).classe("once").build());
 
+		addAcao(AcaoVO.builder().nome("Atribuir Prazo de Assinatura").icone("date_previous").nameSpace("/app/expediente/mov").acao("definir_prazo_assinatura")
+				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeDefinirPrazoAssinatura(mob, titular, lotaTitular)).classe("once").build());
+		
 		// Não aparece a opção de Cancelar Movimentação para documentos
 		// temporários
 		


### PR DESCRIPTION
Realizando validação para ocultar botão "Atribuir Prazo de assinatura" quando for cancelado o documento. Segue evidência: 
![001](https://user-images.githubusercontent.com/73559672/166716091-c800f8b2-020b-403e-8f08-876ac517d4c5.PNG)

![002](https://user-images.githubusercontent.com/73559672/166716113-83166b66-c4d0-4b61-a9a7-8a371681d43d.PNG)

