### PR TITLE
RM101007 - Correção - não gravar o modelos alterados na cp_arquivo_excluir - HCP

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpArquivo.java
@@ -173,7 +173,7 @@ public class CpArquivo implements Serializable, PersistentAttributeInterceptable
 		}
 	}
 
-	public static CpArquivo forUpdate(CpArquivo old) {
+	public static CpArquivo forUpdate(CpArquivo old, Boolean excluirArqAnterior) {
 		if (old != null) {
 			if (old.getIdArq() != null) {
 				CpArquivo arq = new CpArquivo();
@@ -182,8 +182,9 @@ public class CpArquivo implements Serializable, PersistentAttributeInterceptable
 				arq.setOrgaoUsuario(old.getOrgaoUsuario());
 
 				arq.setConteudo(old.getConteudo());
-
-				ContextoPersistencia.em().remove(old);
+				if (excluirArqAnterior) {
+					ContextoPersistencia.em().remove(old);
+				}
 				return arq;
 			} else
 				return old;
@@ -214,25 +215,25 @@ public class CpArquivo implements Serializable, PersistentAttributeInterceptable
 
 	public static CpArquivo updateOrgaoUsuario(CpArquivo old, CpOrgaoUsuario orgaoUsuario) {
 		if (old == null || old.getOrgaoUsuario() == null || !old.getOrgaoUsuario().equals(orgaoUsuario)) {
-			CpArquivo arq = CpArquivo.forUpdate(old);
+			CpArquivo arq = CpArquivo.forUpdate(old, Boolean.FALSE);
 			arq.setOrgaoUsuario(orgaoUsuario);
 			return arq;
 		}
 		return old;
 	}
 
-	public static CpArquivo updateConteudoTp(CpArquivo old, String conteudoTp) {
+	public static CpArquivo updateConteudoTp(CpArquivo old, String conteudoTp, Boolean excluirArqAnterior) {
 		if (old == null || !Texto.equals(old.getConteudoTpArq(), conteudoTp)) {
-			CpArquivo arq = CpArquivo.forUpdate(old);
+			CpArquivo arq = CpArquivo.forUpdate(old, excluirArqAnterior);
 			arq.setConteudoTpArq(conteudoTp);
 			return arq;
 		}
 		return old;
 	}
 
-	public static CpArquivo updateConteudo(CpArquivo old, byte[] conteudo) {
+	public static CpArquivo updateConteudo(CpArquivo old, byte[] conteudo, Boolean excluirArqAnterior) {
 		if (old == null || !Arrays.equals(old.getConteudo(), conteudo)) {
-			CpArquivo arq = CpArquivo.forUpdate(old);
+			CpArquivo arq = CpArquivo.forUpdate(old, excluirArqAnterior);
 			arq.setConteudo(conteudo);
 			arq.setTamanho(conteudo.length);
 			return arq;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -1114,7 +1114,7 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 	public void setConteudoTpDoc(final java.lang.String conteudoTp) {
 		this.conteudoTpDoc = conteudoTp;
 		if (orgaoPermiteHcp() && conteudoBlobDoc==null && !CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
-			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, this.conteudoTpDoc);
+			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, this.conteudoTpDoc, Boolean.TRUE);
 		}
 	}
 	
@@ -1139,7 +1139,7 @@ public abstract class AbstractExDocumento extends ExArquivo implements
 			conteudoBlobDoc = createBlob;
 		} else if(cacheConteudoBlobDoc != null){
 			if(orgaoPermiteHcp())
-				cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobDoc);
+				cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobDoc, Boolean.TRUE);
 			else
 				conteudoBlobDoc = createBlob;
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExModelo.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExModelo.java
@@ -423,7 +423,7 @@ public abstract class AbstractExModelo extends HistoricoAuditavelSuporte
 	public void setConteudoTpBlob(final java.lang.String conteudoTpMod) {
 		this.conteudoTpBlob = conteudoTpMod;
 		if (conteudoBlobMod==null && !CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
-			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, conteudoTpMod);
+			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, conteudoTpMod, Boolean.FALSE);
 	    }
 	}
 
@@ -447,7 +447,7 @@ public abstract class AbstractExModelo extends HistoricoAuditavelSuporte
 		if (this.cpArquivo==null && (this.conteudoBlobMod!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))) {
 			this.conteudoBlobMod = createBlob;
 		} else if(cacheConteudoBlobMod != null){
-			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMod);
+			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMod, Boolean.FALSE);
 		}
 	}
 	

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExMovimentacao.java
@@ -840,7 +840,7 @@ public abstract class AbstractExMovimentacao extends ExArquivo implements Serial
 	public void setConteudoTpMov(final String conteudoTp) {
 	    this.conteudoTpMov = conteudoTp;
 	    if (orgaoPermiteHcp() && this.conteudoBlobMov == null && !CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo")))) {
-	    	cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, conteudoTp);
+	    	cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, conteudoTp, Boolean.FALSE);
 	    }
 	}
 
@@ -865,7 +865,7 @@ public abstract class AbstractExMovimentacao extends ExArquivo implements Serial
 			this.conteudoBlobMov = createBlob;
 		} else if(cacheConteudoBlobMov != null){
 			if (orgaoPermiteHcp())
-				cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMov);
+				cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobMov, Boolean.FALSE);
 			else
 				this.conteudoBlobMov = createBlob;
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExPreenchimento.java
@@ -204,8 +204,8 @@ public abstract class AbstractExPreenchimento extends Objeto implements
 		if (this.cpArquivo==null && (this.preenchimentoBlob!=null || CpArquivoTipoArmazenamentoEnum.BLOB.equals(CpArquivoTipoArmazenamentoEnum.valueOf(Prop.get("/siga.armazenamento.arquivo.tipo"))))){
 			this.preenchimentoBlob = preenchimentoBlob;
 		} else if(cacheConteudoBlobPre != null){
-			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, TipoConteudo.X_WWW_FORM_URLENCODED.getMimeType());
-			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobPre);
+			cpArquivo = CpArquivo.updateConteudoTp(cpArquivo, TipoConteudo.X_WWW_FORM_URLENCODED.getMimeType(), Boolean.TRUE);
+			cpArquivo = CpArquivo.updateConteudo(cpArquivo, cacheConteudoBlobPre, Boolean.TRUE);
 		}
 	}
 	


### PR DESCRIPTION
Correção para  não gravar os modelos alterados na tabela cp_arquivo_excluir, pois a tabela de modelos possui histórico. 