### PR TITLE
Rm120826 Refatoramento da funcionalidade de envio do Documento para visualizacao externa

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeEnviarParaVisualizacaoExterna.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeEnviarParaVisualizacaoExterna.java
@@ -5,6 +5,7 @@ import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.model.enm.ExTipoDeConfiguracao;
+import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
 import com.crivano.jlogic.*;
 
 public class ExPodeEnviarParaVisualizacaoExterna extends CompositeExpressionSupport {
@@ -39,9 +40,10 @@ public class ExPodeEnviarParaVisualizacaoExterna extends CompositeExpressionSupp
 
                 new ExPodeAcessarDocumento(mob, titular, lotaTitular),
 
-                Not.of(new ExPodePorConfiguracao(titular, lotaTitular)
-                        .withIdTpConf(ExTipoDeConfiguracao.VISUALIZACAO_EXTERNA_DOCUMENTOS)
-                        .withCpOrgaoUsu(mob.getDoc().getOrgaoUsuario()))
+                new ExPodeMovimentarPorConfiguracao(
+                        ExTipoDeMovimentacao.ENVIO_PARA_VISUALIZACAO_EXTERNA,
+                        titular, lotaTitular
+                )
         );
     }
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExEmail.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExEmail.java
@@ -27,7 +27,22 @@ public class ExEmail implements ExEnviarEmail, ExMontarEmail {
 		} catch (Exception e) {
 			throw new AplicacaoException("Ocorreu um erro durante o envio do email", 0, e);
 		}
-	} 
+	}
+
+	@Override
+	public void enviarAoDestinatarioExterno(String nomeDestinatario, String emailDestinatario,
+											String sigla, String cod, String urlDoc) {
+
+		String assunto = "Código para visualização do documento " + sigla;
+		String[] destinanarios = { emailDestinatario };
+		String conteudoHTML = docEnviadoParaDestinatarioExterno(nomeDestinatario, emailDestinatario,
+				sigla, cod, urlDoc);
+		try {
+			Correio.enviar(null, destinanarios, assunto, "", conteudoHTML);
+		} catch (Exception e) {
+			throw new AplicacaoException("Ocorreu um erro durante o envio do email", 0, e);
+		}
+	}
 
 	public void enviarAoResponsavelPelaAssinatura(DpPessoa pessoaDest, DpPessoa titular, String sigla) {
 		String assunto = "Responsável pela assinatura: " + pessoaDest.getDescricao();
@@ -97,6 +112,37 @@ public class ExEmail implements ExEnviarEmail, ExMontarEmail {
 		} catch (IOException e) {
 			throw new AplicacaoException("Erro ao montar e-mail para enviar ao usuário " + destinatario.getNomePessoa());
 		}	
+	}
+
+	@Override
+	public String docEnviadoParaDestinatarioExterno(String nomeDestinatario, 
+													String emailDestinatario, 
+													String siglaDoc,
+													String cod,
+													String urlDoc
+	) {
+		String conteudo = "";
+		try (BufferedReader bfr = new BufferedReader(new InputStreamReader(
+				getClass().getResourceAsStream(ExTemplateEmail.DOCUMENTO_ENVIADO_PARA_USUARIO_EXTERNO.getPath()),
+						StandardCharsets.UTF_8))) {
+			String str;
+			while((str = bfr.readLine()) != null) {
+				conteudo += str;
+			}
+			conteudo = conteudo
+					.replace("${url}", Prop.get("/siga.base.url"))
+					.replace("${logo}", Prop.get("/siga.email.logo"))
+					.replace("${titulo}", Prop.get("/siga.email.titulo"))
+					.replace("${nomeDestinatario}", nomeDestinatario)
+					.replace("${siglaDoc}", siglaDoc)
+					.replace("${cod}", cod)
+					.replace("${urlDoc}", urlDoc);
+
+			return conteudo;
+
+		} catch (IOException e) {
+			throw new AplicacaoException("Erro ao montar e-mail para enviar ao usuário " + emailDestinatario);
+		}
 	}
 
 	@Override

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExEnviarEmail.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExEnviarEmail.java
@@ -10,5 +10,7 @@ public interface ExEnviarEmail {
 	public void enviarAoTramitarDocMarcado(DpPessoa pessoaDest, DpPessoa titular, String sigla, String marcador);
 	public void enviarAoResponsavelPelaAssinatura(DpPessoa pessoaDest, DpPessoa titular, String sigla);
 	public void enviarAoTramitarDocParaUsuario(DpPessoa pessoaDest, DpPessoa titular, String sigla);
+	public void enviarAoDestinatarioExterno(String nomeDestinatario, String emailDestinatario,
+											String siglaDoc, String cod, String url);
 	
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExMontarEmail.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExMontarEmail.java
@@ -10,5 +10,7 @@ public interface ExMontarEmail {
 	public String responsavelPelaAssinatura(DpPessoa destinatario, DpPessoa cadastrante, String siglaDoc);
 	public String docMarcadoTramitadoParaUsuario(DpPessoa destinatario, DpPessoa cadastrante, String docSigla, String marcador);
 	public String docTramitadoParaUsuario(DpPessoa destinatario, DpPessoa cadastrante, String siglaDoc);
+	public String docEnviadoParaDestinatarioExterno(String nomeDestinatario, String emailDestinatario,
+													String siglaDoc, String cod, String url);
 	
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExTemplateEmail.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/notificador/especifico/ExTemplateEmail.java
@@ -6,7 +6,8 @@ public enum ExTemplateEmail {
 	DOCUMENTO_TRAMITADO_PARA_UNIDADE ("/templates/email/doc-tramitado-para-unidade.html"),
 	DOCUMENTO_TRAMITADO_PARA_USUARIO("/templates/email/doc-tramitado-para-usuario.html"),
 	INCLUIDO_COMO_COSSIGNATARIO ("/templates/email/incluido-como-cossignatario.html"),
-	RESPONSAVEL_PELA_ASSINATURA ("/templates/email/usuario-responsavel-pela-assinatura.html");
+	RESPONSAVEL_PELA_ASSINATURA ("/templates/email/usuario-responsavel-pela-assinatura.html"),
+	DOCUMENTO_ENVIADO_PARA_USUARIO_EXTERNO("/templates/email/doc-enviado-para-usuario-externo.html");
 	
 	private String path;
 	

--- a/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
+++ b/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+	<head>
+        <meta charset="utf-8">
+    </head>
+	<body style="font-family: Arial, Helvetica, sans-serif; color: #212529;">
+		<div id="header">
+			<div
+				style='height: 80px; background-color: #f6f5f6; margin: 0px; padding: 20px;'>
+				<img style='text-align: center;'
+					src='${url}/${logo}'
+					alt='SIGA' width='150' />
+			</div>
+			<div style='background-color: #dadada;'>
+				<h3 style="height: 20px; margin: 0px; padding: 10px;">${titulo}</h3>
+			</div>
+		</div>
+		<div id="content" style="margin-top: 30px; padding: 20px;">
+			<div>
+				<p> 
+					Prezado usu&aacute;rio(a) <b>${nomeDestinatario}</b>. Vo&ecirc; recebeu o documento <b>(${siglaDoc})</b>, para visualiza&ccedil;&atilde;o.</b> 
+				</p>
+				<br />
+			</div>
+			<div style="margin-top: 20px;">
+				<p>C&oacute;digo de acesso ao documento: <b>${cod}</b></p>
+				<p>Para visualizar o documento, <a href="${urlDoc}">clique aqui.</a></p>
+			</div>
+		</div>
+
+		<div id="footer" style='background-color: #dadada; padding: 5px;'>
+			<p><span style='color: #555;'><b>Oberva&ccedil;&atilde;o</b>: O c&oacute;digo de acesso fornecido expirar&aacute; em 30 (trinta) dias. 
+				Caso seja necess&aacute;rio acessar o documento após esse prazo, solicite um novo c&oacute;digo.</span></p>
+			<p><span style='color: #555;'><b>Aten&ccedil;&atilde;o</b>: Esta &eacute; uma mensagem autom&aacute;tica. Por favor n&atilde;o responda.</span></p>
+		</div>
+	</body>
+</html> 

--- a/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
+++ b/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
@@ -35,6 +35,14 @@
 			<p><span style='color: #555;'><b>Oberva&ccedil;&atilde;o</b>: O c&oacute;digo de acesso fornecido expirar&aacute; em 30 (trinta) dias. 
 				Caso seja necess&aacute;rio acessar o documento após esse prazo, solicite um novo c&oacute;digo.</span></p>
 			<p><span style='color: #555;'><b>Aten&ccedil;&atilde;o</b>: Esta &eacute; uma mensagem autom&aacute;tica. Por favor n&atilde;o responda.</span></p>
+			<p><span style='color: #555;'><b>Confidencialidade</b>: 
+				A informa&ccedil;&atilde;o contida nesta mensagem de e-mail, incluindo quaisquer anexos, &eacute; confidencial e esta 
+				reservada apenas &agrave; pessoa ou entidade para a qual foi endere&ccedil;ada. Se você n&atilde;o &eacute; o destinat&aacute;rio ou a 
+				pessoa respons&aacute;vel por encaminhar esta mensagem, você est&aacute;, por meio desta, notificado que n&atilde;o deverá
+				rever, retransmitir, imprimir, copiar, usar ou distribuir esta mensagem de e-mail ou quaisquer anexos. 
+				Caso você tenha recebido esta mensagem por engano, por favor, contate o remetente imediatamente e 
+				apague esta mensagem de seu computador ou de qualquer outro banco de dados. Muito obrigado.</span>
+			</p>
 		</div>
 	</body>
 </html> 

--- a/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
+++ b/siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
@@ -18,12 +18,15 @@
 		<div id="content" style="margin-top: 30px; padding: 20px;">
 			<div>
 				<p> 
-					Prezado usu&aacute;rio(a) <b>${nomeDestinatario}</b>. Vo&ecirc; recebeu o documento <b>(${siglaDoc})</b>, para visualiza&ccedil;&atilde;o.</b> 
+					Prezado usu&aacute;rio(a) <b>${nomeDestinatario}</b>. Voc&ecirc; recebeu o documento <b>(${siglaDoc})</b>, para visualiza&ccedil;&atilde;o.</b> 
 				</p>
 				<br />
 			</div>
 			<div style="margin-top: 20px;">
-				<p>C&oacute;digo de acesso ao documento: <b>${cod}</b></p>
+				<p><label for="cod">C&oacute;digo de acesso ao documento:</label></p>
+				<textarea id="cod"
+						  style="width: 200px; height: 170px;padding: 20px 20px;box-sizing: border-box;border: 2px solid #ccc;border-radius: 4px;background-color: #f8f8f8;font-size: 10px;resize: none;"
+						  disabled rows="8" cols="30">${cod}</textarea>
 				<p>Para visualizar o documento, <a href="${urlDoc}">clique aqui.</a></p>
 			</div>
 		</div>

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5256,22 +5256,10 @@ public class ExMovimentacaoController extends ExController {
 		final BuscaDocumentoBuilder documentoBuilder = BuscaDocumentoBuilder
 				.novaInstancia().setSigla(sigla);
 
-		final ExDocumento documento = buscarDocumento(documentoBuilder);
-		
-		final long tokenExp = 30 * 24 * 60 * 60L; //token expires in 30 days
-		String codAcessoDocumento = SigaUtil.buildJwtToken("1", 
-				SigaUtil.randomAlfanumerico(10), tokenExp, sigla);
-		
 		DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
 		Calendar c = Calendar.getInstance();
 
-		String servidor = Prop.get("/sigaex.url");
-		String n = documento.getSiglaAssinatura();
-		
-		String caminho = servidor + "/public/app/autenticar?n=" + n + "&cod=" + codAcessoDocumento;
 
-		result.include("url", caminho);
-		result.include("cod", codAcessoDocumento);
 		result.include("sigla", sigla);
 		result.include("dataHora", df.format(c.getTime()));
 
@@ -5281,9 +5269,7 @@ public class ExMovimentacaoController extends ExController {
 	@Post("/app/expediente/mov/enviar_para_visualizacao_externa_gravar")
 	public void enviarParaVisualizacaoExternaGravar(final String sigla,
 													final String nmPessoa,
-													final String email,
-													final String cod,
-													final String url) {
+													final String email) {
 
 		assertAcesso("");
 		
@@ -5291,6 +5277,15 @@ public class ExMovimentacaoController extends ExController {
 				.novaInstancia().setSigla(sigla);
 
 		final ExDocumento doc = buscarDocumento(documentoBuilder);
+		
+		final long tokenExp = 30 * 24 * 60 * 60L; //token expires in 30 days
+		String cod = SigaUtil.buildJwtToken("1",
+				SigaUtil.randomAlfanumerico(10), tokenExp, sigla);
+
+		String servidor = Prop.get("/sigaex.url");
+		String n = doc.getSiglaAssinatura();
+
+		String url = servidor + "/public/app/autenticar?n=" + n + "&cod=" + cod;
 		
 		final ExEmail exEmail = new ExEmail();
 		exEmail.enviarAoDestinatarioExterno(nmPessoa, email, sigla, cod, url);
@@ -5309,8 +5304,6 @@ public class ExMovimentacaoController extends ExController {
 
 			result.include("dest", dest);
 			result.include("descrMov", descrMov);
-			result.include("url", url);
-			result.include("cod", cod);
 			result.include("sigla", sigla);
 			
 			DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -26,6 +26,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import br.gov.jfrj.siga.cp.util.SigaUtil;
+import br.gov.jfrj.siga.ex.util.notificador.especifico.ExEmail;
+import br.gov.jfrj.siga.validation.Email;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.impl.dv.util.Base64;
@@ -5290,23 +5292,11 @@ public class ExMovimentacaoController extends ExController {
 
 		final ExDocumento doc = buscarDocumento(documentoBuilder);
 		
-		try {
-			Correio.enviar(email, "SP Sem Papel - Código para visualização do documento " + doc.getSigla(),
-					"Segue abaixo o código para visualização do documento " + doc.getSigla() +
-							"\nPara visualizá-lo basta clicar no  link abaixo: "
-							+ "\n" + "\nCÓDIGO: " + cod
-							+ "\n" + "\nLink para acesso: "
-							+ "\n" + url
-							+ "\n\nObservação: O código de acesso fornecido expirará em 30 (trinta) dias. "
-							+ "Caso seja necessário acessar o documento após esse prazo, solicite um novo código."
-							+ "\n\nAtenção: esta é uma mensagem automática. Por favor, não responda.");
-			
-		} catch (Exception e) {
-			result.include("mensagem", "Atenção: Falha no envio do e-mail, tente novamente!");	
-		}
-
+		final ExEmail exEmail = new ExEmail();
+		exEmail.enviarAoDestinatarioExterno(nmPessoa, email, sigla, cod, url);
 		result.include("mensagem", "E-mail enviado com sucesso.");
-
+		
+		/* Após o envio do email gravar a movimentação */
 		try {
 			final Date dtMov = ExDao.getInstance().dt();
 			final String dest = "Destinatário: " + nmPessoa + ". " + "e-mail: " + email;

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/enviarParaVisualizacaoExterna.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/enviarParaVisualizacaoExterna.jsp
@@ -89,16 +89,6 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">
-                        <p><label for="cod">C&oacute;digo de acesso ao documento:</label></p>
-                        <textarea id="cod"
-                                  style="width: 200px; height: 170px;padding: 20px 20px;box-sizing: border-box;border: 2px solid #ccc;border-radius: 4px;background-color: #f8f8f8;font-size: 10px;resize: none;"
-                                  disabled rows="8" cols="30">${cod}</textarea>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-sm-12">
-                    <div class="form-group text-center">
                         <label>Data/Hora: ${dataHora}</label>
                     </div>
                 </div>
@@ -107,8 +97,7 @@
                 <div class="col-sm-12">
                     <div class="form-group text-center">
                         <label><b>Aten&ccedil;&atilde;o: </b>Para encaminhar o documento para um usu&aacute;rio n&atilde;o
-                            cadastrado
-                            no sistema, preencha os seguintes campos </label>
+                            cadastrado no sistema, preencha os seguintes campos </label>
                         <br/>
                     </div>
                 </div>
@@ -116,8 +105,6 @@
             <form name="frm" action="${pageContext.request.contextPath}/app/expediente/mov/enviar_para_visualizacao_externa_gravar"
                   method="POST">
                 <input type="hidden" name="sigla" value="${sigla}" />
-                <input type="hidden" name="cod" value="${cod}" />
-                <input type="hidden" name="url" value="${url}" />
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="form-group">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/enviarParaVisualizacaoExterna.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/enviarParaVisualizacaoExterna.jsp
@@ -89,8 +89,10 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">
-                        <label>C&oacute;digo de acesso ao documento:</label>
-                        <a href="${url}" target="_blank" class="link-reduzido">${cod}</a>
+                        <p><label for="cod">C&oacute;digo de acesso ao documento:</label></p>
+                        <textarea id="cod"
+                                  style="width: 200px; height: 170px;padding: 20px 20px;box-sizing: border-box;border: 2px solid #ccc;border-radius: 4px;background-color: #f8f8f8;font-size: 10px;resize: none;"
+                                  disabled rows="8" cols="30">${cod}</textarea>
                     </div>
                 </div>
             </div>
@@ -101,8 +103,6 @@
                     </div>
                 </div>
             </div>
-            <br>
-            <br>
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/resultadoEnvioParaVisualizacaoExterna.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/resultadoEnvioParaVisualizacaoExterna.jsp
@@ -49,8 +49,6 @@
                     <div class="p-3 mb-2 bg-dark text-white text-center" id="bg"><h4><b>Código de Visualiza&ccedil;&atilde;o Externa do Documento</b></h4></div>
                 </div>
             </div>
-            <br>
-            <br>
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">
@@ -61,8 +59,10 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">
-                        <label>C&oacute;digo de acesso ao documento:</label>
-                        <a href="${url}" target="_blank" class="link-reduzido">${cod}</a>
+                        <p><label for="cod">C&oacute;digo de acesso ao documento:</label></p>
+                        <textarea id="cod"
+                                  style="width: 200px; height: 170px;padding: 20px 20px;box-sizing: border-box;border: 2px solid #ccc;border-radius: 4px;background-color: #f8f8f8;font-size: 10px;resize: none;"
+                                  disabled rows="8" cols="30">${cod}</textarea>
                     </div>
                 </div>
             </div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/resultadoEnvioParaVisualizacaoExterna.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/resultadoEnvioParaVisualizacaoExterna.jsp
@@ -59,16 +59,6 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="form-group text-center">
-                        <p><label for="cod">C&oacute;digo de acesso ao documento:</label></p>
-                        <textarea id="cod"
-                                  style="width: 200px; height: 170px;padding: 20px 20px;box-sizing: border-box;border: 2px solid #ccc;border-radius: 4px;background-color: #f8f8f8;font-size: 10px;resize: none;"
-                                  disabled rows="8" cols="30">${cod}</textarea>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-sm-12">
-                    <div class="form-group text-center">
                         <label>Data/Hora: ${dataHora}</label>
                     </div>
                 </div>


### PR DESCRIPTION
### Melhorias da funcionalidade para enviar um Documento para visualização externa

#### Resumo da implementação

1. Habilitação da funcionalidade "Enviar Para Visualização Externa" através do Tipo de Configuração Movimentar com "Envio para Visualização Externa"
2. Envio de email utilizando a classe ExMail com uso do template siga-ex/src/main/resources/templates/email/doc-enviado-para-usuario-externo.html
3. Melhoria do formato do código de acesso ao documento contido na tela de envio e email
4. Remoção do Código de acesso ao Documento
5. Adição de mensagem de confidencialidade no corpo do e-mail

#### Captura de telas

![image](https://user-images.githubusercontent.com/1022974/177198045-de9790e5-d0b3-4025-8ced-6175375651cc.png)

![image](https://user-images.githubusercontent.com/1022974/177402493-2c15e615-26d1-4ef0-ba76-6e634970c9ae.png)

![image](https://user-images.githubusercontent.com/1022974/177410798-a9f7d8ca-9faa-4b9d-b973-13338e703300.png)
