### PR TITLE
RM132834 Funcionalidade para disponibilizar endpoint para verificar assinatura

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
@@ -31,11 +31,12 @@ public class DocumentosIdVerificarAssinaturaGet implements IExApiV1.IDocumentosI
 
         Set<ExMovimentacao> movs = mob.getMovsNaoCanceladas(exTipoDeAssinatura);
         
-        resp.id = req.id;
+        resp.idDoc = req.id;
         
         try {
             for (ExMovimentacao mov : movs) {
-                if (mov.assertAssinaturaValida() != null) {
+                if (mov.assertAssinaturaValida() != null && mov.assertAssinaturaValida().contains("OK")) {
+                    resp.idMov = mov.getIdMov().toString();
                     resp.status = "Ok";
                     return;
                 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
@@ -1,0 +1,54 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import br.gov.jfrj.siga.base.AplicacaoException;
+import br.gov.jfrj.siga.context.AcessoPublico;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
+
+import java.util.Set;
+
+@AcessoPublico
+public class DocumentosIdVerificarAssinaturaGet implements IExApiV1.IDocumentosIdVerificarAssinaturaGet {
+
+    @Override
+    public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
+        final ExMobilDaoFiltro filter = new ExMobilDaoFiltro();
+
+        if(req.id != null &&! req.id.isEmpty())
+            filter.setIdDoc(Long.valueOf(req.id));
+
+        ExMobil mob = ExDao.getInstance().consultarPorSigla(filter);
+        if (mob == null)
+            throw new AplicacaoException(
+                    "Não foi possível encontrar o documento " + req.id);
+
+        ExTipoDeMovimentacao exTipoDeAssinatura = req.assinaturaDigital ?
+                ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO :
+                ExTipoDeMovimentacao.ASSINATURA_COM_SENHA;
+
+        Set<ExMovimentacao> movs = mob.getMovsNaoCanceladas(exTipoDeAssinatura);
+        
+        resp.id = req.id;
+        
+        try {
+            for (ExMovimentacao mov : movs) {
+                if (mov.assertAssinaturaValida() != null) {
+                    resp.status = "Ok";
+                    return;
+                }
+            }    
+        } catch (final Exception e) {
+            resp.status = "ERRO!";    
+        }
+        
+    }
+
+
+    @Override
+    public String getContext() {
+        return "verificar assinatura";
+    }
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosIdVerificarAssinaturaGet.java
@@ -1,7 +1,6 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
 import br.gov.jfrj.siga.base.AplicacaoException;
-import br.gov.jfrj.siga.context.AcessoPublico;
 import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
 import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
@@ -10,7 +9,6 @@ import br.gov.jfrj.siga.persistencia.ExMobilDaoFiltro;
 
 import java.util.Set;
 
-@AcessoPublico
 public class DocumentosIdVerificarAssinaturaGet implements IExApiV1.IDocumentosIdVerificarAssinaturaGet {
 
     @Override

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1496,7 +1496,8 @@ public interface IExApiV1 {
 		}
 
 		public static class Response implements ISwaggerResponse {
-			public String id;
+			public String idDoc;
+			public String idMov;
 			public String status;
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1488,7 +1488,21 @@ public interface IExApiV1 {
 
 		public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
 	}
+	
+	public interface IDocumentosIdVerificarAssinaturaGet extends ISwaggerMethod {
+		public static class Request implements ISwaggerRequest {
+			public String id;
+			public boolean assinaturaDigital;
+		}
 
+		public static class Response implements ISwaggerResponse {
+			public String id;
+			public String status;
+		}
+
+		public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
+	}
+	
 	public interface IDocumentosLocalizarMaisRecenteGet extends ISwaggerMethod {
 		public static class Request implements ISwaggerRequest {
 			public String modelo;

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2500,9 +2500,12 @@ paths:
           schema:
             type: object
             properties:
-              sigla:
-                description: Sigla do documento assinado
+              idDoc:
+                description: Id do documento
                 type: string
+              idMov:
+                description: Id da movimentação da assinatura válida
+                type: string  
               status:
                 type: string
                 default: "ERRO!"  

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2477,7 +2477,40 @@ paths:
           description: Error ocurred
           schema:
             $ref: "#/definitions/Error"
-
+            
+  /documentos/{id}/verificar-assinatura:
+    get:
+      description: Verificar assinatura do documento
+      tags: [ consulta ]
+      parameters:
+        - name: id
+          in: path
+          description: Id do documento
+          type: string
+          required: true
+        - name: assinaturaDigital
+          in: query
+          description: Flag para verificação de assinatura digital ou senha
+          type: boolean
+          default: false
+          required: false
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              sigla:
+                description: Sigla do documento assinado
+                type: string
+              status:
+                type: string
+                default: "ERRO!"  
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+            
   /documentos/localizar/mais-recente:
     get:
       description: "Exibe dados do móbil mais recente que atende às condições desejadas."

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2482,6 +2482,8 @@ paths:
     get:
       description: Verificar assinatura do documento
       tags: [ consulta ]
+      security:
+        - Bearer: [ ]
       parameters:
         - name: id
           in: path

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2483,7 +2483,7 @@ paths:
       description: Verificar assinatura do documento
       tags: [ consulta ]
       security:
-        - Bearer: [ ]
+        - Basic: []
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
### Funcionalidade para disponibilizar endpoint para verificar assinatura

Adição do endpoint `GET documentos/{id}/verificar-assinatura` para verificar se a assinatura de um Documento é válida ou não

#### Referência

[@Get("/app/expediente/mov/assinar_mov_verificar")](https://github.com/projeto-siga/siga/blob/develop/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java#L4353)

#### Captura de Telas

![image](https://user-images.githubusercontent.com/1022974/187997192-8fa27899-9e99-4701-b38b-e78b33154fc5.png)

##### Retorno caso a assinatura seja válida
`{
	"id": "980080",
	"status": "Ok"
}`

##### Retorno caso a assinatura não seja válida
`{
	"id": "1019077",
	"status": "ERRO!"
}`