### PR TITLE
Tratamento para os caracteres como travessão, euro... nos campos de entrevista

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -56,6 +56,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.jboss.logging.Logger;
 
 import br.com.caelum.vraptor.Controller;
@@ -2685,10 +2686,8 @@ public class ExDocumentoController extends ExController {
 								parametro = parametro.replaceAll(m, "");
 						}
 						if (!FuncoesEL.contemTagHTML(parametro)) {
-							if (parametro.contains("\"")) {
-								parametro = parametro.replace("\"", "&quot;");
-								setParam(s, parametro);
-							}
+							parametro = StringEscapeUtils.escapeHtml4(parametro);
+							setParam(s, parametro);
 						}
 
 						baos.write(URLEncoder.encode(parametro, "iso-8859-1")


### PR DESCRIPTION
Ao utilizar travessão, euro.... nos campos de entrevista esses caracteres estão sendo convertidos para ponto de interrogação

![image](https://user-images.githubusercontent.com/34543208/187462593-4298470c-5b98-4514-8788-14972ed93ec4.png)
![image](https://user-images.githubusercontent.com/34543208/187462782-9098028a-560f-4f63-a721-9d85952408e7.png)
