### PR TITLE
RM105099 - Pesquisa da função de confiança por nome e órgão não respeitava o versionamento

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpFuncaoConfianca.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpFuncaoConfianca.java
@@ -69,7 +69,8 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 		@NamedQuery(name = "consultarQuantidadeDpFuncaoConfiancaInclusiveInativas", query = "select count(distinct funcao.idFuncaoIni) from DpFuncaoConfianca funcao "
 				+ "  	where  (:idOrgaoUsu = null or :idOrgaoUsu = 0L or funcao.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu)"
 				+ "  		and upper(funcao.nmFuncaoConfiancaAI) like upper('%' || :nome || '%')"),
-		@NamedQuery(name = "consultarPorNomeOrgaoDpFuncaoConfianca", query = "select fun from DpFuncaoConfianca fun where upper(REMOVE_ACENTO(fun.nomeFuncao)) = upper(REMOVE_ACENTO(:nome)) and fun.orgaoUsuario.idOrgaoUsu = :idOrgaoUsuario")})
+		@NamedQuery(name = "consultarPorNomeOrgaoDpFuncaoConfianca", query = "select fun from DpFuncaoConfianca fun where upper(REMOVE_ACENTO(fun.nomeFuncao)) = upper(REMOVE_ACENTO(:nome)) and fun.orgaoUsuario.idOrgaoUsu = :idOrgaoUsuario"
+				+ "			and fun.dataFimFuncao = null")})
 
 public abstract class AbstractDpFuncaoConfianca extends Objeto implements
 		Serializable, HistoricoAuditavel  {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -651,7 +651,7 @@ public class CpDao extends ModeloDao {
 		query.setParameter("idOrgaoUsuario", o.getOrgaoUsuario().getIdOrgaoUsu());
 
 		final List<DpFuncaoConfianca> l = query.getResultList();
-		if (l.size() != 1)
+		if (l.isEmpty())
 			return null;
 		return l.get(0);
 	}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -651,7 +651,7 @@ public class CpDao extends ModeloDao {
 		query.setParameter("idOrgaoUsuario", o.getOrgaoUsuario().getIdOrgaoUsu());
 
 		final List<DpFuncaoConfianca> l = query.getResultList();
-		if (l.isEmpty())
+		if (l.size() != 1)
 			return null;
 		return l.get(0);
 	}


### PR DESCRIPTION
Trazia também versões não ativas e dava erro na carga via planilha excel porque não encontrava a função de confiança que tivesse sido alterada alguma vez.