### PR TITLE
RM126830 Erro ao juntar doc após assinatura

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -1884,7 +1884,7 @@ public class ExBL extends CpBL {
 				// Receber o móbil pai caso ele tenha sido tramitado para o cadastrante ou sua lotação
 				if (Ex.getInstance().getComp().pode(ExPodeReceber.class, cadastrante, lotaCadastrante, doc.getExMobilPai())) 
 					receber(cadastrante, cadastrante, lotaCadastrante, doc.getExMobilPai(), null);
-				juntarAoDocumentoPai(cadastrante, lotaCadastrante, doc, dtMov, cadastrante, cadastrante, mov);
+				juntarAoDocumentoPai(doc.getCadastrante(), doc.getLotaCadastrante(), doc, dtMov, cadastrante, cadastrante, mov);
 			}
 
 			if (doc.getExMobilAutuado() != null) {


### PR DESCRIPTION
Fluxo anterior:
Ao adicionar um documento com consignatário ou responsável por assinatura, o documento quando assinado pelo mesmo estava juntando os documentos no nome da última pessoa que assinou. E mantendo a unidade da última pessoa que assinou também.

Correção:
De acordo com a demanda, agora com a correção o responsável pela JUNTADA está sendo o usuário que cadastrou o documento.