### PR TITLE
RM65983 - Permissão de Inativação de Lotação com Documentos

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -338,7 +338,12 @@ public class Prop {
 		 * */
 		provider.addPublicProperty("/siga.session.modelos.tempo.expiracao", "60");
 
-		/* Permite inativar lotação com determinadas marcações */
-		provider.addPublicProperty("/siga.lotacao.inativacao.marcadores.permitidos", "false");
+		/* Permite inativar lotação com determinadas marcações*/
+		/* Trocado de Bool para List String que deve conter as chaves de marcadores permitidas separadas por virgula no padrao do getList() */
+		provider.addPublicProperty("/siga.lotacao.inativacao.marcadores.permitidos", null);
+		/* Permitir Inativar Lotação com Marcas nos Grupos de Marcadores. 
+		 * É ligada caso property siga.lotacao.inativacao.marcadores.permitidos seja diferente de null e soma-se as listas
+		 * Default: Documentos não apresentados na Mesa.*/
+		provider.addPublicProperty("/siga.lotacao.inativacao.grupo.marcadores.permitidos", "NENHUM");
 	}
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -2617,7 +2617,7 @@ public class CpBL {
 		Integer quantidade;
 		List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
 
-        if (excluirMarcadoresDaContagem && listaMarcadores != null && !listaMarcadores.isEmpty())
+        if (excluirMarcadoresDaContagem && listaMarcadores != null)
         	quantidade = dao().quatidadeMarcasEmPosseDaLotacaoMarcadores(lotacao,listaMarcadores);
         else
         	quantidade = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
@@ -2637,7 +2637,7 @@ public class CpBL {
 		Integer quantidade;		
         List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
 
-        if (excluirMarcadoresDaContagem && listaMarcadores != null && !listaMarcadores.isEmpty())
+        if (excluirMarcadoresDaContagem && listaMarcadores != null)
         	quantidade = dao().quatidadeMarcasEmPosseDaPessoaMarcadores(pessoa,listaMarcadores);
         else
         	quantidade = dao().quantidadeDocumentos(pessoa);

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1259,10 +1259,8 @@ public class CpBL {
 			
 			if(pessoaAnt != null) {
 				Integer qtde = CpDao.getInstance().quantidadeDocumentos(pessoaAnt);
-				if ((qtde > 0 && !idLotacao.equals(pessoaAnt.getLotacao().getId())) 
-						&& (!podeAlterarOrgaoPessoa || pessoaAnt.getOrgaoUsuario().getId().equals(idOrgaoUsu))) {
-					throw new AplicacaoException(
-							"A unidade da pessoa não pode ser alterada, pois existem documentos pendentes");
+				if ((qtde > 0 && !idLotacao.equals(pessoaAnt.getLotacao().getId())) && (!podeAlterarOrgaoPessoa || pessoaAnt.getOrgaoUsuario().getId().equals(idOrgaoUsu))) {
+					throw new AplicacaoException("A unidade da pessoa não pode ser alterada, pois existem documentos pendentes");
 				}
 				pessoa.setIdInicial(pessoaAnt.getIdInicial());
 				pessoa.setMatricula(pessoaAnt.getMatricula());
@@ -1273,8 +1271,8 @@ public class CpBL {
 					marcadores.add(CpMarcadorEnum.CAIXA_DE_ENTRADA.getId());
 					marcadores.add(CpMarcadorEnum.EM_ELABORACAO.getId());
 					
-					Long qtdeCaixaEntradaTMPPessoa = CpDao.getInstance().qtdeMarcasMarcadorPessoa(pessoaAnt.getPessoaInicial(), marcadores);
-					Long qtdeCaixaEntradaTMPLotacao = CpDao.getInstance().qtdeMarcasMarcadorLotacao(pessoaAnt.getLotacao().getLotacaoInicial(), marcadores);
+					Long qtdeCaixaEntradaTMPPessoa = CpDao.getInstance().quantidadeMarcasPorPessoaMarcadores(pessoaAnt, marcadores, true);
+					Long qtdeCaixaEntradaTMPLotacao = CpDao.getInstance().quantidadeMarcasPorLotacaoMarcadores(pessoaAnt.getLotacao(), marcadores, true);
 					Long qtdePessoaLotacao = CpDao.getInstance().qtdePessoaLotacao(pessoaAnt.getLotacao().getLotacaoAtual(), Boolean.TRUE);
 					
 					if(qtdeCaixaEntradaTMPPessoa > 0 || (qtdeCaixaEntradaTMPLotacao > 0 && qtdePessoaLotacao.equals(Long.valueOf(1L)))) {
@@ -2239,7 +2237,8 @@ public class CpBL {
 			final Long idLotacao, final String nmLotacao, final String siglaLotacao, final String situacao,
 			DpLotacao lotacao, DpLotacao lotacaoNova, Date dataSistema) {
 		List<DpPessoa> listPessoa = CpDao.getInstance().pessoasPorLotacao(idLotacao, Boolean.TRUE, Boolean.FALSE);
-		Integer qtdeDocumentoCriadosPosse = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
+		
+		Integer qtdeDocumentoCriadosPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, Boolean.FALSE); // Não restringe Marcadores
 		
 		if(!Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(titular, lotaTitular,"SIGA;GI;CAD_LOTACAO;ALT") && qtdeDocumentoCriadosPosse > 0 && 
 				(!lotacao.getNomeLotacao().equalsIgnoreCase(Texto.removerEspacosExtra(nmLotacao).trim()) || !lotacao.getSiglaLotacao().equalsIgnoreCase(siglaLotacao.toUpperCase().trim()))) {
@@ -2605,5 +2604,142 @@ public class CpBL {
 		}
 		return orgaos;
 	} 
+	
+	
+    /**
+     * Consulta quantidade de documentos criados OU que estão em posse da lotação, conforme parâmetros e propriedades
+     *
+     * @param lotacao
+     * @return
+     */
+	public Integer quatidadeMarcasOuDocumentosEmPosseDaLotacao(DpLotacao lotacao, boolean excluirMarcadoresDaContagem) { 
+
+		Integer quantidade;
+		List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
+
+        if (excluirMarcadoresDaContagem && listaMarcadores != null && !listaMarcadores.isEmpty())
+        	quantidade = dao().quatidadeMarcasEmPosseDaLotacaoMarcadores(lotacao,listaMarcadores);
+        else
+        	quantidade = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
+
+        return quantidade;
+    }
+	
+	
+    /**
+     * Consulta quantidade de documentos criados OU que estão em posse da lotação, conforme parâmetros e propriedades
+     *
+     * @param lotacao
+     * @return
+     */
+	public Integer quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(DpPessoa pessoa, boolean excluirMarcadoresDaContagem) { 
+
+		Integer quantidade;		
+        List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
+
+        if (excluirMarcadoresDaContagem && listaMarcadores != null && !listaMarcadores.isEmpty())
+        	quantidade = dao().quatidadeMarcasEmPosseDaPessoaMarcadores(pessoa,listaMarcadores);
+        else
+        	quantidade = dao().quantidadeDocumentos(pessoa);
+
+        return quantidade;
+    }
+	
+	public boolean restringeMarcadoresParaInativacaoLotacao() {
+		final String TODOS_MARCADORES = "*";
+		final String marcadoresPermitidos = Prop.get("/siga.lotacao.inativacao.marcadores.permitidos");
+		
+		return !TODOS_MARCADORES.equals(marcadoresPermitidos);
+		
+	}
+	
+	
+	public List<Long> getListaMarcadoresPermitidosInativacaoLotacao() {
+
+        List<String> listaMarcadores = null;
+        List<String> listaGrupoMarcadores = null;
+        List<Long> listaMarcadoresPermitidos = null;
+		
+		if (restringeMarcadoresParaInativacaoLotacao()) {
+			
+	        listaMarcadores = Prop.getList("/siga.lotacao.inativacao.marcadores.permitidos");
+	        
+	        if (listaMarcadores != null) {
+		        listaGrupoMarcadores = Prop.getList("/siga.lotacao.inativacao.grupo.marcadores.permitidos");
+		        listaMarcadoresPermitidos = CpMarcadorEnum.getListIdByListChaves(listaMarcadores);
+		        
+				//Soma-se aos Marcadores Permitidos os marcadores relacionados aos grupos definidos
+				if (!listaGrupoMarcadores.isEmpty()) {
+					for (String grupo : listaGrupoMarcadores) {
+						if (!"".equals(grupo)) {
+							listaMarcadoresPermitidos.addAll(CpMarcadorEnum.getListIdByGrupo(CpMarcadorGrupoEnum.valueOf(grupo.trim())));
+						}			
+					}			
+				}
+	        }
+		}
+			
+		return listaMarcadoresPermitidos;
+		
+	}
+	
+	
+	public boolean podeAtivarLotacao(DpLotacao lotacao, DpPessoa cadastrante) throws Exception {	
+		final String servico = "SIGA:Sistema Integrado de Gestão Administrativa;GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Lotação";
+		Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(cadastrante, cadastrante.getLotacao(), servico);
+		
+		if (lotacao.getDataFimLotacao() == null) {
+			throw new AplicacaoException("Ativação não permitida. " + SigaMessages.getMessage("usuario.lotacao") + " não encontra-se inativa.", 0);
+		}
+		
+		return true;
+		
+	}
+	
+	public boolean podeInativarLotacao(DpLotacao lotacao, DpPessoa cadastrante) throws Exception {		
+		final String servico = "SIGA:Sistema Integrado de Gestão Administrativa;GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Lotação";
+		Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(cadastrante, cadastrante.getLotacao(), servico);
+		
+		/* Verifica Lotações Filhas */
+		if (dao().listarLotacoesPorPai(lotacao).size() > 0) 
+			throw new AplicacaoException("Inativação não permitida. Está " + SigaMessages.getMessage("usuario.lotacao") + " é pai de outra " + SigaMessages.getMessage("usuario.lotacao"),0);
+		
+		/* Verifica Pessoas Ativas */
+		List<DpPessoa> listaPessoasAtivasLotacao = CpDao.getInstance().pessoasPorLotacao(lotacao.getId(), Boolean.TRUE, Boolean.FALSE);
+		Integer quantidadePessoasAtivas = listaPessoasAtivasLotacao.size();
+		if (quantidadePessoasAtivas > 0) {
+			throw new AplicacaoException("Inativação não permitida. Existem usuários ativos vinculados nessa " + SigaMessages.getMessage("usuario.lotacao"), 0);
+			
+		}
+		
+		if (restringeMarcadoresParaInativacaoLotacao()) {	
+			/* Verifica Quantidade de Marcas para Lotação */
+			Integer quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, Boolean.TRUE); 
+			if (quantidadeEmPosse > 0) {
+				throw new AplicacaoException("Inativação não permitida. Existem documentos vinculados nessa " + SigaMessages.getMessage("usuario.lotacao"), 0);
+				
+			}
+			
+			/* Verifica Quantidade de Marcas para as Pessoas Inativas da Lotação */
+			final DpPessoaDaoFiltro flt = new DpPessoaDaoFiltro();
+			flt.setBuscarFechadas(Boolean.TRUE);
+			flt.setLotacao(lotacao);	
+			flt.setNome("");
+			List<DpPessoa> listaPessoasInativasDaLotacao = CpDao.getInstance().consultarPorFiltro(flt);
+			
+			if (listaPessoasInativasDaLotacao != null && listaPessoasInativasDaLotacao.size() > 0 ) {
+				for (DpPessoa pessoa : listaPessoasInativasDaLotacao) {
+					quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(pessoa, Boolean.TRUE); 
+					if (quantidadeEmPosse > 0) {
+						throw new AplicacaoException("Inativação não permitida. Existem documentos de usuários inativos vinculados nessa " + SigaMessages.getMessage("usuario.lotacao"), 0);
+						
+					}	
+				}
+			}
+		}
+		
+		return true;	
+	}
+
 	
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
@@ -225,15 +225,28 @@ public enum CpMarcadorEnum {
 		}
 		return null;
 	}
-
-	public static List<Integer> getListIdByGrupo(String nomegrupo) {
-		List<Integer> listMar = new ArrayList<Integer>();
+	
+	public static List<Long> getListIdByGrupo(CpMarcadorGrupoEnum grupo) {
+		List<Long> listMar = new ArrayList<Long>();
 		for (CpMarcadorEnum mar : CpMarcadorEnum.values()) {
-			if (mar.getGrupo().getNome().equals(nomegrupo)) {
-				listMar.add(mar.id);
+			if (mar.getGrupo().getNome().equals(grupo.getNome())) {
+				listMar.add(mar.getId());
 			}
 		}
 		return listMar;
+	}
+	
+	public static List<Long> getListIdByListChaves(List<String> chaves){
+		final List<Long> listaMarcadores = new ArrayList<Long>();
+		if (chaves != null) {
+			for(String chave : chaves) {
+				CpMarcadorEnum marcador = CpMarcadorEnum.valueOf(chave.trim());
+				if(marcador != null) {
+					listaMarcadores.add(marcador.getId());
+				}
+			}	
+		}
+		return listaMarcadores;
 	}
 
 	public String getIcone() {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
@@ -238,11 +238,13 @@ public enum CpMarcadorEnum {
 	
 	public static List<Long> getListIdByListChaves(List<String> chaves){
 		final List<Long> listaMarcadores = new ArrayList<Long>();
-		if (chaves != null) {
+		if (chaves != null && !chaves.isEmpty()) {
 			for(String chave : chaves) {
-				CpMarcadorEnum marcador = CpMarcadorEnum.valueOf(chave.trim());
-				if(marcador != null) {
-					listaMarcadores.add(marcador.getId());
+				if (!"".equals(chave)) {
+	 				CpMarcadorEnum marcador = CpMarcadorEnum.valueOf(chave.trim());
+					if(marcador != null) {
+						listaMarcadores.add(marcador.getId());
+					}
 				}
 			}	
 		}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
@@ -108,22 +108,16 @@ import br.gov.jfrj.siga.sinc.lib.Desconsiderar;
 				+ "	 group by lAux.idLotacaoIni having max(lAux.dataInicioLotacao) = lotacao.dataInicioLotacao)"),
 		@NamedQuery(name = "consultarPorNomeOrgaoDpLotacao", query = "select lot from DpLotacao lot where upper(REMOVE_ACENTO(lot.nomeLotacao)) = upper(REMOVE_ACENTO(:nome)) and lot.orgaoUsuario.idOrgaoUsu = :idOrgaoUsu")})
 		@NamedNativeQueries({
-		@NamedNativeQuery(name = "consultarQuantidadeDocumentosPorDpLotacao", query = "SELECT count(1) FROM corporativo.cp_marca marca "
-				+ " left join corporativo.dp_lotacao lotacao on lotacao.ID_LOTACAO = marca.ID_LOTACAO_INI"
-				+ " WHERE id_marcador not in (1,10,32)"
-				+ " AND lotacao.id_lotacao_ini = :idLotacao"
-				+ " AND id_tp_marca = :idTipoMarca "),
-		@NamedNativeQuery(name = "consultarQtdeDocCriadosPossePorDpLotacao", query = "SELECT count(1) FROM siga.ex_documento doc "
-				+ " left join corporativo.dp_lotacao lot on doc.id_lota_cadastrante = lot.id_lotacao "
-				+ " left join siga.ex_mobil mob on mob.id_doc = doc.id_doc "
-				+ " left join corporativo.cp_marca marca on marca.id_ref = mob.ID_MOBIL"
-				+ " where lot.id_lotacao_ini = :idLotacao or marca.ID_LOTACAO_INI = :idLotacao"),
-		@NamedNativeQuery(name = "consultarQtdeDocCriadosPossePorDpLotacaoECpMarca", query = "SELECT count(1) FROM siga.ex_documento doc "
-						+ " left join corporativo.dp_lotacao lot on doc.id_lota_cadastrante = lot.id_lotacao "
-						+ " left join siga.ex_mobil mob on mob.id_doc = doc.id_doc "
-						+ " left join corporativo.cp_marca marca on marca.id_ref = mob.ID_MOBIL"
-						+ " where lot.id_lotacao_ini = :idLotacao or (marca.ID_LOTACAO_INI = :idLotacao"
-				        + " and marca.ID_MARCADOR not in (:listMarcadores))")})
+			@NamedNativeQuery(name = "consultarQuantidadeDocumentosPorDpLotacao", query = "SELECT count(1) FROM corporativo.cp_marca marca "
+					+ " left join corporativo.dp_lotacao lotacao on lotacao.ID_LOTACAO = marca.ID_LOTACAO_INI"
+					+ " WHERE id_marcador not in (1,10,32)"
+					+ " AND lotacao.id_lotacao_ini = :idLotacao"
+					+ " AND id_tp_marca = :idTipoMarca "),
+			@NamedNativeQuery(name = "consultarQtdeDocCriadosPossePorDpLotacao", query = "SELECT count(1) FROM siga.ex_documento doc "
+					+ " left join corporativo.dp_lotacao lot on doc.id_lota_cadastrante = lot.id_lotacao "
+					+ " left join siga.ex_mobil mob on mob.id_doc = doc.id_doc "
+					+ " left join corporativo.cp_marca marca on marca.id_ref = mob.ID_MOBIL"
+					+ " where lot.id_lotacao_ini = :idLotacao or marca.ID_LOTACAO_INI = :idLotacao")})
 
 public abstract class AbstractDpLotacao extends DpResponsavel implements
 		Serializable, HistoricoAuditavel {
@@ -209,6 +203,14 @@ public abstract class AbstractDpLotacao extends DpResponsavel implements
 	
 	@Column(name = "IS_SUSPENSA")
 	private Integer isSuspensa;
+	
+	@Column(name = "MOTIVO_INATIVACAO", length = 500)
+	@Desconsiderar
+	private String motivoInativacao;
+	
+	@Column(name = "MOTIVO_ATIVACAO", length = 500)
+	@Desconsiderar
+	private String motivoAtivacao;
 
 	public Integer getIsExternaLotacao() {
 		return isExternaLotacao;
@@ -442,5 +444,26 @@ public abstract class AbstractDpLotacao extends DpResponsavel implements
 	public void setIsSuspensa(Integer isSuspensa) {
 		this.isSuspensa = isSuspensa;
 	}
+	
+	
+	/* 
+	 * Motivo da Inativação/Ativação de Lotações para Histórico
+	 * */
+	public String getMotivoInativacao() {
+		return motivoInativacao;
+	}
+
+	public void setMotivoInativacao(String motivoInativacao) {
+		this.motivoInativacao = motivoInativacao;
+	}
+
+	public String getMotivoAtivacao() {
+		return motivoAtivacao;
+	}
+
+	public void setMotivoAtivacao(String motivoAtivacao) {
+		this.motivoAtivacao = motivoAtivacao;
+	}
+
 
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -51,6 +51,7 @@ import javax.persistence.criteria.Root;
 
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.DateUtils;
+import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.util.Texto;
 import br.gov.jfrj.siga.cp.CpAcesso;
 import br.gov.jfrj.siga.cp.CpConfiguracao;
@@ -73,6 +74,7 @@ import br.gov.jfrj.siga.cp.bl.SituacaoFuncionalEnum;
 import br.gov.jfrj.siga.cp.model.HistoricoAuditavel;
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorEnum;
 import br.gov.jfrj.siga.cp.model.enm.CpMarcadorFinalidadeEnum;
+import br.gov.jfrj.siga.cp.model.enm.CpMarcadorGrupoEnum;
 import br.gov.jfrj.siga.cp.model.enm.CpSituacaoDeConfiguracaoEnum;
 import br.gov.jfrj.siga.cp.model.enm.CpTipoDeConfiguracao;
 import br.gov.jfrj.siga.cp.model.enm.ITipoDeConfiguracao;
@@ -2813,19 +2815,12 @@ public class CpDao extends ModeloDao {
 		}
 	}
 
-	public Integer consultarQtdeDocCriadosPossePorDpLotacaoECpMarca(Long idLotacao) {
-		try {
-			Query sql = em().createNamedQuery("consultarQtdeDocCriadosPossePorDpLotacaoECpMarca");
-			sql.setParameter("idLotacao", idLotacao);
-			sql.setParameter("listMarcadores", Arrays.asList(
-					CpMarcadorEnum.RECOLHER_PARA_ARQUIVO_PERMANENTE.getId(),
-					CpMarcadorEnum.ARQUIVADO_INTERMEDIARIO.getId(),
-					CpMarcadorEnum.ARQUIVADO_PERMANENTE.getId()));
-			final int l = ((BigDecimal) sql.getSingleResult()).intValue();
-			return l;
-		} catch (final NullPointerException e) {
-			return null;
-		}
+	public Integer quatidadeMarcasEmPosseDaLotacaoMarcadores(DpLotacao lotacao, List<Long> marcadoresPermitidos) {
+		return quantidadeMarcasPorLotacaoMarcadores(lotacao, marcadoresPermitidos, false).intValue();
+	}
+	
+	public Integer quatidadeMarcasEmPosseDaPessoaMarcadores(DpPessoa pessoa, List<Long> marcadoresPermitidos) {		
+		return quantidadeMarcasPorPessoaMarcadores(pessoa, marcadoresPermitidos, false).intValue();
 	}
 	
 	public CpToken obterCpTokenPorTipoToken(final Long idTpToken, final String token) {
@@ -3071,29 +3066,62 @@ public class CpDao extends ModeloDao {
 		return sql.getResultList();
 	}
 
-
-	public Long qtdeMarcasMarcadorPessoa(DpPessoa pessoa, List<Long> marcadores) {
+	
+	/*
+	 * 
+	 * Conta quantas Marcas a Pessoa tem em Posse
+	 * 
+	 * Caso seja passada Lista de Marcadores, os Marcadores são contados ou retirados da contagem conforme parâmetro [contarComMarcadoresPresente]
+	 *         True: Contar Marcas que estejam com os Marcadores da Lista
+	 *         False: Contar Marcas com os Marcadores diferentes dos Marcadores da Lista
+	 */
+	public Long quantidadeMarcasPorPessoaMarcadores(DpPessoa pessoa, List<Long> marcadores, boolean contarComMarcadoresPresente) { 
 		CriteriaBuilder qb = em().getCriteriaBuilder();
 		CriteriaQuery<Long> cq = qb.createQuery(Long.class);
 		Root<CpMarca> c = cq.from(CpMarca.class);
 		cq.select(qb.count(c));
+		
 		Predicate predicateAnd;
-		Predicate predicateEqualPessoa  = cb().equal(c.get("dpPessoaIni"), pessoa);
-		Predicate predicateEqualMarca  = cb().and(c.get("cpMarcador").in(marcadores));
-		predicateAnd = cb().and(predicateEqualPessoa, predicateEqualMarca);
+		Predicate predicateEqualPessoa  = cb().equal(c.get("dpPessoaIni"), pessoa.getPessoaInicial());
+		Predicate predicateMarcadores = null;
+		
+		if (marcadores != null && !marcadores.isEmpty()) {
+			if (contarComMarcadoresPresente)
+				predicateMarcadores  = cb().and(c.get("cpMarcador").in(marcadores));
+			else
+				predicateMarcadores  = cb().and(cb().not(c.get("cpMarcador").in(marcadores)));
+		}
+		
+		predicateAnd = cb().and(predicateEqualPessoa, predicateMarcadores);
 		cq.where(predicateAnd);
 		return em().createQuery(cq).getSingleResult();
 	}
 	
-	public Long qtdeMarcasMarcadorLotacao(DpLotacao lotacao, List<Long> marcadores) {
+	/*
+	 * 
+	 * Conta quantas Marcas a Lotação tem em Posse
+	 * 
+	 * Caso seja passada Lista de Marcadores, os Marcadores são contados ou retirados da contagem conforme parâmetro [contarComMarcadoresPresente]
+	 *         True: Contar Marcas que estejam com os Marcadores da Lista
+	 *         False: Contar Marcas com os Marcadores diferentes dos Marcadores da Lista
+	 */
+	public Long quantidadeMarcasPorLotacaoMarcadores(DpLotacao lotacao, List<Long> marcadores, boolean contarComMarcadoresPresente) {
 		CriteriaBuilder qb = em().getCriteriaBuilder();
 		CriteriaQuery<Long> cq = qb.createQuery(Long.class);
 		Root<CpMarca> c = cq.from(CpMarca.class);
 		cq.select(qb.count(c));
 		Predicate predicateAnd;
-		Predicate predicateEqualLotacao  = cb().equal(c.get("dpLotacaoIni"), lotacao);
-		Predicate predicateEqualMarca  = cb().and(c.get("cpMarcador").in(marcadores));
-		predicateAnd = cb().and(predicateEqualLotacao, predicateEqualMarca);
+		Predicate predicateEqualLotacao  = cb().equal(c.get("dpLotacaoIni"), lotacao.getLotacaoInicial());
+		Predicate predicateMarcadores = null;
+		
+		if (marcadores != null && !marcadores.isEmpty()) {
+			if (contarComMarcadoresPresente)
+				predicateMarcadores  = cb().and(c.get("cpMarcador").in(marcadores));
+			else
+				predicateMarcadores  = cb().and(cb().not(c.get("cpMarcador").in(marcadores)));
+		}
+		
+		predicateAnd = cb().and(predicateEqualLotacao, predicateMarcadores);
 		cq.where(predicateAnd);
 		return em().createQuery(cq).getSingleResult();
 	}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -3090,9 +3090,12 @@ public class CpDao extends ModeloDao {
 				predicateMarcadores  = cb().and(c.get("cpMarcador").in(marcadores));
 			else
 				predicateMarcadores  = cb().and(cb().not(c.get("cpMarcador").in(marcadores)));
+			
+			predicateAnd = cb().and(predicateEqualPessoa, predicateMarcadores);
+		} else {
+			predicateAnd = predicateEqualPessoa;
 		}
 		
-		predicateAnd = cb().and(predicateEqualPessoa, predicateMarcadores);
 		cq.where(predicateAnd);
 		return em().createQuery(cq).getSingleResult();
 	}
@@ -3119,9 +3122,12 @@ public class CpDao extends ModeloDao {
 				predicateMarcadores  = cb().and(c.get("cpMarcador").in(marcadores));
 			else
 				predicateMarcadores  = cb().and(cb().not(c.get("cpMarcador").in(marcadores)));
+			
+			predicateAnd = cb().and(predicateEqualLotacao, predicateMarcadores);
+		} else {
+			predicateAnd = predicateEqualLotacao;
 		}
 		
-		predicateAnd = cb().and(predicateEqualLotacao, predicateMarcadores);
 		cq.where(predicateAnd);
 		return em().createQuery(cq).getSingleResult();
 	}

--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V132_0__motivo-inativacao-ativacao-lotacao.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V132_0__motivo-inativacao-ativacao-lotacao.sql
@@ -1,0 +1,12 @@
+-- Adicionado 2 campos para Persistência do Motivo da Inativação e Ativação. 
+-- Campos são separados devido a estrutura de versionamento permitir Ativar com Motivo e com a mesma linha Inativar com Motivo adicionando 
+
+
+ALTER TABLE CORPORATIVO.DP_LOTACAO 
+ADD (MOTIVO_INATIVACAO VARCHAR2(500));
+
+ALTER TABLE CORPORATIVO.DP_LOTACAO 
+ADD (MOTIVO_ATIVACAO VARCHAR2(500));
+
+COMMENT ON COLUMN CORPORATIVO.DP_LOTACAO.MOTIVO_INATIVACAO IS 'Armazena o motivo da Inativação da Lotação';
+COMMENT ON COLUMN CORPORATIVO.DP_LOTACAO.MOTIVO_ATIVACAO IS 'Armazena o motivo da Ativação da Lotação';

--- a/siga-cp/src/main/resources/db/mysql/sigacp/V132.0__motivo-inativacao-ativacao-lotacao.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V132.0__motivo-inativacao-ativacao-lotacao.sql
@@ -1,0 +1,6 @@
+-- Adicionado 2 campos para Persistência do Motivo da Inativação e Ativação. 
+-- Campos são separados devido a estrutura de versionamento permitir Ativar com Motivo e com a mesma linha Inativar com Motivo adicionando 
+
+ALTER TABLE `corporativo`.`dp_lotacao`
+ADD COLUMN `MOTIVO_INATIVACAO` VARCHAR(500) NULL `IS_SUSPENSA`,
+ADD COLUMN `MOTIVO_ATIVACAO` VARCHAR(500) NULL `MOTIVO_INATIVACAO`;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -55,7 +55,7 @@ public class Mesa2 {
 		public boolean grupoHide;
 		public boolean grupoAtingiuLimite;
 		public List<MesaItem> grupoDocs;
-		public List<Integer> grupoMarcadores;
+		public List<Long> grupoMarcadores;
 	}
 	
 	public static class MesaItem implements ISwaggerModel {
@@ -447,7 +447,7 @@ public class Mesa2 {
 						grpItem.grupoQtdLota = 15L;
 					}
 					grpItem.grupoHide = gEnum.isHide();
-					grpItem.grupoMarcadores = CpMarcadorEnum.getListIdByGrupo(gEnum.getNome());
+					grpItem.grupoMarcadores = CpMarcadorEnum.getListIdByGrupo(gEnum);
 					gruposBase.add(grpItem);
 				}
 			}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2Ant.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2Ant.java
@@ -58,7 +58,7 @@ public class Mesa2Ant {
 		public boolean grupoHide;
 		public boolean grupoAtingiuLimite;
 		public List<MesaItem> grupoDocs;
-		public List<Integer> grupoMarcadores;
+		public List<Long> grupoMarcadores;
 	}
 	
 	public static class MesaItem implements ISwaggerModel {
@@ -542,7 +542,7 @@ public class Mesa2Ant {
 					}
 					grpItem.grupoQtdPag = 15L;
 					grpItem.grupoHide = gEnum.isHide();
-					grpItem.grupoMarcadores = CpMarcadorEnum.getListIdByGrupo(gEnum.getNome());
+					grpItem.grupoMarcadores = CpMarcadorEnum.getListIdByGrupo(gEnum);
 					gruposBase.add(grpItem);
 				}
 			}

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -52,7 +52,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	public DpLotacaoController() {
 		super();
 	}
-
+ 
 	@Inject
 	public DpLotacaoController(HttpServletRequest request, Result result, CpDao dao, SigaObjects so, EntityManager em) {
 		super(request, result, dao, so, em);
@@ -405,46 +405,67 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 				nmLotacao, idOrgaoUsu, siglaLotacao, situacao, isExternaLotacao, lotacaoPai, idLocalidade);
 		this.result.redirectTo(this).lista(0, idOrgaoUsu, siglaLotacao);
 	}
-
-	@Transacional
-	@Post("/app/lotacao/ativarInativar")
-	public void ativarInativar(final Long id) throws Exception {
+		
+	@Get("/app/lotacao/ativar")
+	public void ativar(final Long id) throws Exception {
 		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
 
-		// ativar
-		if (lotacao.getDataFimLotacao() != null && !"".equals(lotacao.getDataFimLotacao())) {
+		if (Cp.getInstance().getBL().podeAtivarLotacao(lotacao, getTitular())) {
+			result.include("lotacao",lotacao);
+		} 
+	}
+	
+	@Get("/app/lotacao/inativar")
+	public void inativar(final Long id) throws Exception {
+		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
+		
+		if (Cp.getInstance().getBL().podeInativarLotacao(lotacao, getTitular())) {
+			result.include("lotacao",lotacao);
+		}	
+	}
+	
+	@Transacional
+	@Post("/app/lotacao/ativar_gravar")
+	public void ativarGravar(final Long id, final String motivo) throws Exception {	
+		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
+		
+		if (Cp.getInstance().getBL().podeAtivarLotacao(lotacao, getTitular())) {
 			DpLotacao lotacaoNova = new DpLotacao();
 			lotacao.setDataFimLotacao(null);
-			Cp.getInstance().getBL().copiaLotacao(lotacao, lotacaoNova);
-			dao().gravarComHistorico(lotacaoNova, lotacao, null, getIdentidadeCadastrante());
-		} else {// inativar
-			Integer qtdePessoa = CpDao.getInstance().pessoasPorLotacao(id, Boolean.TRUE, Boolean.FALSE).size();
-			Integer qtdeDocumentoCriadosPosse = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
+			try {
+				Cp.getInstance().getBL().copiaLotacao(lotacao, lotacaoNova);
+				lotacao.setMotivoAtivacao(motivo);
+				
+				dao().gravarComHistorico(lotacaoNova, lotacao, null, getIdentidadeCadastrante());
+				
+				this.result.redirectTo(this).lista(0, lotacao.getIdOrgaoUsuario(), "");
+			} catch (final Exception e) {
+				throw new AplicacaoException("Erro na gravação", 0, e);
+			}
+		}	
+		
+	}
+	
+	@Transacional
+	@Post("/app/lotacao/inativar_gravar")
+	public void inativarGravar(final Long id, final String motivo) throws Exception {
+		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);		
 
-			if (qtdePessoa > 0 || qtdeDocumentoCriadosPosse > 0) {
-				throw new AplicacaoException("Inativação não permitida. Existem documentos e usuários vinculados nessa "
-						+ SigaMessages.getMessage("usuario.lotacao"), 0);
-			} else if (dao().listarLotacoesPorPai(lotacao).size() > 0) {
-				throw new AplicacaoException(
-						"Inativação não permitida. Está " + SigaMessages.getMessage("usuario.lotacao")
-								+ " é pai de outra " + SigaMessages.getMessage("usuario.lotacao"),
-						0);
-			} else {
-				Calendar calendar = new GregorianCalendar();
-				Date date = new Date();
-				calendar.setTime(date);
-				lotacao.setDataFimLotacao(calendar.getTime());
+		if (Cp.getInstance().getBL().podeInativarLotacao(lotacao, getTitular())) {
 
-				try {
-					dao().gravarComHistorico(lotacao, getIdentidadeCadastrante());
-				} catch (final Exception e) {
-					throw new AplicacaoException("Erro na gravação", 0, e);
-				}
+			lotacao.setDataFimLotacao(dao.consultarDataEHoraDoServidor());
+			lotacao.setMotivoInativacao(motivo);
+
+			try {
+				dao().gravarComHistorico(lotacao, getIdentidadeCadastrante());
+				this.result.redirectTo(this).lista(0, lotacao.getIdOrgaoUsuario(), "");
+			} catch (final Exception e) {
+				throw new AplicacaoException("Erro na gravação", 0, e);
 			}
 		}
-		this.result.redirectTo(this).lista(0, lotacao.getIdOrgaoUsuario(), lotacao.getSiglaLotacao());
-	}
 
+	}
+	
 	@Transacional
 	@Post("/app/lotacao/suspender")
 	public void suspender(final Long id) throws Exception {
@@ -579,25 +600,6 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
     protected List<DpLotacao> carregaLotacao(CpOrgaoUsuario orgaoUsuario) {
         CpOrgaoUsuario u = CpDao.getInstance().consultarOrgaoUsuarioPorId(orgaoUsuario.getIdOrgaoUsu());
         return (List<DpLotacao>) CpDao.getInstance().consultarLotacaoPorOrgao(u);
-    }
-
-
-    /**
-     * Consulta quantidade de documentos criados que estão em posse da lotação
-     *
-     * @param lotacao
-     * @return
-     */
-    private Integer consultarQtdeDocumentoCriadosPosse(DpLotacao lotacao) {
-
-        Integer qtdeDocumentoCriadosPosse;
-
-        if (Prop.getBool("/siga.lotacao.inativacao.marcadores.permitidos"))
-            qtdeDocumentoCriadosPosse = dao().consultarQtdeDocCriadosPossePorDpLotacaoECpMarca(lotacao.getIdInicial());
-        else
-            qtdeDocumentoCriadosPosse = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
-
-        return qtdeDocumentoCriadosPosse;
     }
 
 }

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/ativar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/ativar.jsp
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<%@ page language="java" contentType="text/html; charset=UTF-8" buffer="64kb"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+
+
+<siga:pagina titulo="Ativar">
+
+	<script type="text/javascript">
+		function sbmt() {
+			document.getElementById("btnOk").disabled = true;
+			if (validaMotivo()) {
+				sigaModal.abrir('confirmacaoModal');		
+			}
+		}
+		
+        function confirmar() {
+            sigaSpinner.mostrar();
+            sigaModal.fechar('confirmacaoModal');
+            document.frm.submit();
+        }
+        
+        function cancelar() {
+        	document.getElementById("btnOk").disabled = false;
+            sigaModal.fechar('confirmacaoModal');
+            window.location.href = '/siga/app/lotacao/listar?idOrgaoUsu='+ ${lotacao.orgaoUsuario.idOrgaoUsu};
+        }
+
+		function validaMotivo() {
+			var motivo = document.getElementById("motivo").value;
+			if (motivo.length > 500) {
+				document.getElementById("btnOk").disabled = false;
+				sigaModal.alerta('Motivo com mais de 500 caracteres');
+				
+				return false;
+			}
+			return true;
+		}
+	</script>
+	
+	<div class="container-fluid">
+		<div class="card bg-light mb-3">
+			<div class="card-header">
+				<h5>Ativar <fmt:message key="usuario.lotacao"/> - ${lotacao.sigla}</h5>
+			</div>
+			<div class="card-body">
+				<form name="frm" action="/siga/app/lotacao/ativar_gravar" method="post">
+					<input type="hidden" name="postback" value="1" />
+					<input type="hidden" name="id" value="${lotacao.id}" />
+					<div class="form-group row">
+						<div class="col-12 col-md-6">
+							<p><strong>Informações de ativação</strong></p>
+							<label for="motivo">Motivo</label>
+							<textarea placeholder="Preencher o campo com o motivo da ativação" class="form-control" name="motivo" id="motivo" cols="60" rows="2"></textarea>
+						</div>
+					</div>
+					<div class="form-group row">
+						<div class="col-12 col-md-6">
+							<input type="button" id="btnOk" value="Ok" class="btn btn-primary" onclick="sbmt();"/>
+							<input type="button" value="Cancela" onclick="cancelar();" class="btn btn-link ml-2" />
+						</div>
+					</div>
+
+					
+					<siga:siga-modal id="confirmacaoModal" exibirRodape="false" tituloADireita="Confirmação">
+						<div id="msg" class="modal-body">
+				       		Deseja ativar cadastro selecionado?
+				     	</div>
+				     	<div class="modal-footer">
+				       		<button type="button" class="btn btn-danger" data-dismiss="modal" onclick="cancelar();">Não</button>		        
+				       		<a href="#" class="btn btn-success btn-confirmacao" role="button" aria-pressed="true" onclick="confirmar();">Sim</a>
+						</div>
+					</siga:siga-modal>
+				</form>
+			</div>
+		</div>
+	</div>
+</siga:pagina>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/inativar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/inativar.jsp
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<%@ page language="java" contentType="text/html; charset=UTF-8" buffer="64kb"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+
+
+<siga:pagina titulo="Inativar">
+
+	<script type="text/javascript">
+		function sbmt() {
+			document.getElementById("btnOk").disabled = true;
+			if (validaMotivo()) {
+				sigaModal.abrir('confirmacaoModal');		
+			}
+		}
+		
+        function confirmar() {
+            sigaSpinner.mostrar();
+            sigaModal.fechar('confirmacaoModal');
+            document.frm.submit();
+        }
+        
+        function cancelar() {
+        	document.getElementById("btnOk").disabled = false;
+            sigaModal.fechar('confirmacaoModal');
+            window.location.href = '/siga/app/lotacao/listar?idOrgaoUsu='+ ${lotacao.orgaoUsuario.idOrgaoUsu};
+        }
+
+		function validaMotivo() {
+			var motivo = document.getElementById("motivo").value;
+			if (motivo.length > 500) {
+				document.getElementById("btnOk").disabled = false;
+				sigaModal.alerta('Motivo com mais de 500 caracteres');
+				
+				return false;
+			}
+			return true;
+		}
+	</script>
+	
+	<div class="container-fluid">
+		<div class="card bg-light mb-3">
+			<div class="card-header">
+				<h5>Inativar <fmt:message key="usuario.lotacao"/> - ${lotacao.sigla}</h5>
+			</div>
+			<div class="card-body">
+				<form name="frm" action="/siga/app/lotacao/inativar_gravar" method="post">
+					<input type="hidden" name="postback" value="1" />
+					<input type="hidden" name="id" value="${lotacao.id}" />
+					<div class="form-group row">
+						<div class="col-12 col-md-6">
+							<p><strong>Informações de Inativação</strong></p>
+							<label for="motivo">Motivo</label>
+							<textarea placeholder="Preencher o campo com o motivo da Inativação" class="form-control" name="motivo" id="motivo" cols="60" rows="2"></textarea>
+						</div>
+					</div>
+					<div class="form-group row">
+						<div class="col-12 col-md-6">
+							<input type="button" id="btnOk" value="Ok" class="btn btn-primary" onclick="sbmt();"/>
+							<input type="button" value="Cancela" onclick="cancelar();" class="btn btn-link ml-2" />
+						</div>
+					</div>
+
+					
+					<siga:siga-modal id="confirmacaoModal" exibirRodape="false" tituloADireita="Confirmação">
+						<div id="msg" class="modal-body">
+				       		Deseja inativar cadastro selecionado?
+				     	</div>
+				     	<div class="modal-footer">
+				       		<button type="button" class="btn btn-danger" data-dismiss="modal" onclick="cancelar();">Não</button>		        
+				       		<a href="#" class="btn btn-success btn-confirmacao" role="button" aria-pressed="true" onclick="confirmar();">Sim</a>
+						</div>
+					</siga:siga-modal>
+				</form>
+			</div>
+		</div>
+	</div>
+</siga:pagina>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
@@ -94,9 +94,7 @@ function sbmt(offset) {
 							<c:url var="url" value="/app/lotacao/editar">
 								<c:param name="id" value="${lotacao.id}"></c:param>
 							</c:url>
-							<c:url var="urlAtivarInativar" value="/app/lotacao/ativarInativar">
-								<c:param name="id" value="${lotacao.id}"></c:param>
-							</c:url>
+
 							<c:url var="urlSuspender" value="/app/lotacao/suspender">
 								<c:param name="id" value="${lotacao.id}"></c:param>
 							</c:url>
@@ -104,14 +102,21 @@ function sbmt(offset) {
 							<div class="btn-group">								  
 							  <c:choose>
 								<c:when test="${empty lotacao.dataFimLotacao}">
-									<a href="${urlAtivarInativar}" onclick='javascript:atualizarUrl("javascript:submitPost(\"${urlAtivarInativar}\")","Deseja inativar o cadastro selecionado?");return false;' class="btn btn-primary" role="button" 
-										aria-pressed="true" data-siga-modal-abrir="confirmacaoModal" style="min-width: 80px;">Inativar</a>
+									<c:url var="urlAtivarInativar" value="/app/lotacao/inativar">
+										<c:param name="id" value="${lotacao.id}"></c:param>
+									</c:url>
+									
+									<a href="${urlAtivarInativar}" class="btn btn-primary" role="button" aria-pressed="true" style="min-width: 80px;">Inativar</a>
 									<button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 									    <span class="sr-only"></span>
 								    </button>
 								</c:when>
 								<c:otherwise>
-									<a href="javascript:submitPost('${urlAtivarInativar}')" class="btn btn-danger" role="button" aria-pressed="true" style="min-width: 80px;">Ativar</a>
+									<c:url var="urlAtivarInativar" value="/app/lotacao/ativar">
+										<c:param name="id" value="${lotacao.id}"></c:param>
+									</c:url>
+									
+									<a href="${urlAtivarInativar}" class="btn btn-danger" role="button" aria-pressed="true" style="min-width: 80px;">Ativar</a>
 									<button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 									    <span class="sr-only"></span>
 								    </button>
@@ -149,7 +154,7 @@ function sbmt(offset) {
 		</table>				
 		<div class="gt-table-buttons">
 			<c:url var="url" value="/app/lotacao/editar"></c:url>
-			<c:url var="urlAtivarInativar" value="/app/lotacao/ativarInativar"></c:url>
+			<c:url var="urlAtivarInativar" value="/app/lotacao/inativar"></c:url>
 			<input type="button" value="Incluir" onclick="javascript:window.location.href='${url}'" class="btn btn-primary">
 		</div>				
 		</form>


### PR DESCRIPTION
**Refactor do Pull Request: https://github.com/projeto-siga/siga/pull/2213**
*PR foi refeito para contemplar outras regras e organizar os métodos de contagem de Marcas

### Funcionalidade de Inativação de Lotações por Documentos em Posse em Determinadas Situações (Marcas)

**Objetivo:**

> Permitir que Unidade com documentos nos status de Cancelado e Sem Efeito, seja inativada.

**Situação Atual**

Hoje o sistema permite inativar lotações caso ainda não tenham produzidos documentos ou caso estivesse habilitada a propriedade "siga.lotacao.inativacao.marcadores.permitidos" (implementação do MTI https://github.com/projeto-siga/siga/pull/2105) o sistema permitir inativar Lotações sem documentos criados e com os documentos em Posse com as situações:

- RECOLHER_PARA_ARQUIVO_PERMANENTE
- ARQUIVADO_INTERMEDIARIO
- ARQUIVADO_PERMANENTE

**Adequações**

Foi reaproveitada a funcionalidade existente feita pelo MTI, porém com as seguintes alterações:

- Property siga.lotacao.inativacao.marcadores.permitidos alterada de boolean para uma lista de chaves do ENUM CpMarcador.
- Query alterada para retirar a cláusula de filtro da criação de documentos, ou seja, não importando mais se a Lotação já criou documentos, importa só se há documentos sob posse com a lotação que não está na lista da property acima.

Conforme solicitado, criado dois campos para armazenamento do Motivo da Inativação e Motivo da Ativação. São dois campos para prever que a unidade pode ter sido reativada sob um motivo e desativada novamente sob outro motivo.

Observação para o **MTI**: O default da property foi alterado para NULL pra permitir ligar e desligar. Deve-se cadastrar a property
siga.lotacao.inativacao.marcadores.permitidos com os seguintes valores para ter o mesmo comportamento desenvolvido anteriormente: **RECOLHER_PARA_ARQUIVO_PERMANENTE,ARQUIVADO_INTERMEDIARIO,ARQUIVADO_PERMANENTE**

### Níveis de Contagem para Inativação

Foram estabelecidos 4 níveis de permissão para Inativação de Lotações com Marcas (Documentos vinculados) 


**1. Sem Bloqueio de Marcas:**

Ao cadastrar a Property com * NÃO haverá restrição para inativar a Lotação, pois o Wildcard * permite inativar com qualquer marcador, tanto para pessoa quanto para a Lotação

        <property name="siga.lotacao.inativacao.marcadores.permitidos" value="*"/>


**2. Com Marcadores Permitidos:** 
Ao cadastrar a Property siga.lotacao.inativacao.marcadores.permitidos com os Marcadores permitidos separado por vírgula, o sistema contará para Lotação e para as pessoas inativas associadas a Lotação quantas marcas há vinculadas exceto a especificada. 
Somada a lista acima, incluí-se por default o Grupo de Marcadores NENHUM, para desconsiderar documentos que não são apresentados na Mesa Virtual. Para cadastrar outro grupo, sobrescrever a property com a lista separada por vírgula:
siga.lotacao.inativacao.grupo.marcadores.permitidos

Ex.: 
```
        <property name="siga.lotacao.inativacao.marcadores.permitidos" value="CANCELADO,SEM_EFEITO"/>
              +
        <property name="siga.lotacao.inativacao.grupo.marcadores.permitidos" value="NENHUM,AGUARDANDO_ACAO_DE_TEMPORALIDADE"/>
```

**3. Com listas vazias:**

        <property name="siga.lotacao.inativacao.marcadores.permitidos" value=""/>
        <property name="siga.lotacao.inativacao.grupo.marcadores.permitidos" value=""/>

Usa contador considerando TODAS as marcas, mas não desvia para consulta que leva em consideração os documentos cadastrados pela Lotação.


**4. Com Bloqueio Total:** 

Caso a Lotação já tenha criado documentos ou possui marcas atribuídas, não será permitido.
Essa é a situação DEFAULT:
siga.lotacao.inativacao.marcadores.permitidos = NULL

**Telas e Fluxo**

Na tela de Listagem das Lotações, clicar no botão inativar
![image](https://user-images.githubusercontent.com/20362170/208747497-eaa55e7a-a4d1-4d4d-a546-2d878b12cc4a.png)

Caso contenha Documentos com outras situações (marcadores) OU Pessoas Ativas OU Lotações "filhas" OU marcas para Pessoas Inativas da Lotação, deve ser tratado antes de inativar conforme warning apresentado:
![image](https://user-images.githubusercontent.com/20362170/208748580-7ebf7c1a-4d8a-44c0-b4c7-ebc6545fb5a5.png)

Caso não contenha pessoas ativas ou somente documentos em posse com os marcadores que seguem as regras parametrizadas, abre a tela para informar o motivo:
![image](https://user-images.githubusercontent.com/20362170/208750839-50332cd5-056d-4bf2-96c5-949649350fcb.png)
![image](https://user-images.githubusercontent.com/20362170/208751092-e19a1c7b-4051-47a6-84da-ed0a6543d486.png)
![image](https://user-images.githubusercontent.com/20362170/208752708-664cb906-bead-4676-adce-90f29b2359c0.png)
![image](https://user-images.githubusercontent.com/20362170/208752815-3c5746d5-6a3a-4d7f-a65c-2d58cd595351.png)
Caso não seja confirmado, usuário retornará para tela de consulta.
Caso seja confirmado, retornará para tela de consulta com status de Extinta:
![image](https://user-images.githubusercontent.com/20362170/208753352-9de6de2d-4ea6-46af-910e-5fe3502979b8.png)

É possível executar o mesmo processo para ativação da Lotação:
![image](https://user-images.githubusercontent.com/20362170/208753770-d0f9c82b-029f-48a2-8d65-1d65489d2d7a.png)
![image](https://user-images.githubusercontent.com/20362170/208753809-d30d8cef-70ea-4aa6-817e-ff5804f7c8ae.png)







