### PR TITLE
RM127315 Histórico de movimentações no endpoint DocumentosSiglaGet

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaGet.java
@@ -68,7 +68,9 @@ public class DocumentosSiglaGet implements IDocumentosSiglaGet {
 			}
 		}
 
-		final ExDocumentoVO docVO = new ExDocumentoVO(doc, mob, cadastrante, titular, lotaTitular, true, req.auditar != null && req.auditar, true, true);
+		final ExDocumentoVO docVO = new ExDocumentoVO(doc, mob, cadastrante, titular, lotaTitular,
+				req.completo != null && req.completo, req.auditar != null && req.auditar,
+				true, req.exibe != null && req.exibe);
 		// TODO: Resolver o problema declares multiple JSON fields named
 		// serialVersionUID
 		// Usado o Expose temporariamente

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -737,6 +737,7 @@ public interface IExApiV1 {
 			public String sigla;
 			public Boolean completo;
 			public Boolean auditar;
+			public Boolean exibe;
 		}
 
 		public static class Response implements ISwaggerResponse, ISwaggerResponseFile {

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -1143,6 +1143,12 @@ paths:
         - $ref: "#/parameters/sigla"
         - $ref: "#/parameters/completo"
         - $ref: "#/parameters/auditar"
+        - name: exibe
+          in: query
+          description: Informar true se deseja exibir lista de movimentações reduzidas no histórico
+          required: false
+          default: false
+          type: boolean
       responses:
         200:
           description: Successful response


### PR DESCRIPTION
### Histórico de movimentações no endpoint DocumentosSiglaGet

Adequação do histórico de movimentações retornado pelo endpoint `GET
/documentos/{sigla}`.
Verificou-se que houve uma alteração na lógica de exibição do histórico de movimentações retornado pelo endpoint citado.
Somente uma lista resumida de movimentações está sendo apresentada, impactando na apresentação de documentos no módulo de acesso externo do siga.
Esta adequação apresenta ou não a lista resumida de movimentações (histórico) através de um parâmetro na chamada do endpoint.

#### Referência

https://github.com/projeto-siga/siga/commit/621d051b4a5720933981d02d97bbe97f422b6f76

#### Resumo da implementação

1. Adição do parâmetro `exibe` para retornar ou não a lista de movimentações de forma resumida
2. Tratamento do parâmetro `completo` que atualmente está estático no método
