### PR TITLE
RM117565 - Problema para Redefinir Acesso

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExAcesso.java
@@ -251,7 +251,7 @@ public class ExAcesso {
 		
 			// Aberto
 			if (doc.isPendenteDeAssinatura()) {
-				switch (doc.getExNivelAcesso().getGrauNivelAcesso()) {
+				switch (doc.getExNivelAcessoAtual().getGrauNivelAcesso()) {
 				case (int) ExNivelAcesso.NIVEL_ACESSO_PESSOAL:
 				case (int) ExNivelAcesso.NIVEL_ACESSO_PESSOA_SUB:
 					add(doc.getCadastrante());


### PR DESCRIPTION
Redefinição de acesso não estava sendo respeitada quando o documento não esta assinado.