### PR TITLE
RM135470 e RM135465 - Fix da Pequisa Avançada Tab de Meses e Submit Formulário

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
@@ -362,7 +362,7 @@ function submitBusca(cliente) {
 								<label>&nbsp;</label> 
 								<c:if test="${ultMovTipoResp == 1}">
 									<span id="divUltMovResp" style="display: ">
-										<siga:selecao propriedade="ultMovResp" tema="simple" paramList="buscarFechadas=true" modulo="siga"/>
+										<siga:selecao propriedade="ultMovResp" tema="simple" onchange="validarFiltrosPesquisa()" paramList="buscarFechadas=true" modulo="siga"/>
 									</span>
 									<span id="divUltMovLotaResp" style="display: none">
 										<siga:selecao propriedade="ultMovLotaResp" tema="simple" paramList="buscarFechadas=true" modulo="siga"/>
@@ -373,7 +373,7 @@ function submitBusca(cliente) {
 										<siga:selecao propriedade="ultMovResp" tema="simple" paramList="buscarFechadas=true" modulo="siga"/>
 									</span>
 									<span id="divUltMovLotaResp" style="display: ">
-										<siga:selecao propriedade="ultMovLotaResp" tema="simple" paramList="buscarFechadas=true" modulo="siga"/>
+										<siga:selecao propriedade="ultMovLotaResp" tema="simple" onchange="validarFiltrosPesquisa()" paramList="buscarFechadas=true" modulo="siga"/>
 									</span>
 								</c:if>
 							</div>
@@ -490,8 +490,7 @@ function submitBusca(cliente) {
 						<div class="col-sm-4">
 							<div class="form-group">
 								<label><fmt:message key="documento.numero"/></label>
-								<input id="numExpediente" type="text" size="10" name="numExpediente" value="${numExpediente}" 
-									onchange="validarFiltrosPesquisa()" maxlength="10" class="form-control"/>
+								<input id="numExpediente" type="text" size="10" name="numExpediente" value="${numExpediente}" maxlength="10" class="form-control"/>
 							</div>
 						</div>
 					</div>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aBuscar.jsp
@@ -294,8 +294,7 @@ function submitBusca(cliente) {
 		<div id="pesqFiltros" class="card-body collapse show">
 			<div class="tab-content" id="nav-tabContent">
 				<div class="tab-pane fade show active" id="content1">
-				  <form id="buscar" name="buscar" onsubmit="javascript: return limpaCampos()"
-						action="buscar" method="get" class="form100">
+				  <form id="buscar" name="buscar" action="buscar" method="get" class="form100">
 					<input type="hidden" name="popup" value="${popup}" />
 					<input type="hidden" name="propriedade" value="${propriedade}" />
 					<input type="hidden" name="postback" value="1" />

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -56,7 +56,12 @@
 			}
 			listar["paramoffset"].value = offset;
 			listar["p.offset"].value = offset;
-			listar.submit();
+			
+			if (limpaCampos()) {
+				listar.submit();
+			} else {
+				return;
+			}
 		}
 		
 		function submitBusca() {
@@ -71,7 +76,13 @@
 			}
 			$('#buscandoSpinner').removeClass('d-none');
 			document.getElementById("btnBuscar").disabled = true;
-			listar.submit();
+			
+			if (limpaCampos()) {
+				listar.submit();
+			} else {
+				return;
+			}
+			
 		}
 	</script>
 	

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -103,7 +103,7 @@
 				</c:otherwise>
 			</c:choose>
 		</c:if>	
-		<form id="listar" name="listar" onsubmit="javascript: return limpaCampos()" action="listar" method="get" class="form100">
+		<form id="listar" name="listar" action="listar" method="get" class="form100">
 			<input type="hidden" name="popup" value="${popup}" /> 
 			<input type="hidden" name="propriedade" value="${propriedade}" /> 
 			<input type="hidden" name="postback" value="1" /> 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/aListar.jsp
@@ -176,28 +176,24 @@
 											<div id="divUltMovResp" style="display:"
 												class="form-group col-md-4">
 												<label for="ultMovTipoResp"><fmt:message key="tela.pesquisa.pessoa"/></label>
-												<siga:selecao propriedade="ultMovResp" tema="simple"
-													paramList="buscarFechadas=true" modulo="siga" />
+												<siga:selecao propriedade="ultMovResp" tema="simple" onchange="validarFiltrosPesquisa()" paramList="buscarFechadas=true" modulo="siga" />
 											</div>
 											<div id="divUltMovLotaResp" style="display: none"
 												class="form-group col-md-4">
 												<label for="ultMovTipoResp"><fmt:message key="usuario.lotacao"/></label>
-												<siga:selecao propriedade="ultMovLotaResp" tema="simple"
-													paramList="buscarFechadas=true" modulo="siga" />
+												<siga:selecao propriedade="ultMovLotaResp" tema="simple" paramList="buscarFechadas=true" modulo="siga" />
 											</div>
 										</c:if>
 										<c:if test="${ultMovTipoResp == 2}">
 											<div id="divUltMovResp" style="display: none"
 												class="form-group col-md-4">
 												<label for="ultMovTipoResp"><fmt:message key="tela.pesquisa.pessoa"/></label>
-												<siga:selecao propriedade="ultMovResp" tema="simple"
-													paramList="buscarFechadas=true" modulo="siga" />
+												<siga:selecao propriedade="ultMovResp" tema="simple" paramList="buscarFechadas=true" modulo="siga" />
 											</div>
 											<div id="divUltMovLotaResp" style="display:"
 												class="form-group col-md-4">
 												<label for="ultMovTipoResp"><fmt:message key="usuario.lotacao"/></label>
-												<siga:selecao propriedade="ultMovLotaResp" tema="simple"
-													paramList="buscarFechadas=true" modulo="siga" />
+												<siga:selecao propriedade="ultMovLotaResp" tema="simple" onchange="validarFiltrosPesquisa()" paramList="buscarFechadas=true" modulo="siga" />
 											</div>
 										</c:if>
 									</div>
@@ -298,8 +294,7 @@
 										</div>
 											<div class="form-group col-md-3">
 												<label for="numExpediente"><fmt:message key="documento.numero"/></label>
-											    <input type="text" size="10" id="numExpediente" name="numExpediente" value="${numExpediente}" 
-											    	onchange="validarFiltrosPesquisa()" maxlength="10" class="form-control" />
+											    <input type="text" size="10" id="numExpediente" name="numExpediente" value="${numExpediente}" maxlength="10" class="form-control" />
 											</div>
 									</div>
 									<div class="form-row">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/headerMeses.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/headerMeses.jsp
@@ -28,6 +28,15 @@
 		podeDescricao(false);
 		$(document.body).on("change","#idFormaDoc",function(){ podeDescricao(false);});	
 		$(document.body).on("change","#idMod",function(){ podeDescricao(false);});
+		//Add Event Change into form listar
+		if (document.getElementById('listar')) {
+			$(document.body).on("change","#listar",function(){validarFiltrosPesquisa();});
+		} 
+		//Add Event Change into form buscar
+		if (document.getElementById('buscar')) {
+			$(document.body).on("change","#buscar",function(){validarFiltrosPesquisa();});
+		} 
+		
 		if ($('a[data-toggle="tooltip"]'))
 			$('a[data-toggle="tooltip"]').tooltip({
 			    placement: 'bottom',
@@ -226,8 +235,7 @@
 			return;
 		
 		// Se pesquisa dos documentos de uma pessoa/lotação, não tem limite de data
-		if ((document.getElementById('formulario_ultMovLotaRespSel_id').value != 0
-				|| document.getElementById('formulario_ultMovRespSel_id').value != 0)
+		if ((document.getElementById('formulario_ultMovLotaRespSel_sigla').value != '' || document.getElementById('formulario_ultMovRespSel_sigla').value != '')	
 				&& document.getElementById('ultMovIdEstadoDoc').value != 0) { 
 			desabilitaTabMeses();
 			return;
@@ -591,6 +599,8 @@
 
 		if (document.getElementById('formulario_ultMovLotaRespSel_id').value != "")
 			count++;	
+		
+		validarFiltrosPesquisa();
 
 		if (count < 2 && ${formOrigem eq 'busca'}) {
 			alert('Esta pesquisa retornará muitos resultados. Favor restringi-la um pouco mais.');

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/headerMeses.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/headerMeses.jsp
@@ -488,46 +488,48 @@
 		}
 
 		var listar_idTpDoc = document.getElementById('idTpDoc');
+		if (listar_idTpDoc !== null) {
+			switch (parseInt(listar_idTpDoc.value)) {
+			case 0:
+				document.getElementById('numExtDoc').value = '';
 
-		switch (parseInt(listar_idTpDoc.value)) {
-		case 0:
-			document.getElementById('numExtDoc').value = '';
+				document.getElementById('formulario_cpOrgaoSel_id').value = '';
+				document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
+				document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
+				document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
+				document.getElementById('cpOrgaoSelSpan').innerHTML = '';
+				document.getElementById('numAntigoDoc').value = '';
 
-			document.getElementById('formulario_cpOrgaoSel_id').value = '';
-			document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
-			document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
-			document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
-			document.getElementById('cpOrgaoSelSpan').innerHTML = '';
-			document.getElementById('numAntigoDoc').value = '';
+				break;
+			case 1:
+				document.getElementById('numExtDoc').value = '';
+				document.getElementById('formulario_cpOrgaoSel_id').value = '';
+				document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
+				document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
+				document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
+				document.getElementById('cpOrgaoSelSpan').innerHTML = '';
+				document.getElementById('numAntigoDoc').value = '';
 
-			break;
-		case 1:
-			document.getElementById('numExtDoc').value = '';
-			document.getElementById('formulario_cpOrgaoSel_id').value = '';
-			document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
-			document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
-			document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
-			document.getElementById('cpOrgaoSelSpan').innerHTML = '';
-			document.getElementById('numAntigoDoc').value = '';
+				break;
+			case 2:
+				document.getElementById('formulario_cpOrgaoSel_id').value = '';
+				document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
+				document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
+				document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
+				document.getElementById('cpOrgaoSelSpan').innerHTML = '';
 
-			break;
-		case 2:
-			document.getElementById('formulario_cpOrgaoSel_id').value = '';
-			document.getElementById('formulario_cpOrgaoSel_descricao').value = '';
-			document.getElementById('formulario_cpOrgaoSel_buscar').value = '';
-			document.getElementById('formulario_cpOrgaoSel_sigla').value = '';
-			document.getElementById('cpOrgaoSelSpan').innerHTML = '';
+				break;
+			case 3:
+				document.getElementById('idFormaDoc').value = '5';
 
-			break;
-		case 3:
-			document.getElementById('idFormaDoc').value = '5';
-
-			break;
+				break;
+			}
+			
 		}
-	
+		
 		var count = 0;
 
-		if (document.getElementById('idTpDoc').value != 0)
+		if (document.getElementById('idTpDoc') !== null && document.getElementById('idTpDoc').value != 0)
 			count++;	
 		
 		if (document.getElementById('dtDocString').value != "")
@@ -536,7 +538,7 @@
 		if (document.getElementById('dtDocFinalString').value != "")
 			count++;
 		
-		if (document.getElementById('idTipoFormaDoc').value != 0)
+		if (document.getElementById('tipoForma').value != 0)
 			count++;
 		
 		if (document.getElementById('idMod') != null && document.getElementById('idMod').value != 0)
@@ -551,43 +553,43 @@
 		if (document.getElementById('numExpediente').value != "")
 			count++;		
 		
-		if (document.getElementById('subscritorSel_id').value != "")
+		if (document.getElementById('formulario_subscritorSel_id').value != "")
 			count++;	
 		
-		if (document.getElementById('cadastranteSel_id').value != "")
+		if (document.getElementById('formulario_cadastranteSel_id').value != "")
 			count++;	
 			
-		if (document.getElementById('lotaCadastranteSel_id').value != "")
+		if (document.getElementById('formulario_lotaCadastranteSel_id').value != "")
 			count++;	
 			
-		if (document.getElementById('destinatarioSel_id').value != "")
+		if (document.getElementById('formulario_destinatarioSel_id').value != "")
 			count++;	
 
-		if (document.getElementById('lotacaoDestinatarioSel_id').value != "")
+		if (document.getElementById('formulario_lotacaoDestinatarioSel_id').value != "")
 			count++;	
 
-		if (document.getElementById('orgaoExternoDestinatarioSel_id').value != "")
+		if (document.getElementById('formulario_orgaoExternoDestinatarioSel_id').value != "")
 			count++;	
 
 		if (document.getElementById('nmDestinatario').value != "")
 			count++;	
 
-		if (document.getElementById('classificacaoSel_id').value != "")
+		if (document.getElementById('formulario_classificacaoSel_id').value != "")
 			count++;	
 
 		if (document.getElementById('descrDocumento').value != "")
 			count++;	
 			
-		if (document.getElementById('fullText').value != "")
+		if (document.getElementById('fullText') !== null && document.getElementById('fullText').value != "")
 			count++;
 
 		if (document.getElementById('ultMovIdEstadoDoc').value != 0)
 			count++;	
 
-		if (document.getElementById('ultMovRespSel_id').value != "")
+		if (document.getElementById('formulario_ultMovRespSel_id').value != "")
 			count++;	
 
-		if (document.getElementById('ultMovLotaRespSel_id').value != "")
+		if (document.getElementById('formulario_ultMovLotaRespSel_id').value != "")
 			count++;	
 
 		if (count < 2 && ${formOrigem eq 'busca'}) {


### PR DESCRIPTION
Percebido algumas instabilidades nas combinações e alterações de campos filtros do formulário de Pesquisa Avançada.

Ao trocar de Pessoa para Lotação e Lotação para Pessoa percebia-se um resíduo no formulário nos campos hiddens que provocava um envio desses Ids para o Controller provocando uma combinação de filtros inválidas.

![image](https://user-images.githubusercontent.com/20362170/192841449-23e74f24-97cd-4889-8dd7-4aa66612f06b.png)

Foi adequado o fluxo do Submit que havia sido perdido na troca do componente input submit para button quando foi implementado o spinner nessa tela.
Percebido também que a função que faz essa limpeza havia diversos Ids de Elementos que estavam incorretos desde a criação. Foi realizado esse ajuste também.


Outro problema percebido é com relação ao envio de range de datas usando a Tab dos Meses.

Primeira Consulta
![image](https://user-images.githubusercontent.com/20362170/192841644-654282b6-3cd6-4817-8feb-aba47e51916f.png)

Segunda Consulta
![image](https://user-images.githubusercontent.com/20362170/192841734-9d2d9d33-5151-4a18-b47c-13a55e6d8c53.png)

![image](https://user-images.githubusercontent.com/20362170/192841881-ef4d6319-3884-4691-944f-d5028c2a10d0.png)

Tab Meses estava sendo controlada (desabilitada) apenas após o submit em caso de filtro de Situação + Objeto.
Isso provocava que no primeiro submit (sem alteração do formulário) era enviado a dtIni e dtFim da pesquisa e no segundo era limpa essas datas para pesquisar pela situação.

Colada a validação no change do Form e no submit para garantir uma resposta adequada para o usuário em tela e um correto envio de dados ao Controller.

Obs.: Trocado de _id para _sigla o elemento ultMov pois o Id fica resíduo antes do change. A sigla deu um retorno mais imediato para a interface

