### PR TITLE
RM131384 Config Pesquisa Genérica via X-JUS

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpTipoDeConfiguracao.java
@@ -110,8 +110,18 @@ public enum CpTipoDeConfiguracao implements ITipoDeConfiguracao {
 					CpSituacaoDeConfiguracaoEnum.NAO_PODE },
 			CpSituacaoDeConfiguracaoEnum.PODE, true), 
 
-	UTILIZAR_PESQUISA_XJUS(212, "Utilizar X-JUS na Pesquisa Avançada",
+	UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS(212, "Utilizar X-JUS na Pesquisa Avançada",
 			"Utilizada para ativar pesquisa avançada via X-JUS.\n"
+					+ "PODE: Ativa.\n"
+					+ "NÃO PODE: Não ativa.",
+			new CpParamCfg[] { CpParamCfg.ORGAO, CpParamCfg.PESSOA, CpParamCfg.LOTACAO },
+			new CpParamCfg[] { CpParamCfg.SITUACAO },
+			new CpSituacaoDeConfiguracaoEnum[] { CpSituacaoDeConfiguracaoEnum.PODE,
+					CpSituacaoDeConfiguracaoEnum.NAO_PODE },
+			CpSituacaoDeConfiguracaoEnum.NAO_PODE, true),
+
+	UTILIZAR_PESQUISA_GENERICA_VIA_XJUS(213, "Utilizar X-JUS na Pesquisa Genérica",
+			"Utilizada para ativar pesquisa genérica via X-JUS.\n"
 					+ "PODE: Ativa.\n"
 					+ "NÃO PODE: Não ativa.",
 			new CpParamCfg[] { CpParamCfg.ORGAO, CpParamCfg.PESSOA, CpParamCfg.LOTACAO },

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
@@ -12,6 +12,8 @@ import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import br.gov.jfrj.siga.cp.logic.CpPodePorConfiguracao;
+import br.gov.jfrj.siga.cp.model.enm.CpTipoDeConfiguracao;
 import com.mashape.unirest.http.Unirest;
 
 import br.com.caelum.vraptor.Consumes;
@@ -126,7 +128,7 @@ public class PrincipalController extends SigaController {
 			final GenericoSelecao sel = buscarGenericoPorSigla(sigla, pes, lot, incluirMatricula);
 
 			if (sel.getId() == null) {
-				if (Prop.getBool("/xjus.url") != null) {
+				if (podeUtilizarPesquisaGenericaViaXjus()) {
 					sel.setId(-1L);
 					sel.setSigla(sigla);
 					sel.setDescricao("/siga/app/xjus#!?filter=" + sigla);
@@ -275,6 +277,12 @@ public class PrincipalController extends SigaController {
 		response.addHeader("Access-Control-Allow-Origin", "*");
 		response.addHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PUT,OPTIONS");
 		response.addHeader("Access-Control-Allow-Headers", "Content-Type,Authorization");
+	}
+
+	private boolean podeUtilizarPesquisaGenericaViaXjus() throws Exception {
+		return new CpPodePorConfiguracao(getCadastrante(), getLotaCadastrante())
+				.withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_GENERICA_VIA_XJUS)
+				.eval();
 	}
 
 }

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/PrincipalController.java
@@ -128,7 +128,7 @@ public class PrincipalController extends SigaController {
 			final GenericoSelecao sel = buscarGenericoPorSigla(sigla, pes, lot, incluirMatricula);
 
 			if (sel.getId() == null) {
-				if (podeUtilizarPesquisaGenericaViaXjus()) {
+				if (podeUtilizarPesquisaGenericaViaXjus(pes, lot)) {
 					sel.setId(-1L);
 					sel.setSigla(sigla);
 					sel.setDescricao("/siga/app/xjus#!?filter=" + sigla);
@@ -279,10 +279,11 @@ public class PrincipalController extends SigaController {
 		response.addHeader("Access-Control-Allow-Headers", "Content-Type,Authorization");
 	}
 
-	private boolean podeUtilizarPesquisaGenericaViaXjus() throws Exception {
-		return new CpPodePorConfiguracao(getCadastrante(), getLotaCadastrante())
+	private boolean podeUtilizarPesquisaGenericaViaXjus(DpPessoa pessoa, DpLotacao lotacao) throws Exception {
+		return (Prop.getBool("/xjus.url") != null && new CpPodePorConfiguracao(pessoa, lotacao)
 				.withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_GENERICA_VIA_XJUS)
-				.eval();
+				.withOrgaoObjeto(lotacao.getLotacaoAtual().getOrgaoUsuario())
+				.eval());
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -602,7 +602,10 @@ public class ExMobilController extends
 	}
 
 	private void pesquisarXjus(ExMobilDaoFiltro flt) {
-		if (!(new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS).eval())) {
+		if (!( new ExPodePorConfiguracao(getTitular(), getLotaTitular())
+				.withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS)
+				.eval() )
+		) {
 			flt.setDescrPesquisaXjus(null);
 			return;
 		}
@@ -1055,12 +1058,6 @@ public class ExMobilController extends
 		result.include("lista", docs);
 		List<ExNivelAcesso> listaNivelAcesso = ExDao.getInstance().listarOrdemNivel();
 		result.include("listaNivelAcesso", listaNivelAcesso);
-	}
-
-	private boolean podeUtilizarPesquisaAvancadaViaXjus() throws Exception {
-		return Cp.getInstance().getConf().podePorConfiguracao(
-				getCadastrante(), getCadastrante().getLotacao(),
-				CpTipoDeConfiguracao.UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS);
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -48,6 +48,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletRequest;
 
+import br.gov.jfrj.siga.cp.logic.CpPodePorConfiguracao;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -601,7 +602,7 @@ public class ExMobilController extends
 	}
 
 	private void pesquisarXjus(ExMobilDaoFiltro flt) {
-		if (!(new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_XJUS).eval())) {
+		if (!(new ExPodePorConfiguracao(getTitular(), getLotaTitular()).withIdTpConf(CpTipoDeConfiguracao.UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS).eval())) {
 			flt.setDescrPesquisaXjus(null);
 			return;
 		}
@@ -1054,6 +1055,12 @@ public class ExMobilController extends
 		result.include("lista", docs);
 		List<ExNivelAcesso> listaNivelAcesso = ExDao.getInstance().listarOrdemNivel();
 		result.include("listaNivelAcesso", listaNivelAcesso);
+	}
+
+	private boolean podeUtilizarPesquisaAvancadaViaXjus() throws Exception {
+		return Cp.getInstance().getConf().podePorConfiguracao(
+				getCadastrante(), getCadastrante().getLotacao(),
+				CpTipoDeConfiguracao.UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS);
 	}
 
 }


### PR DESCRIPTION
### Configuração para habilitar ou desabilitar a pesquisa genérica via X-JUS

Desenvolvimento de configuração para habilitar ou desabilitar a pesquisa genérica via X-JUS. 
Essa pesquisa é realizada através da caixa de pesquisa contida no cabeçalho da página do Siga.

![image](https://user-images.githubusercontent.com/1022974/186490447-57d1a01a-3fcd-42f4-8ad5-6d5b711a1d35.png)

Atualmente o sistema define se vai ou não utilizar o X-JUS nesse campo através da property `xjus.url`


#### Resumo da implementação

1. Adição da UTILIZAR_PESQUISA_GENERICA_VIA_XJUS na CpTipoDeConfiguracao (Situação default: Não Pode)
2. Renomeação da configuração UTILIZAR_PESQUISA_AVANCADA_VIA_XJUS na CpTipoDeConfiguracao (Situação default: Não Pode)
3. Adição do método podeUtilizarPesquisaGenericaViaXjus no PrincipalController para verificar se a configuração de pesquisa genérica via X-JUS está habilitada

#### Conclusão

Após a implementação da configuração, foi possível habilitar e desabilitar a pesquisa genérica através do X-JUS