### PR TITLE
RM121450 Marcador Resp. pela Assinatura ao invés de Como Subscritor

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
@@ -63,7 +63,7 @@ public enum CpMarcadorEnum {
 	//
 	EM_TRANSITO_ELETRONICO(24, "Em Trâmite", "fas fa-shipping-fast", "", CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
 	//
-	COMO_SUBSCRITOR(25, "Como Subscritor", "fas fa-key", "", CpMarcadorGrupoEnum.A_ASSINAR),
+	COMO_SUBSCRITOR(25, SigaMessages.getMessage("marcador.como.subscritor.label"), "fas fa-key", "", CpMarcadorGrupoEnum.A_ASSINAR),
 	//
 	APENSADO(26, "Apensado", "fas fa-compress-arrows-alt", "", CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
 	//
@@ -245,11 +245,7 @@ public enum CpMarcadorEnum {
 	}
 
 	public String getNome() {
-		if (SigaMessages.isSigaSP() && nome.equals("Como Subscritor")) {
-			return "Responsável pela Assinatura";
-		} else {
-			return nome;
-		}
+		return nome;
 	}
 
 	public CpMarcadorGrupoEnum getGrupo() {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/CpMarcador.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/CpMarcador.java
@@ -209,10 +209,9 @@ public class CpMarcador extends AbstractCpMarcador {
 
 	public static ActiveRecord<CpMarcador> AR = new ActiveRecord<>(CpMarcador.class);
 
-	public static final List<Long> MARCADORES_DEMANDA_JUDICIAL = Arrays.asList(CpMarcadorEnum.DEMANDA_JUDICIAL_BAIXA.getId(),
-			CpMarcadorEnum.DEMANDA_JUDICIAL_MEDIA.getId(), CpMarcadorEnum.DEMANDA_JUDICIAL_ALTA.getId());
+	public static List<Long> MARCADORES_DEMANDA_JUDICIAL;
 	
-	public static final List<Long> MARCADOR_A_DEVOLVER_FORA_DO_PRAZO = Arrays.asList(CpMarcadorEnum.A_DEVOLVER_FORA_DO_PRAZO.getId());
+	public static List<Long> MARCADOR_A_DEVOLVER_FORA_DO_PRAZO;
 	
 	/**
 	 * Ordena de acordo com a {@link #getOrdem() Ordem}.
@@ -235,10 +234,15 @@ public class CpMarcador extends AbstractCpMarcador {
 	}
 
 	public boolean isDemandaJudicial() {
+		if (MARCADORES_DEMANDA_JUDICIAL == null)
+			 MARCADORES_DEMANDA_JUDICIAL = Arrays.asList(CpMarcadorEnum.DEMANDA_JUDICIAL_BAIXA.getId(),
+						CpMarcadorEnum.DEMANDA_JUDICIAL_MEDIA.getId(), CpMarcadorEnum.DEMANDA_JUDICIAL_ALTA.getId());
 		return MARCADORES_DEMANDA_JUDICIAL.contains(this.getIdMarcador());
 	}
 	
 	public boolean isADevolverForaDoPrazo() {
+		if (MARCADOR_A_DEVOLVER_FORA_DO_PRAZO == null)
+			MARCADOR_A_DEVOLVER_FORA_DO_PRAZO = Arrays.asList(CpMarcadorEnum.A_DEVOLVER_FORA_DO_PRAZO.getId());
 		return MARCADOR_A_DEVOLVER_FORA_DO_PRAZO.contains(this.getIdMarcador());
 	}
 

--- a/siga-cp/src/main/resources/messages_GOVSP.properties
+++ b/siga-cp/src/main/resources/messages_GOVSP.properties
@@ -96,6 +96,7 @@ mensagem.semEfeito.documento=Este documento será cancelado. Prosseguir?
 mensagem.cancela.documento=Este documento se tornará sem efeito e seus dados serão copiados para um novo documento em elaboração.Prosseguir?
 marcador.semEfeito.label=Cancelado
 marcador.cancelado.label=Sem efeito
+marcador.como.subscritor.label=Responsável pela Assinatura
 responsavel.externo=Externo
 responsavel.campo.livre=Campo Livre
 protocolo.transferencia=Protocolo de Tramitação

--- a/siga-cp/src/main/resources/messages_SIGA.properties
+++ b/siga-cp/src/main/resources/messages_SIGA.properties
@@ -96,6 +96,7 @@ mensagem.semEfeito.documento=Esta operação tornará esse documento sem efeito. Pr
 mensagem.cancela.documento=Esse documento será cancelado e seus dados serão copiados para um novo expediente em elaboração. Prosseguir?
 marcador.semEfeito.label=Sem Efeito
 marcador.cancelado.label=Cancelado
+marcador.como.subscritor.label=Como Subscritor
 responsavel.externo=Externo
 responsavel.campo.livre=Campo Livre
 protocolo.transferencia=Protocolo de Transferência

--- a/siga-cp/src/main/resources/messages_TRF2.properties
+++ b/siga-cp/src/main/resources/messages_TRF2.properties
@@ -96,6 +96,7 @@ mensagem.semEfeito.documento=Esta operação tornará esse documento sem efeito. Pr
 mensagem.cancela.documento=Esse documento será cancelado e seus dados serão copiados para um novo expediente em elaboração. Prosseguir?
 marcador.semEfeito.label=Sem Efeito
 marcador.cancelado.label=Cancelado
+marcador.como.subscritor.label=Como Subscritor
 responsavel.externo=Externo
 responsavel.campo.livre=Campo Livre
 protocolo.transferencia=Protocolo de Transferência


### PR DESCRIPTION
Em GOVSP, o marcador Como Subscritor foi renomeado para Responsável pela Assinatura. No nosso ambiente de homologação e desenvolvimento, isso não estava renomeado. Corrigido via script somente no ambiente de São Paulo.

Também foi corrigida a internacionalização no CpMarcadorEnum e um erro de inicialização dela que não conseguia carregar o provider das properties que acontecia depois.