### PR TITLE
Corrige bug na edição de modelos

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Texto.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/util/Texto.java
@@ -18,12 +18,52 @@
  ******************************************************************************/
 package br.gov.jfrj.siga.base.util;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Texto {
 
+	public static Map<String, String> htmlEntities;
+	
+	static {
+		htmlEntities = new HashMap<String, String>();
+		
+		htmlEntities.put("&aacute;", "á");	htmlEntities.put("&Aacute;", "Á");
+		htmlEntities.put("&agrave;", "à");	htmlEntities.put("&Agrave;", "À");
+		htmlEntities.put("&acirc;" , "â");	htmlEntities.put("&Acirc;" , "Â");
+		htmlEntities.put("&atilde;", "ã");	htmlEntities.put("&Atilde;", "Ã");
+		htmlEntities.put("&auml;"  , "ä");	htmlEntities.put("&Auml;"  , "Ä");
+		htmlEntities.put("&aring;" , "å");	htmlEntities.put("&Aring;" , "Å");
+		htmlEntities.put("&aelig;" , "æ");	htmlEntities.put("&Aelig;" , "Æ");
+		
+		htmlEntities.put("&eacute;", "é");	htmlEntities.put("&Eacute;", "É");
+		htmlEntities.put("&egrave;", "è");	htmlEntities.put("&Egrave;", "È");
+		htmlEntities.put("&ecirc;" , "ê");	htmlEntities.put("&Ecirc;" , "Ê");
+		htmlEntities.put("&euml;"  , "ë");	htmlEntities.put("&Euml;"  , "Ë");
+		
+		htmlEntities.put("&iacute;", "í");	htmlEntities.put("&Iacute;", "Í");
+		htmlEntities.put("&igrave;", "ì");	htmlEntities.put("&Igrave;", "Ì");
+		htmlEntities.put("&icirc;" , "î");	htmlEntities.put("&Icirc;" , "Î");
+		htmlEntities.put("&iuml;"  , "ï");	htmlEntities.put("&Iuml;"  , "Ï");
+		
+		htmlEntities.put("&oacute;", "ó");	htmlEntities.put("&Oacute;", "Ó");
+		htmlEntities.put("&ograve;", "ò");	htmlEntities.put("&Ograve;", "Ò");
+		htmlEntities.put("&ocirc;" , "ô");	htmlEntities.put("&Ocirc;" , "Ô");
+		htmlEntities.put("&otilde;", "õ");	htmlEntities.put("&Otilde;", "Õ");
+		htmlEntities.put("&ouml;"  , "ö");	htmlEntities.put("&Ouml;"  , "Ö");
+		htmlEntities.put("&oslash;", "ø"); 	htmlEntities.put("&Oslash;", "Ø");
+		
+		htmlEntities.put("&uacute;", "ú");	htmlEntities.put("&Uacute;", "Ú");
+		htmlEntities.put("&ugrave;", "ù");	htmlEntities.put("&Ugrave;", "Ù");
+		htmlEntities.put("&ucirc;" , "û");	htmlEntities.put("&Ucirc;" , "Û");
+		htmlEntities.put("&uuml;"  , "ü");	htmlEntities.put("&Uuml;"  , "Ü");
+		
+		htmlEntities.put("&ccedil;", "ç"); 	htmlEntities.put("&Ccedil;", "Ç");
+	    htmlEntities.put("&szlig;" , "ß"); 	htmlEntities.put("&nbsp;"  , " ");
+	}
+	
 	/**
 	 * Remove os acentos da string e coloca os caracteres em letras minúsculas
 	 * 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -56,7 +56,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jboss.logging.Logger;
 
 import br.com.caelum.vraptor.Controller;
@@ -2516,8 +2516,15 @@ public class ExDocumentoController extends ExController {
 					final String param[] = s.split("=");
 					try {
 						if (param.length == 2) {
-							exDocumentoDTO.getParamsEntrevista().put(param[0],
-									URLDecoder.decode(param[1], "iso-8859-1"));
+							
+							String parametro = URLDecoder.decode(param[1], "iso-8859-1");
+							
+							parametro = StringEscapeUtils.unescapeHtml4(parametro);
+							for (Entry<String, String> entry : Texto.htmlEntities.entrySet()) {
+								parametro = parametro.replaceAll(entry.getKey(), entry.getValue());
+							}
+							
+							exDocumentoDTO.getParamsEntrevista().put(param[0],parametro);
 						}
 					} catch (final UnsupportedEncodingException e) {
 					}


### PR DESCRIPTION
Fluxo anterior:
Nos modelos freemaker, ao cadastrar um documento as informações de entrevista são encodadas para o escape HTML4 para que possa exibir as informações que o usuário digitou no cadastro.
Porém ao editar o documento as informações não eram retornadas com os caracteres corretamente para o freemaker, então não encontrava a palavra com o encode.

Correção:
Agora com a correção os caracteres mais utilizados são removidos o unicode para que possa voltar ao padrão UTF-8 em que foi escrito no freemaker, assim evitando valores padrões no dropdown como SELECIONE

Caracteres testado:
( € £ @ _ á ã é í ô Ó ú~~ ´´ & $ [ + - = , . — º ª{ "  ç Ç
- Além dos caracteres no HasMap de htmlEntities

Modelos testado:
- Escala de Plantões Departamento de Atenção à Saúde - HCFAMEMA
- Memorando
- Relatório de Justificativa - OS

OBS: Alguns caracteres específicos / emoji, tais como (►, Ž), continua sem aparecer, pois, o mesmo não consegue ser encontrado na tabela de código ASCII, então o freemaker não entende, substituindo o mesmo pelo caractere *?*