### PR TITLE
Melhoria Definição de Acompanhamento Evitando a inclusão duplicada do mesmo usuário diversas vezes - RM140510

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5721,6 +5721,21 @@ public class ExBL extends CpBL {
 			final Date dtMov, DpLotacao lotaResponsavel, final DpPessoa responsavel, final DpPessoa subscritor,
 			final DpPessoa titular, final String descrMov, String nmFuncaoSubscritor, ExPapel papel)
 			throws AplicacaoException {
+		List<ExMovimentacao> movs = mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.VINCULACAO_PAPEL, true);
+		StringBuilder msg = new StringBuilder();
+		movs.forEach(m -> {
+			if(responsavel != null && responsavel.equals(m.getSubscritor()) && papel.equals(m.getExPapel())) {
+				msg.append("Usuário ").append(m.getSubscritor().getNomePessoa()).append(" já foi definido");
+			} else {
+				if(responsavel == null && m.getSubscritor() == null && lotaResponsavel.equals(m.getLotaSubscritor()) && papel.equals(m.getExPapel())) {
+					msg.append("Unidade ").append(m.getLotaSubscritor().getNomeLotacao()).append(" já foi definida");
+				}
+			};
+			if (msg.length() > 0 ) {
+				msg.append(" como ").append(papel.getDescPapel()).append(" no acompanhamento do documento ").append(mob.getDnmSigla());
+				throw new AplicacaoException(msg.toString());
+			}
+		});
 		vincularPapel(cadastrante, lotaCadastrante, mob, dtMov, lotaResponsavel, 
 				responsavel, subscritor, titular, descrMov, nmFuncaoSubscritor, papel, null);
 	}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5730,7 +5730,7 @@ public class ExBL extends CpBL {
 				if(responsavel == null && m.getSubscritor() == null && lotaResponsavel.equals(m.getLotaSubscritor()) && papel.equals(m.getExPapel())) {
 					msg.append("Unidade ").append(m.getLotaSubscritor().getNomeLotacao()).append(" já foi definida");
 				}
-			};
+			}
 			if (msg.length() > 0 ) {
 				msg.append(" como ").append(papel.getDescPapel()).append(" no acompanhamento do documento ").append(mob.getDnmSigla());
 				throw new AplicacaoException(msg.toString());


### PR DESCRIPTION
### **Descrição**

Melhorar o processo na definição de acompanhamento evitando a inclusão duplicada do mesmo usuário diversas vezes no mesmo documento na definição de acompanhamento.

### **Prints Abaixo:**

![image](https://user-images.githubusercontent.com/15185675/209673933-88d62843-2efc-4fbb-9650-658fc88db496.png)

-----------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/209674392-095a0631-ee82-4d1c-8875-b69d3ee91b6f.png)

-----------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/209674097-812bc9f7-51a7-4649-b82d-83e8c841be99.png)

-----------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/209674190-9596e694-e74f-448a-92b1-143e71391ba8.png)

-----------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/209674550-9c040b45-679b-4858-9d21-95b2e95eac03.png)







