### PR TITLE
GOVSP - RM144644 - Mesa 2 em loop tentando trazer marca sem mobil

### DIFF
--- a/siga/src/main/webapp/css/style_siga.css
+++ b/siga/src/main/webapp/css/style_siga.css
@@ -4,7 +4,7 @@
 }
 .text-size-5 {
 	font-size: 16px;
-	font-weight: 400;
+	font-weight: 400; 
 }
 .text-size-6 {
 	font-size: 14px;
@@ -240,8 +240,9 @@ a.doc-sign:hover {
     position: fixed;
     right: -320px;
     width: 350px;
-    top: 180px;
-    z-index: 100;	
+    top: 150px;
+    z-index: 1100;
+    font-size: 0.8em;
 }
 .btn-mesa-config {
 	width: 30px;

--- a/siga/src/main/webapp/javascript/mesa2.js
+++ b/siga/src/main/webapp/javascript/mesa2.js
@@ -552,7 +552,13 @@ function carregaFromJson(json, appMesa) {
 					preencheLinhasFantasmas(grp, appMesa);
 					Vue.set(appMesa.grupos, g, grp[0]);
 				}
-			}
+			} 
+		} else { 
+			let grpVue = getGrupoVue(grp[0].grupoNome); 
+			// Se ainda houver linha a preencher no grupo e nao encontrou, reduz 1 do contador. 
+			// Provavelmente existe marca sem mobil no grupo 
+			if (grpVue.grupoDocs[grpVue.grupoCounterAtivo - 1].codigo == "") 
+				grpVue.grupoDocs.length--;
 		}
 	}
 	

--- a/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
@@ -372,4 +372,4 @@
 	</script>
 </siga:pagina>
 <script src="/siga/bootstrap/4.6.0/js/bootstrap.bundle.min.js" type="text/javascript"></script>
-<script type="text/javascript" src="/siga/javascript/mesa2.js?v=1665081275"></script>
+<script type="text/javascript" src="/siga/javascript/mesa2.js?v=1671250628"></script>


### PR DESCRIPTION
Ao tentar trazer a mesa de um usuário ou unidade que tivesse alguma marca sem mobil associado, a mesa entrava em loop porque a quantidade prevista na contagem não era igual a quantidade trazida. Ajustado para que caso não traga nada em alguma tentativa, subtraia um da quantidade prevista cada vez que tentar. 

Corrigido também o tamanho do modal de configuração da mesa que extrapolava o limite da tela.
![image](https://user-images.githubusercontent.com/49542320/208657874-a974493f-c1b3-40c5-a3ec-33d78595db88.png)
