### PR TITLE
PCRJ-2764 API SIGA documentosGet - inclusao da propriedade limite dias na pesquisa

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -46,6 +46,14 @@ public class Prop {
 			return null;
 		return Integer.valueOf(p.trim());
 	}
+	
+	public static Long getLong(String nome) {
+		String p = Prop.get(nome);
+		if (p == null)
+			return null;
+		return Long.valueOf(p.trim());
+	}
+
 
 	public static Double getDouble(String nome) {
 		String p = Prop.get(nome);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosGet.java
@@ -33,9 +33,8 @@ import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.persistencia.ExMobilApiBuilder;
 
 public class DocumentosGet implements IDocumentosGet {
-	final private static String SIGA_DOC_PESQ_PESQDESCR = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;PESQDESCR:Pesquisar descrição";
 	final private static String SIGA_DOC_PESQ_DTLIMITADA = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;DTLIMITADA:Pesquisar somente com data limitada";
-	final static public Long MAXIMO_DIAS_PESQUISA = 30L;
+	final static public Long MAXIMO_DIAS_PESQUISA = Prop.getLong("/siga.pesquisa.limite.dias") != null ? Prop.getLong("/siga.pesquisa.limite.dias"):30L;
 	DpPessoa titular;
 	DpLotacao lotaTitular;
 	


### PR DESCRIPTION
Inclusão da propriedade **siga.pesquisa.limite.dias**  no serviço de  pesquisa de documentos.
![2764-api-limite-dias](https://user-images.githubusercontent.com/78379805/179056979-7aec4a68-5e61-4245-bde7-09e702d68c70.PNG)
