### PR TITLE
PCRJ- Erro na transferência em lote,  qnd doc. tem nivel acesso igual NIVEL_ACESSO_ENTRE_ORGAOS

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -2836,7 +2836,7 @@ public class ExMovimentacaoController extends ExController {
 
 		result.include("mov", mov);
 		result.include("itens", arrays);
-		result.include("lotaTitular", mov.getLotaTitular());
+		result.include("lotaTitular", getLotaTitular());
 //		result.include("dtMovString", dtMovString);
 //		result.include("subscritorSel", subscritorSel);
 //		result.include("titularSel", titularSel);


### PR DESCRIPTION
Na PCRJ utilizamos a versão .10.0.21.9.
Recentemente um dos nossos usuários relatou erro ao realizar a transferência em lote.
![2445-pull-1](https://user-images.githubusercontent.com/78379805/168147936-ebeaea52-240f-44f3-99d2-d6848a78c00c.PNG)
Verificamos que o "nullPointerException" é lançado pelo método mostraDescricaoConfidencial da ExBL.java, que recebe "lotaTitular" = null.
Tudo começa no controlador ExMovimentacaoController,  que atribui null ao "lotatitular"
![2545-1](https://user-images.githubusercontent.com/78379805/168147856-1b76f7c8-c8a8-4a96-a0ca-e42decfbbc04.PNG)
**Provavelmente, o erro não ocorra mais na versão 10.2.4.1,  devido ao tratamento realizado nesse método.**
![2445-pull-2](https://user-images.githubusercontent.com/78379805/168148943-4b3ea6c8-9fa5-4a95-b141-fc7a30277b92.PNG)
Contudo entendemos que o tratamento mascarou o erro e real retorno do método, que sempre retorna "False".
Resolvemos realizar a alteração na origem do erro : ExMovimentacaoController.
result.include("lotaTitular", getLotaTitular());





