### PR TITLE
RM128265

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6583,8 +6583,16 @@ public class ExBL extends CpBL {
 				atualizarVariaveisDenormalizadas(mob.doc(), incluirAcesso, excluirAcesso);
 			if (mob.isGeral())
 				atualizarMarcas(mob.doc());
-			else
+			else {
 				atualizarMarcas(mob);
+				if(mob.isVolume()) {
+					for(ExMobil m : mob.getDoc().getExMobilSet()) {
+						if(!m.isGeralDeProcesso() && !mob.equals(m)) {
+							atualizarMarcas(m);
+						}			 
+					}	
+				}
+			}
 		}
 		set.add(mob.doc().getCodigo());
 	}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -852,9 +852,19 @@ public class ExMarcadorBL {
 
 	public ExMovimentacao contemTransferenciaRetorno(ExMovimentacao mov, ExMobil mob) {
 		ExMovimentacao movRetorno = null;
-		List<ExMovimentacao> transferencias = mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.TRANSFERENCIA, false);
-		transferencias.addAll(mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA, false));
-		transferencias.removeAll(mob.getMovimentacoesCanceladas());
+		List<ExMovimentacao> transferencias = new ArrayList<>();
+		
+		if(mob.isVolume()) {
+			for(ExMobil m : mob.getDoc().getExMobilSet()) {
+				if(!m.isGeralDeProcesso() && m.getNumSequencia() >= mob.getNumSequencia()) {
+					transferencias.addAll(m.getMovimentacoesPorTipo(ExTipoDeMovimentacao.TRANSFERENCIA, true));
+				}
+			}
+		} else {
+			transferencias.addAll(mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.TRANSFERENCIA, true));
+		}
+		transferencias.addAll(mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA, true));
+//		transferencias.removeAll(mob.getMovimentacoesCanceladas());
 
 		Iterator it = transferencias.iterator();
 		while (it.hasNext()) {


### PR DESCRIPTION
O alerta de devolução fora do prazo não é resetado no processo apesar do retorno à lotação de origem que definiu data de devolução. A data de devolução foi definida na tramitação do volume 1 do processo e o retorno à origem aconteceu por meio da tramitação do volume 2