### PR TITLE
RM131410 - Violação do Hash do Documento usando Assinatura em Lote e Assijus Externo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -1692,11 +1692,6 @@ public class ExBL extends CpBL {
 	
 				mov.setDescrMov(assinante.getNomePessoa() + ":" + assinante.getSigla() + " [Digital]");
 				
-				if (doc.getDtPrimeiraAssinatura() == null) {
-					doc.setDtPrimeiraAssinatura(CpDao.getInstance().dt());  
-					Ex.getInstance().getBL().gravar(cadastrante, titular, mov.getLotaTitular(), doc);
-				}
-				
 				notificar = new ExNotificar();
 				notificar.cossignatario(doc, cadastrante);
 				
@@ -1954,7 +1949,10 @@ public class ExBL extends CpBL {
 			final ExMovimentacao mov;
 			try {
 				iniciarAlteracao();
-	
+				
+				//Atualiza data da primeira assinatura antes de prosseguir com o Hash de Auditoria
+				atualizaDataPrimeiraAssinatura(doc,cadastrante,titular);
+				
 				// Hash de auditoria
 				//
 				final byte[] pdf = doc.getConteudoBlobPdf();
@@ -1967,11 +1965,6 @@ public class ExBL extends CpBL {
 				mov.setDescrMov(assinante.getNomePessoa() + ":" + assinante.getSigla() + " ["+formaAssinaturaSenha+"]");
 				String cpf = Long.toString(assinante.getCpfPessoa());
 				acrescentarHashDeAuditoria(mov, sha256, autenticando, assinante.getNomePessoa(), cpf, null);
-	
-				if (doc.getDtPrimeiraAssinatura() == null) {
-					doc.setDtPrimeiraAssinatura(CpDao.getInstance().dt());  
-					Ex.getInstance().getBL().gravar(cadastrante, titular, mov.getLotaTitular(), doc);
-				}
 				
 				notificar = new ExNotificar();
 				notificar.cossignatario(doc, cadastrante);
@@ -8622,6 +8615,31 @@ public class ExBL extends CpBL {
 		} catch (final Exception e) {
 			throw new AplicacaoException("Erro ao enviar para visualização externa",
 					ExTipoDeMovimentacao.ENVIO_PARA_VISUALIZACAO_EXTERNA.getId(), e);
+		}
+	}
+	
+	/*
+	 * 
+	 * Caso não tenha registro de Assinatura, processa a data da primeira assinatura com re-processamento do documento
+	   antes de tirar o Hash do documento para Assinatura Digital do Hash
+	 * 
+	 * Data será atualizada caso não tenha registros de assinatura e caso ja haja data, se forem iguais não atualiza para evitar
+	 * processamentos adicionais
+	 * 
+	 * */
+
+	public void atualizaDataPrimeiraAssinatura(ExDocumento doc, DpPessoa cadastrante, DpPessoa titular) throws Exception {
+		
+		Date dataPrimeiraAssinatura = doc.getDtPrimeiraAssinatura();
+		if (dataPrimeiraAssinatura == null || doc. getAssinaturasDigitais().isEmpty()) {
+			
+			SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+			Date dataAtualSemTempo = sdf.parse(sdf.format(CpDao.getInstance().dt()));
+			
+			if (! dataAtualSemTempo.equals(dataPrimeiraAssinatura)) {
+				doc.setDtPrimeiraAssinatura(dataAtualSemTempo);  
+				gravar(cadastrante, titular, titular.getLotacao(), doc);
+			}
 		}
 	}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAssinadorExternoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAssinadorExternoController.java
@@ -52,6 +52,7 @@ import br.gov.jfrj.siga.bluc.service.BlucService;
 import br.gov.jfrj.siga.cp.model.enm.ITipoDeMovimentacao;
 import br.gov.jfrj.siga.dp.DpLotacao;
 import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.dp.dao.CpDao;
 import br.gov.jfrj.siga.ex.ExDocumento;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
@@ -232,7 +233,11 @@ public class ExAssinadorExternoController extends ExController {
 			
 			if (mov == null && !doc.isFinalizado()) {
 				DpPessoa cadastrante = obterCadastrante(null, mob, mov);
+				doc.setDtPrimeiraAssinatura(CpDao.getInstance().dt()); 
 				Ex.getInstance().getBL().finalizar(cadastrante, cadastrante.getLotacao(), doc);
+			} else {
+				DpPessoa cadastrante = obterCadastrante(null, mob, mov);
+				Ex.getInstance().getBL().atualizaDataPrimeiraAssinatura(doc,cadastrante,cadastrante);
 			}
 			
 			PdfData pdfd = getPdf(id);
@@ -247,12 +252,21 @@ public class ExAssinadorExternoController extends ExController {
 			jsonError(e);
 		}
 	}
-
+	
+	@Transacional
 	@Get("/public/app/assinador-externo/doc/{id}/hash")
 	public void assinadorExternoHash(String id) throws Exception {
 		try {
 			assertPassword();
 			JSONObject req = getJsonReq(request);
+			
+			String sigla = id2sigla(id) + ".pdf";
+			ExMobil mob = Documento.getMobil(sigla);
+			ExMovimentacao mov = Documento.getMov(mob, sigla);
+			ExDocumento doc = mob.getDoc();	
+			
+			DpPessoa cadastrante = obterCadastrante(null, mob, mov);
+			Ex.getInstance().getBL().atualizaDataPrimeiraAssinatura(doc,cadastrante,cadastrante);
 
 			PdfData pdfd = getPdf(id);
 


### PR DESCRIPTION
Processamento da Data de Primeira Assinatura no Assinar em Lote por Certificado e Por Senha estava ocorrendo após a coleta e assinatura do Hash dos Documentos, fazendo que o artefato de assinatura (p7s para Certificado e JWT para Senha) tivessem um hash diferente do final armazenado.

PR de Referência: https://github.com/projeto-siga/siga/pull/2040

O Fluxo estava da seguinte forma:

Com Certificado:
Hash do Documento -> Assinatura -> Validação da Assinatura = > Armazenamento da Assinatura -> Atualização da Data da Primeira Assinatura -> Gravação Documento Reprocessado

Com Senha:
Gravação da Movimentação de Assinatura -> Geração e Armazenamento do Hash de Auditoria Documento -> Atualização da Data da Primeira Assinatura -> Gravação Documento Reprocessado


Para garantir que o documento não seja violado por essa atualização após a assinatura, foi alterado o fluxo para:

Com Certificado:
Atualização da Data da Primeira Assinatura -> Gravação Documento Reprocessado -> Hash do Documento -> Assinatura -> Validação da Assinatura -> Armazenamento da Assinatura -> 

Com Senha:
Gravação da Movimentação de Assinatura -> Atualização da Data da Primeira Assinatura -> Gravação Documento Reprocessado
-> Geração e Armazenamento do Hash de Auditoria Documento 


Foi levado ao controller do ExAssinadorExterno, tanto popup, quanto externo (que não tinha divergindo o comportamento quando era assinado direto pelo assijus) a função de fazer esse processamento.

*Observação: Trigger do Oracle EX_DOCUMENTO_BLOCK não tem mais efeito para barrar esse tipo de violação. uma vez que o armazenamento foi para a TABELA CpArquivoBlob ou HCP. Deveria ter um controle de assinatura x hash do documento armazenados no banco para barrar violações desse tipo