### PR TITLE
FIX: MT004: Botão Redefinir Acesso Padrão usando variavel local

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeDesfazerRestricaoDeAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeDesfazerRestricaoDeAcesso.java
@@ -30,8 +30,8 @@ public class ExPodeDesfazerRestricaoDeAcesso extends CompositeExpressionSupport 
 		this.titular = titular;
 		this.lotaTitular = lotaTitular;
 
-		List<ExMovimentacao> lista = new ArrayList<ExMovimentacao>();
-		lista.addAll(mob.getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
+		this.lista = new ArrayList();
+		this.lista.addAll(mob.getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
 	}
 
 	@Override


### PR DESCRIPTION
No construtor estava sendo instanciada uma varável local lista e não a variável global que é verificada no método create,
com isso o botão redefinir acesso padrão não estava sendo exibido ao utilizar o botão Restrição de Acesso