### PR TITLE
RM126392 Refatoramento e correção da funcionalidade de Publicação no Portal da Transparência

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/AcaoVO.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/AcaoVO.java
@@ -35,6 +35,7 @@ public class AcaoVO {
 	private String nome;
 	private String descr;
 	private String nameSpace;
+	private String url;
 	private String acao;
 	boolean pode;
 	private String msgConfirmacao;
@@ -131,6 +132,13 @@ public class AcaoVO {
 		this.explicacao = explicacao;
 	}
 
+	public AcaoVO(String icone, String nome, String nameSpace, String url, String acao, boolean pode, String explicacao,
+				  String msgConfirmacao, TreeMap<String, String> params, String pre, String pos, String classe,
+				  String modal) {
+		this(icone, nome, nameSpace, acao, pode, explicacao, msgConfirmacao, params, pre, pos, classe, modal);
+		this.url = url;
+	}
+
 	public AcaoVO() {
 		// TODO Auto-generated constructor stub
 	}
@@ -148,6 +156,9 @@ public class AcaoVO {
 	}
 
 	public String getUrl() {
+		if(url != null && !url.isEmpty()){
+			return this.url;
+		}
 		String resultUrl = "";
 		if (this.params != null) {
 			String valueOfParameterToAdd;
@@ -200,6 +211,10 @@ public class AcaoVO {
 		this.nameSpace = nameSpace;
 	}
 
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
 	public void setAcao(String acao) {
 		this.acao = acao;
 	}
@@ -241,6 +256,7 @@ public class AcaoVO {
 		private String nome;
 		private String descr;
 		private String nameSpace;
+		private String url;
 		private String acao;
 		private boolean pode;
 		private String msgConfirmacao;
@@ -270,6 +286,11 @@ public class AcaoVO {
 		
 		public Builder nameSpace(String nameSpace) {
 			this.nameSpace = nameSpace;
+			return this;
+		}
+
+		public Builder url(String url) {
+			this.url = url;
 			return this;
 		}
 
@@ -343,6 +364,7 @@ public class AcaoVO {
 			acaoVO.setNome(nome);
 			acaoVO.setDescr(descr);
 			acaoVO.setNameSpace(nameSpace);
+			acaoVO.setUrl(url);
 			acaoVO.setAcao(acao);
 			acaoVO.setPode(pode);
 			acaoVO.setMsgConfirmacao(msgConfirmacao);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -7942,62 +7942,43 @@ public class ExBL extends CpBL {
 		
 	}
 
-	public CpToken publicarTransparencia(ExMobil mob, DpPessoa cadastrante, DpLotacao lotaCadastrante, String[] listaMarcadores, boolean viaWS) {
+	public String publicarTransparencia(ExMobil mob, DpPessoa cadastrante, DpLotacao lotaCadastrante, boolean viaWS) {
 
 		/* Verificação de autorização - Via WS é feito bypass*/
-		if (!viaWS && !Ex.getInstance().getComp().pode(ExPodePublicarPortalDaTransparencia.class, cadastrante, lotaCadastrante,mob)) {
+		if (!viaWS && !Ex.getInstance().getComp().pode(ExPodePublicarPortalDaTransparencia.class, cadastrante, lotaCadastrante, mob)) {
 			throw new AplicacaoException(
 					"Não é possível " + SigaMessages.getMessage("documento.publicar.portaltransparencia"));
 		}
-		
-		
-		/* 1- Redefinição para Público - Via WS é feito bypass*/	
-		if (!viaWS && !Ex.getInstance().getComp().pode(ExPodeRedefinirNivelDeAcesso.class, cadastrante, lotaCadastrante,mob)) {
+
+		/* 1- Redefinição para Público - Via WS é feito bypass*/
+		if (!viaWS && !Ex.getInstance().getComp().pode(ExPodeRedefinirNivelDeAcesso.class, cadastrante, lotaCadastrante, mob)) {
 			throw new AplicacaoException(
 					"Não é possível redefinir o nível de acesso");
 		}
+
 		ExNivelAcesso exTipoSig = null;
 		exTipoSig = dao().consultar(ExNivelAcesso.ID_PUBLICO, ExNivelAcesso.class, false);
-		
+
 		redefinirNivelAcesso(cadastrante, lotaCadastrante, mob.getDoc(), null, lotaCadastrante, cadastrante, cadastrante, cadastrante, null, exTipoSig);
 		/* END Redefinição para Público */
-		
-		
-		/* 2- Gravação dos Marcadores */
-		if (listaMarcadores != null) {
-			CpMarcador cpMarcador = new CpMarcador();
-			
-			for(String marcador: listaMarcadores) {
-			   cpMarcador = dao().consultar(Long.parseLong(marcador), CpMarcador.class, false);
-			   try {
-				marcar(cadastrante, lotaCadastrante, cadastrante, lotaCadastrante, mob, null, cadastrante, lotaCadastrante, null, cpMarcador, null, null, true);
-			   } catch (Exception e) {
-					throw new RuntimeException("Ocorreu um erro ao gravar marcadores", e);
-			   }
-			}
-		}
-		
-		/* END Gravação dos Marcadores  */
 
-		CpToken sigaUrlPermanente;
+		CpToken cpToken;
 		try {
 			/*3- Gerar URL Permanente */
-			sigaUrlPermanente = Cp.getInstance().getBL().gerarUrlPermanente(mob.getDoc().getIdDoc());
-			
-			/*4- Gerar Movimentação de Publicação */
-			final ExMovimentacao mov = criarNovaMovimentacao(
-					ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA, cadastrante, lotaCadastrante,
-					mob, null, cadastrante, null, cadastrante, null, null);
-			
-			mov.setDescrMov("Publicação em Portal da Transparência.");
+			cpToken = Cp.getInstance().getBL().gerarUrlPermanente(mob.getDoc().getIdDoc());
 
-			gravarMovimentacao(mov);
-			atualizarMarcas(mob.getDoc());
+			/*4- Gerar Movimentação de Publicação */
+			gravarNovaMovimentacao(ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA,
+					cadastrante, lotaCadastrante, mob, null,
+					null, null, null, null, null,
+					"Publicação em Portal da Transparência do documento " + mob.getSigla());
+
 		} catch (Exception e) {
 			throw new RuntimeException("Ocorreu um erro na publicação do documento em Portal da Transparência", e);
 		}
 		
-		return sigaUrlPermanente;
+		String url = Cp.getInstance().getBL().obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
+		return url;
 		
 	}
 	

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -7992,21 +7992,21 @@ public class ExBL extends CpBL {
 		/* END Redefinição para Público */
 
 		CpToken cpToken;
+		String url;
 		try {
 			/*3- Gerar URL Permanente */
 			cpToken = Cp.getInstance().getBL().gerarUrlPermanente(mob.getDoc().getIdDoc());
-
+			url = Cp.getInstance().getBL().obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
+			
 			/*4- Gerar Movimentação de Publicação */
 			gravarNovaMovimentacao(ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA,
-					cadastrante, lotaCadastrante, mob, null,
-					null, null, null, null, null,
-					"Publicação em Portal da Transparência do documento " + mob.getSigla());
+					cadastrante, lotaCadastrante, mob, null,null, null, 
+					null, null, null, "Publicado no Portal da Transparência");
 
 		} catch (Exception e) {
 			throw new RuntimeException("Ocorreu um erro na publicação do documento em Portal da Transparência", e);
 		}
 		
-		String url = Cp.getInstance().getBL().obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
 		return url;
 		
 	}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -750,8 +750,10 @@ public class ExDocumentoVO extends ExVO {
 		vo.addAcao(AcaoVO.builder().nome("Vi_ncular").icone("page_find").nameSpace("/app/expediente/mov").acao("referenciar")
 				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodeReferenciar(mob, titular, lotaTitular)).build());
 
-		vo.addAcao(AcaoVO.builder().nome(SigaMessages.getMessage("documento.publicar.portaltransparencia")).icone("report_link").nameSpace("/app/expediente/mov").acao("publicacao_transparencia")
-				.params("sigla", mob.getCodigoCompacto()).exp(new ExPodePublicarPortalDaTransparencia(mob, titular, lotaTitular)).classe("once").build());
+		vo.addAcao(AcaoVO.builder().nome(SigaMessages.getMessage("documento.publicar.portaltransparencia"))
+				.icone("report_link").nameSpace("/app/expediente/mov").acao("publicacao_transparencia")
+				.params("sigla", mob.getCodigoCompacto())
+				.exp(new ExPodePublicarPortalDaTransparencia(mob, titular, lotaTitular)).classe("once").build());
 		
 		vo.addAcao(AcaoVO.builder().nome("Gerar Protocolo").icone("printer").nameSpace("/app/expediente/doc").acao("gerarProtocolo")
 				.params("sigla", mob.getCodigoCompacto()).params("popup", "true").exp(And.of(new CpPodeBoolean(mostrarGerarProtocolo(doc), "pode mostrar protocolo"), new ExPodeGerarProtocolo(doc, titular, lotaTitular))).classe("once").build());

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -547,7 +547,9 @@ public class ExMovimentacaoVO extends ExVO {
 					.build());
 		}
 
-		if (exTipoMovimentacao == ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA) {
+		if (exTipoMovimentacao == ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA ||
+				exTipoMovimentacao == ExTipoDeMovimentacao.GERAR_LINK_PUBLICO_PROCESSO) {
+			
 			CpToken cpToken = CpDao.getInstance()
 					.obterCpTokenPorTipoIdRef(CpToken.TOKEN_URLPERMANENTE, mov.getExDocumento().getIdDoc());
 			String url = Cp.getInstance().getBL()

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import br.gov.jfrj.siga.cp.CpToken;
+import br.gov.jfrj.siga.cp.bl.Cp;
+import br.gov.jfrj.siga.dp.dao.CpDao;
 import br.gov.jfrj.siga.ex.logic.*;
 import org.apache.commons.lang3.StringUtils;
 
@@ -542,6 +545,18 @@ public class ExMovimentacaoVO extends ExVO {
 					.exp(new ExPodeEnviarParaVisualizacaoExterna(mov.mob(), titular, lotaTitular))
 					.msgConfirmacao("Confirma a revogação da visualização externa?")
 					.build());
+		}
+
+		if (exTipoMovimentacao == ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA) {
+			CpToken cpToken = Cp.getInstance().getBL().gerarUrlPermanente(mov.getIdDoc());
+			String url = Cp.getInstance().getBL().obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
+			
+			AcaoVO acaoVO = AcaoVO.builder().nome(mov.getExMobil().getSigla())
+					.url(url)
+					.exp(new CpPodeSempre())
+					.build();
+			
+			addAcao(acaoVO);
 		}
 		
 		if (descricao != null && descricao.equals(mov.getObs())) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -548,8 +548,10 @@ public class ExMovimentacaoVO extends ExVO {
 		}
 
 		if (exTipoMovimentacao == ExTipoDeMovimentacao.PUBLICACAO_PORTAL_TRANSPARENCIA) {
-			CpToken cpToken = Cp.getInstance().getBL().gerarUrlPermanente(mov.getIdDoc());
-			String url = Cp.getInstance().getBL().obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
+			CpToken cpToken = CpDao.getInstance()
+					.obterCpTokenPorTipoIdRef(CpToken.TOKEN_URLPERMANENTE, mov.getExDocumento().getIdDoc());
+			String url = Cp.getInstance().getBL()
+					.obterURLPermanente(cpToken.getIdTpToken().toString(), cpToken.getToken());
 			
 			AcaoVO acaoVO = AcaoVO.builder().nome(mov.getExMobil().getSigla())
 					.url(url)

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGerarLinkPublicoPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGerarLinkPublicoPost.java
@@ -60,7 +60,7 @@ public class DocumentosSiglaGerarLinkPublicoPost implements IExApiV1.IDocumentos
         /* Grava movimentação com tipo Gerar Link Publico */
         Ex.getInstance().getBL().gravarNovaMovimentacao(ExTipoDeMovimentacao.GERAR_LINK_PUBLICO_PROCESSO,
                 cadastrante, lotaCadastrante, mob, dtMov, null, null,
-                null, null, null, "Gerado link público do documento " + mob.getSigla());
+                null, null, null, "Gerado link público");
 
         resp.link = link;
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/service/impl/ExServiceImpl.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/service/impl/ExServiceImpl.java
@@ -1123,15 +1123,11 @@ public class ExServiceImpl implements ExService {
 						listaMarcadores = marcadoresStr.split(",");
 					}
 
-					CpToken sigaUrlPermanente = new CpToken();
-					sigaUrlPermanente = Ex.getInstance().getBL().publicarTransparencia(mob, cadastrante,
-							cadastrante.getLotacao(), listaMarcadores, true);
-					String url = System.getProperty("siga.ex.enderecoAutenticidadeDocs")
-							.replace("/sigaex/public/app/autenticar", "");
-					String caminho = url + "/siga/public/app/sigalink/1/" + sigaUrlPermanente.getToken();
+					String url = Ex.getInstance().getBL()
+							.publicarTransparencia(mob, cadastrante, cadastrante.getLotacao(), false);
 
 					return "Documento " + siglaDocumento
-							+ " enviado para publicação. Gerado para acesso externo ao documento: " + caminho;
+							+ " enviado para publicação. Gerado para acesso externo ao documento: " + url;
 				}
 			} catch (Exception ex) {
 				ctx.rollback(ex);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5094,17 +5094,15 @@ public class ExMovimentacaoController extends ExController {
 		String[] listaMarcadores = request.getParameterValues("lstMarcadores");
 
 		/* Gravação dos Marcadores */
-		if (listaMarcadores != null) {
-			for (String marcador : listaMarcadores) {
-				CpMarcador cpMarcador = dao().consultar(Long.parseLong(marcador), CpMarcador.class, false);
-				try {
-					Ex.getInstance().getBL()
-							.marcar(getCadastrante(), getLotaCadastrante(), getTitular(), getLotaTitular(),
-									doc.getPrimeiroMobil(),null, getCadastrante(), getLotaCadastrante(), 
-									null, cpMarcador, null, null, true);
-				} catch (Exception e) {
-					throw new RuntimeException("Ocorreu um erro ao gravar marcadores", e);
-				}
+		for (String marcador : listaMarcadores) {
+			CpMarcador cpMarcador = dao().consultar(Long.parseLong(marcador), CpMarcador.class, false);
+			try {
+				Ex.getInstance().getBL()
+						.marcar(getCadastrante(), getLotaCadastrante(), getTitular(), getLotaTitular(),
+								doc.getPrimeiroMobil(), null, getCadastrante(), getLotaCadastrante(),
+								null, cpMarcador, null, null, true);
+			} catch (Exception e) {
+				throw new RuntimeException("Ocorreu um erro ao gravar marcadores", e);
 			}
 		}
 		/* END Gravação dos Marcadores  */

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
@@ -144,8 +144,12 @@
 										<siga:links inline="${true}"
 											separator="${not empty mov.descricao and mov.descricao != null}">
 											<c:forEach var="acao" items="${mov.acoes}">
+												<c:set var="acaourl" value="${pageContext.request.contextPath}${acao.url}"/>
+												<c:if test="${mov.exTipoMovimentacao == 'PUBLICACAO_PORTAL_TRANSPARENCIA'}">
+													<c:set var="acaourl" value="${acao.url}"/>
+												</c:if>
 												<siga:link title="${acao.nomeNbsp}" pre="${acao.pre}" pos="${acao.pos}" 
-													url="${pageContext.request.contextPath}${acao.url}" test="${acao.pode}" popup="${acao.popup}" 
+													url="${acaourl}" test="${acao.pode}" popup="${acao.popup}" 
 													confirm="${acao.msgConfirmacao}" ajax="${acao.ajax}" 
 													idAjax="${mov.idMov}" classe="${acao.classe}" post="${acao.post}"/>
 												<c:if test="${assinadopor and mov.exTipoMovimentacao == 'ANEXACAO'}">

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/aExibirHistorico.jsp
@@ -145,7 +145,8 @@
 											separator="${not empty mov.descricao and mov.descricao != null}">
 											<c:forEach var="acao" items="${mov.acoes}">
 												<c:set var="acaourl" value="${pageContext.request.contextPath}${acao.url}"/>
-												<c:if test="${mov.exTipoMovimentacao == 'PUBLICACAO_PORTAL_TRANSPARENCIA'}">
+												<c:if test="${mov.exTipoMovimentacao == 'PUBLICACAO_PORTAL_TRANSPARENCIA' 
+													|| mov.exTipoMovimentacao == 'GERAR_LINK_PUBLICO_PROCESSO'}">
 													<c:set var="acaourl" value="${acao.url}"/>
 												</c:if>
 												<siga:link title="${acao.nomeNbsp}" pre="${acao.pre}" pos="${acao.pos}" 


### PR DESCRIPTION
### Refatoramento e correção da funcionalidade de Publicação no Portal da Transparência

Atualmente a funcionalidade de Publicação no Portal da Transparência está desatulizada e incompatível com algumas evoluções do sistema. Principalmente na lógica dos Marcadores, ocasionando inclusive, erro no momento da seleção dos marcadores antes do envio para publicação.
`java.lang.RuntimeException: Ocorreu um erro ao gravar marcadores
at br.gov.jfrj.siga.ex.bl.ExBL.publicarTransparencia(ExBL.java:7973)
...
br.gov.jfrj.siga.vraptor.SigaTransacionalInterceptor.intercept(SigaTransacionalInterceptor.java:83)
Caused by: br.gov.jfrj.siga.base.AplicacaoException: Não é possível marcar porque está finalizado e é móbil geral
...`

#### Resumo da implementação

1. FIX: Erro ao publicar com marcação do móbil geral
2. Lógica dos marcadores separada para diminuir as responsabilidades do método publicarTransparencia
3. Simplificação do método aPublicarTransparencia
4. Adição de botão com link público no histórico de movimentações contendo a url do SigaLink para os tipos de movimentação PUBLICACAO_PORTAL_TRANSPARENCIA e GERAR_LINK_PUBLICO_PROCESSO

#### Captura de telas

![image](https://user-images.githubusercontent.com/1022974/181833412-997cab34-f0b3-438d-8469-64770f09f5bb.png)

![image](https://user-images.githubusercontent.com/1022974/181833538-50bf9bde-8696-43cc-89c5-ce94c107f96c.png)
