### PR TITLE
RM129347 Ordenação da pesquisa na exportação para CSV

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -770,11 +770,15 @@ public class ExDao extends CpDao {
 				queryExportacao = em().createNativeQuery("select doc.*, mob.*, label.* from corporativo.cp_marca label "
 						+ " inner join siga.ex_mobil mob on mob.id_mobil = label.id_ref "
 						+ " inner join siga.ex_documento doc on doc.id_doc =  mob.id_doc "
-						+ " where label.id_marca in ( "+ montadorQuery.montaQueryConsultaporFiltro(flt, false) + " )","ExportacaoCsvResults");				
+						+ " where label.id_marca in ( "
+						+ montadorQuery.montaQueryConsultaporFiltro(flt, false) + " )"
+						+ " order by doc.dtDoc desc, doc.idDoc desc", "ExportacaoCsvResults");				
 			} else {
 				queryExportacao = em().createQuery("select doc, mob, label from ExMarca label"
 						+ " inner join label.exMobil mob inner join mob.exDocumento doc"
-						+ " where label.idMarca in ("+montadorQuery.montaQueryConsultaporFiltro(flt, false)+")");
+						+ " where label.idMarca in ("
+						+ montadorQuery.montaQueryConsultaporFiltro(flt, false) + ")"
+						+ " order by doc.dtDoc desc, doc.idDoc desc");
 				
 			}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -379,24 +379,18 @@ public class ExMobilController extends
 					builder.getOffset(), -1, getTitular(),
 					getLotaTitular());
 			
-			Set<?> items = new HashSet<>(lista); 
 			
-			InputStream inputStream = null;
 			StringBuffer texto = new StringBuffer();
 			texto.append(";Responsável pela Assinatura;;;Responsável pela situação atual" + System.lineSeparator());
 			texto.append("Número;Unidade;Usuário;Data;Unidade;Usuário;Data;Situação;Documento;Descrição" + System.lineSeparator());
 			
 			
-			ExDocumento e = new ExDocumento();
-			ExMobil m = new ExMobil();
-			ExMarca ma = new ExMarca();
-			String descricao = "";
-			String marcadorFormatado = "";
-			
-			for (Object object : items) {
-				e = (ExDocumento)(((Object[])object)[0]);
-				m = (ExMobil)(((Object[])object)[1]);
-				ma = (ExMarca)(((Object[])object)[2]);
+			for (Object object : lista) {
+				ExDocumento e = (ExDocumento)(((Object[])object)[0]);
+				ExMobil m = (ExMobil)(((Object[])object)[1]);
+				ExMarca ma = (ExMarca)(((Object[])object)[2]);
+				String descricao;
+				String marcadorFormatado;
 	
 				texto.append(m.getDnmSigla()+";");
 				if(e.getLotaSubscritor() != null && e.getLotaSubscritor().getSigla() != null) {
@@ -458,7 +452,7 @@ public class ExMobilController extends
 				texto.append(";");
 				texto.append(System.lineSeparator());
 			}
-			inputStream = new ByteArrayInputStream(texto.toString().getBytes("ISO-8859-1"));
+			InputStream inputStream = new ByteArrayInputStream(texto.toString().getBytes("ISO-8859-1"));
 			
 			return new InputStreamDownload(inputStream, "text/csv", "documentos.csv");	
 


### PR DESCRIPTION
### Ordenação da pesquisa na exportação para CSV

Melhoria da funcionalidade de exportação para CSV dos resultados da pesquisa da Tela de Pesquisa Avançada.
Atualmente os resultados exportados estão com uma ordenação diferente do apresentado em tela.

#### Resumo da implementação

1. Adição do ORDER BY na query de exportação contida no método consultarPorFiltroOtimizado da classe ExDao


#### Captura de Telas

![TestePesquisa03-DescricaoTesteCSVExportado-01](https://user-images.githubusercontent.com/1022974/187911123-fd6fa620-0175-4acf-815b-39bd4c1806e3.PNG)


