### PR TITLE
Feature/gov/Resolvendo problema na alteração de registro de usuários

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1404,7 +1404,6 @@ public class CpBL {
 		
 		try {
 	//		dao().em().getTransaction().begin();
-
 			if(pessoaAnt != null && pessoaAnt.getId() != null) {
 				pessoa.setMatricula(pessoaAnt.getMatricula());
 				pessoa.setIdePessoa(pessoaAnt.getIdePessoa());

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1400,7 +1400,7 @@ public class CpBL {
 		List<DpPessoa> listaPessoasMesmoCPF = new ArrayList<DpPessoa>();
 		DpPessoa pessoa2 = new DpPessoa();
 	
-		listaPessoasMesmoCPF.addAll(CpDao.getInstance().listarCpfAtivoInativo(pessoa.getCpfPessoa()));
+		listaPessoasMesmoCPF.addAll(CpDao.getInstance().listarPorCpf(pessoa.getCpfPessoa()));
 		
 		try {
 	//		dao().em().getTransaction().begin();


### PR DESCRIPTION
Pelo fato de ter uma CONSTRAINT na base de dados que garante que terá somente um usuário para um ORGAO/CARGO/FUNÇÃO DE CONFIANÇA/LOTAÇÃO e CPF. Logo, quando existe dois usuários com os mesmos registros sendo que um deles está INATIVO é lançado uma exceção (ConstraintViolationException) impossibilitando tal alteração.

Analisando o código pude perceber em um dos métodos responsável por essa rotina estava chamando um outro método que trás uma coleção de usuários com CPF ativos e inativos, por esse motivo estava impossibilitando a alteração. Daí substituí por um método já existente no sistema que trás somente os CPF ativos. Em tese, agora é possível alterar registro de usuário ativo que possui o mesmo registro de outro usuário inativo.

Evidência: 
![alter](https://user-images.githubusercontent.com/73559672/170355670-cb02c48c-0d02-4d53-938c-85d3464375a7.jpg)

![result](https://user-images.githubusercontent.com/73559672/170355705-412d4670-50ef-48a2-9c79-50f31b915e71.jpg)


