### PR TITLE
RM116172 - Correção da Constraint Criada no Script V116

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1502,17 +1502,15 @@ public class CpBL {
 			}
 		
 			return pessoa;
-		//	dao().em().getTransaction().commit();
 		} catch (final Exception e) {
 			if (e.getCause() instanceof ConstraintViolationException 
 					&& ((ConstraintViolationException) e.getCause()).getConstraintName().toUpperCase().contains("DP_PESSOA_UNIQUE_PESSOA_ATIVA")) {
 				throw new AplicacaoException("Ocorreu um problema no cadastro da pessoa.");
 			} else if (e.getCause() instanceof ConstraintViolationException 
-					&& ((ConstraintViolationException) e.getCause()).getConstraintName().toUpperCase().contains("SIGA_VALID_UNIQUE")) {
+					&& ((ConstraintViolationException) e.getCause()).getConstraintName().toUpperCase().contains("PESSOA_ATIVA_CHAVES_UNICA")) {
 				throw new AplicacaoException(
-						"Usuário já cadastrado com estes dados: Órgão, Cargo, Função, Unidade e CPF");
-			}else {
-		//	dao().em().getTransaction().rollback();
+						"Pessoa já cadastrada e ativa com estes dados: Órgão, Cargo, Função, Unidade e CPF");
+			} else {
 				throw new AplicacaoException("Erro na gravação", 0, e);
 			}
 		}

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V123_0__Correcao_Constraint_Pessoa_Unica_Ativa.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V123_0__Correcao_Constraint_Pessoa_Unica_Ativa.sql
@@ -1,0 +1,19 @@
+-- -----------------------------------------------------------------------------------------------
+--	CORREÇÃO DA CONSTRAINT CRIADA NO SCRIPT V116 ONDE NÃO FOI TRATADO DADOS INATIVOS
+--	SCRIPT: EVITA A DUPLICIDADE DE PESSOAS COM O MESMO Órgão, Cargo, Função, Unidade e CPF.
+
+-- NÃO APLICADO O NOVALIDATE. DEVE-SE TRATAR DADOS ATIVOS QUE ESTEJAM REPETIDOS.
+
+-- -----------------------------------------------------------------------------------------------
+
+-- DROP CONSTRAINT
+ALTER TABLE CORPORATIVO.DP_PESSOA DROP CONSTRAINT siga_valid_unique;
+-- DROP IDX
+DROP INDEX corporativo.user_index_for_un ;
+
+-- CREATE IDX PESSOA ATIVA SEM REPETIÇÃO DAS CHAVES CPF + ID_ORGAO_USU + ID_LOTACAO + ID_CARGO + ID_FUNCAO_CONFIANCA
+CREATE UNIQUE INDEX CORPORATIVO.PESSOA_ATIVA_CHAVES_UNICA on CORPORATIVO.DP_PESSOA (
+    CASE WHEN DATA_FIM_PESSOA IS NULL THEN 
+        CPF_PESSOA || '-' || ID_ORGAO_USU || '-' || ID_LOTACAO || '-' || ID_CARGO || '-' || ID_FUNCAO_CONFIANCA 
+    END
+);


### PR DESCRIPTION
CORREÇÃO DA CONSTRAINT CRIADA NO SCRIPT V116 ONDE NÃO FOI TRATADO DADOS INATIVOS
https://github.com/projeto-siga/siga/pull/1968

Quando é alterado o nome, o sistema aplica a alteração para registros ativos e inativos. A data fim é copiado para o novo registro quando ele é um registro inativo. Isso fazia que a constraint fosse violada no formato anterior, onde a data fim compunha o indíce. 

Mais explicações no PR que foi bloqueado:
https://github.com/projeto-siga/siga/pull/2109

Nessa nova constraint, não foi aplicado o NOVALIDATE. Os dados devem ser analisados e tratados para evitar sujeiras e erros em outras funcionalidades onde há mais de um registro ativo com o mesmo conjunto de chave:
Órgão, Cargo, Função, Unidade e CPF

Para verificar os dados:

```
//Consulta de registros que devem ser tratados
select * from (
 select CPF_PESSOA, ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO,count(1) qtd from corporativo.dp_pessoa where DATA_FIM_PESSOA IS NULL group by CPF_PESSOA, ID_ORGAO_USU, ID_CARGO, ID_FUNCAO_CONFIANCA, ID_LOTACAO
 ) a where a.qtd >1 

//após análise setar a data fim. 
update corporativo.dp_pessoa set data_fim_pessoa = current_timestamp where id_pessoa in()

//ou usar o /app/pessoa/ativarInativar passando o id que será inativado
https://XXXXXXXXXX/siga/app/pessoa/ativarInativar?id=YYYYY
```
