### PR TITLE
RM144138 - Bloqueio de Posse de Documentos Alteração de Lotação de Pessoa dentro do mesmo Órgão

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -345,5 +345,10 @@ public class Prop {
 		 * É ligada caso property siga.lotacao.inativacao.marcadores.permitidos seja diferente de null e soma-se as listas
 		 * Default: Documentos não apresentados na Mesa.*/
 		provider.addPublicProperty("/siga.lotacao.inativacao.grupo.marcadores.permitidos", "NENHUM");
+		
+		/* Permite Alterar a lotação da Pessoa com determinadas marcações*/
+		provider.addPublicProperty("/siga.alteracao.lotacao.pessoa.marcadores.permitidos", get("/siga.lotacao.inativacao.marcadores.permitidos"));
+		provider.addPublicProperty("/siga.alteracao.lotacao.pessoa.grupo.marcadores.permitidos", get("/siga.lotacao.inativacao.grupo.marcadores.permitidos"));
+		
 	}
 }

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -2241,7 +2241,7 @@ public class CpBL {
 			DpLotacao lotacao, DpLotacao lotacaoNova, Date dataSistema) {
 		List<DpPessoa> listPessoa = CpDao.getInstance().pessoasPorLotacao(idLotacao, Boolean.TRUE, Boolean.FALSE);
 		
-		Integer qtdeDocumentoCriadosPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, Boolean.FALSE); // Não restringe Marcadores
+		Integer qtdeDocumentoCriadosPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, null, Boolean.FALSE); // Não restringe Marcadores
 		
 		if(!Cp.getInstance().getConf().podeUtilizarServicoPorConfiguracao(titular, lotaTitular,"SIGA;GI;CAD_LOTACAO;ALT") && qtdeDocumentoCriadosPosse > 0 && 
 				(!lotacao.getNomeLotacao().equalsIgnoreCase(Texto.removerEspacosExtra(nmLotacao).trim()) || !lotacao.getSiglaLotacao().equalsIgnoreCase(siglaLotacao.toUpperCase().trim()))) {
@@ -2615,10 +2615,9 @@ public class CpBL {
      * @param lotacao
      * @return
      */
-	public Integer quatidadeMarcasOuDocumentosEmPosseDaLotacao(DpLotacao lotacao, boolean excluirMarcadoresDaContagem) { 
+	public Integer quatidadeMarcasOuDocumentosEmPosseDaLotacao(DpLotacao lotacao, List<Long> listaMarcadores, boolean excluirMarcadoresDaContagem) { 
 
 		Integer quantidade;
-		List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
 
         if (excluirMarcadoresDaContagem && listaMarcadores != null)
         	quantidade = CpDao.getInstance().quatidadeMarcasEmPosseDaLotacaoMarcadores(lotacao,listaMarcadores);
@@ -2632,13 +2631,12 @@ public class CpBL {
     /**
      * Consulta quantidade de documentos criados OU que estão em posse da lotação, conforme parâmetros e propriedades
      *
-     * @param lotacao
+     * @param pessoa
      * @return
      */
-	public Integer quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(DpPessoa pessoa, boolean excluirMarcadoresDaContagem) { 
+	public Integer quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(DpPessoa pessoa, List<Long> listaMarcadores, boolean excluirMarcadoresDaContagem) { 
 
 		Integer quantidade;		
-        List<Long> listaMarcadores = getListaMarcadoresPermitidosInativacaoLotacao();
 
         if (excluirMarcadoresDaContagem && listaMarcadores != null)
         	quantidade = CpDao.getInstance().quatidadeMarcasEmPosseDaPessoaMarcadores(pessoa,listaMarcadores);
@@ -2651,6 +2649,14 @@ public class CpBL {
 	public boolean restringeMarcadoresParaInativacaoLotacao() {
 		final String TODOS_MARCADORES = "*";
 		final String marcadoresPermitidos = Prop.get("/siga.lotacao.inativacao.marcadores.permitidos");
+		
+		return !TODOS_MARCADORES.equals(marcadoresPermitidos);
+		
+	}
+	
+	public boolean restringeMarcadoresParaAlteracaoLotacaoPessoa() {
+		final String TODOS_MARCADORES = "*";
+		final String marcadoresPermitidos = Prop.get("/siga.alteracao.lotacao.pessoa.marcadores.permitidos");
 		
 		return !TODOS_MARCADORES.equals(marcadoresPermitidos);
 		
@@ -2669,6 +2675,35 @@ public class CpBL {
 	        
 	        if (listaMarcadores != null) {
 		        listaGrupoMarcadores = Prop.getList("/siga.lotacao.inativacao.grupo.marcadores.permitidos");
+		        listaMarcadoresPermitidos = CpMarcadorEnum.getListIdByListChaves(listaMarcadores);
+		        
+				//Soma-se aos Marcadores Permitidos os marcadores relacionados aos grupos definidos
+				if (!listaGrupoMarcadores.isEmpty()) {
+					for (String grupo : listaGrupoMarcadores) {
+						if (!"".equals(grupo)) {
+							listaMarcadoresPermitidos.addAll(CpMarcadorEnum.getListIdByGrupo(CpMarcadorGrupoEnum.valueOf(grupo.trim())));
+						}			
+					}			
+				}
+	        }
+		}
+			
+		return listaMarcadoresPermitidos;
+		
+	}
+	
+	public List<Long> getListaMarcadoresPermitidosAlteracaoLotacaoPessoa() {
+
+        List<String> listaMarcadores = null;
+        List<String> listaGrupoMarcadores = null;
+        List<Long> listaMarcadoresPermitidos = null;
+		
+		if (restringeMarcadoresParaAlteracaoLotacaoPessoa()) {
+			
+	        listaMarcadores = Prop.getList("/siga.alteracao.lotacao.pessoa.marcadores.permitidos");
+	        
+	        if (listaMarcadores != null) {
+		        listaGrupoMarcadores = Prop.getList("/siga.alteracao.lotacao.pessoa.grupo.marcadores.permitidos");
 		        listaMarcadoresPermitidos = CpMarcadorEnum.getListIdByListChaves(listaMarcadores);
 		        
 				//Soma-se aos Marcadores Permitidos os marcadores relacionados aos grupos definidos
@@ -2717,7 +2752,8 @@ public class CpBL {
 		
 		if (restringeMarcadoresParaInativacaoLotacao()) {	
 			/* Verifica Quantidade de Marcas para Lotação */
-			Integer quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, Boolean.TRUE); 
+			List<Long> listaMarcadoresPermitidos = getListaMarcadoresPermitidosInativacaoLotacao();
+			Integer quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaLotacao(lotacao, listaMarcadoresPermitidos, Boolean.TRUE); 
 			if (quantidadeEmPosse > 0) {
 				throw new AplicacaoException("Inativação não permitida. Existem documentos vinculados nessa " + SigaMessages.getMessage("usuario.lotacao"), 0);
 				
@@ -2732,7 +2768,7 @@ public class CpBL {
 			
 			if (listaPessoasInativasDaLotacao != null && listaPessoasInativasDaLotacao.size() > 0 ) {
 				for (DpPessoa pessoa : listaPessoasInativasDaLotacao) {
-					quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(pessoa, Boolean.TRUE); 
+					quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(pessoa, listaMarcadoresPermitidos, Boolean.TRUE); 
 					if (quantidadeEmPosse > 0) {
 						throw new AplicacaoException("Inativação não permitida. Existem documentos de usuários inativos vinculados nessa " + SigaMessages.getMessage("usuario.lotacao"), 0);
 						
@@ -2745,7 +2781,7 @@ public class CpBL {
 	}
 	
 	public boolean podeAlterarLotacaoPessoaDentroMesmoOrgao(DpPessoa pessoa, DpPessoa cadastrante) {	
-		Integer quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(pessoa, Boolean.TRUE); 
+		Integer quantidadeEmPosse = quatidadeMarcasOuDocumentosEmPosseDaPessoaDaLotacao(pessoa, getListaMarcadoresPermitidosAlteracaoLotacaoPessoa(), Boolean.TRUE); 
 		if (quantidadeEmPosse > 0) {
 			return false; 
 		}	

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
@@ -27,7 +27,7 @@
 
 <script src="/siga/javascript/jquery/jquery-migrate-1.2.1.min.js" type="text/javascript"></script>
 
-<script src="/siga/javascript/siga.js?v=1654106630" type="text/javascript" charset="utf-8"></script>
+<script src="/siga/javascript/siga.js?v=1672155815" type="text/javascript" charset="utf-8"></script>
 
 <script src="/siga/javascript/picketlink.js" type="text/javascript" charset="utf-8"></script>
 

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -647,7 +647,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_PESSOA:Cadastrar Pessoa");
 		
 
-		DpPessoa pes = new CpBL().criarUsuario(id, getIdentidadeCadastrante(), idOrgaoUsu, idCargo, idFuncao, idLotacao, nmPessoa, dtNascimento, cpf, email, identidade,
+		new CpBL().criarUsuario(id, getIdentidadeCadastrante(), idOrgaoUsu, idCargo, idFuncao, idLotacao, nmPessoa, dtNascimento, cpf, email, identidade,
 				orgaoIdentidade, ufIdentidade, dataExpedicaoIdentidade, nomeExibicao, enviarEmail);
 
 

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/ativar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/ativar.jsp
@@ -12,6 +12,7 @@
 			document.getElementById("btnOk").disabled = true;
 			if (validaMotivo()) {
 				sigaModal.abrir('confirmacaoModal');		
+				sigaModal.reabilitarBotaoAposFecharModal('confirmacaoModal','btnOk');
 			}
 		}
 		

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/inativar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/inativar.jsp
@@ -11,7 +11,8 @@
 		function sbmt() {
 			document.getElementById("btnOk").disabled = true;
 			if (validaMotivo()) {
-				sigaModal.abrir('confirmacaoModal');		
+				sigaModal.abrir('confirmacaoModal');	
+				sigaModal.reabilitarBotaoAposFecharModal('confirmacaoModal','btnOk');
 			}
 		}
 		

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
@@ -6,7 +6,6 @@
 
 <script type="text/javascript">
 	function validar() {		
-		sigaSpinner.mostrar();
 		document.getElementById("btnOk").disabled = true;
 		var idOrgaoUsu = document.getElementsByName('idOrgaoUsu')[0].value;
 		var nmPessoa = document.getElementsByName('nmPessoa')[0].value;	
@@ -81,9 +80,23 @@
 		}
 			
 		document.getElementById("email").disabled = false
-		frm.submit();
+		
+		sigaModal.abrir('confirmacaoAlteracaoModal');
+		sigaModal.reabilitarBotaoAposFecharModal('confirmacaoAlteracaoModal','btnOk');
 	}
 			
+    function confirmarAlteracao() {
+        sigaSpinner.mostrar();
+        sigaModal.fechar('confirmacaoAlteracaoModal');
+        document.frm.submit();
+    }
+    
+    function cancelar() {
+    	document.getElementById("btnOk").disabled = false;
+        sigaModal.fechar('confirmacaoModal');
+    }
+	
+	
 	function habilitarBotaoOk() {		
 		sigaSpinner.ocultar();
 		document.getElementById("btnOk").disabled = false;
@@ -376,6 +389,15 @@
 							</div>
 						</div>
 					</c:if>
+					<siga:siga-modal id="confirmacaoAlteracaoModal" exibirRodape="false" tituloADireita="Confirmação">
+						<div id="msg" class="modal-body">
+				       		Deseja alterar cadastro?
+				     	</div>
+				     	<div class="modal-footer">
+				       		<button type="button" class="btn btn-danger" data-dismiss="modal" onclick="cancelar();">Não</button>		        
+				       		<a href="#" class="btn btn-success btn-confirmacao" role="button" aria-pressed="true" onclick="confirmarAlteracao();">Sim</a>
+						</div>
+					</siga:siga-modal>
 				</form>	
 			</div>
 		</div>					

--- a/siga/src/main/webapp/javascript/siga.js
+++ b/siga/src/main/webapp/javascript/siga.js
@@ -1678,6 +1678,21 @@ var sigaModal = {
 				return (typeof modal.data('bs.modal') !== 'undefined' && modal.data('bs.modal')._isShown);				
 			}
 		},
+		reabilitarBotaoAposFecharModal: function(idModal,botaoASerHabilitado) {
+		
+			if (idModal) {
+				var modal = $('#'.concat(idModal));
+				var botao = $('#'.concat(botaoASerHabilitado));
+				
+				if (botao.length > 0) {
+					modal.on('hidden.bs.modal', function (e) {
+						botao[0].disabled = false;			
+					});
+				}	
+			}
+
+		
+		},
 		obterCabecalhoPadrao: function(tituloADireita) {
 			if (typeof uriLogoSiga !== 'undefined') {
 				var detalheEsquerda = uriLogoSiga ? '<div class="col-6  p-0"><img src="' + uriLogoSiga + '" class="siga-modal__logo" alt="logo siga"></div>' : '<h5 class="modal-title">Siga</h5>';


### PR DESCRIPTION
Conforme requisito, na alteração da lotação da pessoa dentro do mesmo órgão, implementado o check da quantidade de documentos para a pessoa em determinada situação e que segue a mesma estrutura do PR https://github.com/projeto-siga/siga/pull/2217 onde é possível parametrizar quais marcas serão consideradas para não bloquear ou não a alteração da Lotação da Pessoa dentro do mesmo órgão.

Devido a falta de definição de conceitos, criada properties apartadas e segue como Default das propriedades o configurado para a Inativação de Lotação.

1. Sem Bloqueio: 
`<property name="siga.alteracao.lotacao.pessoa.marcadores.permitidos" value="*"/>`

2. Bloqueio Com Marcadores não impeditivos:
```
<property name="siga.alteracao.lotacao.pessoa.marcadores.permitidos" value="CANCELADO,SEM_EFEITO"/>
<property name="siga.alteracao.lotacao.pessoa.grupo.marcadores.permitidos" value="NENHUM,AGUARDANDO_ACAO_DE_TEMPORALIDADE"/>
```

3. Bloqueio Todos os Marcadores:
```
<property name="siga.alteracao.lotacao.pessoa.marcadores.permitidos" value=""/>
<property name="siga.alteracao.lotacao.pessoa.grupo.marcadores.permitidos" value=""/>
```

4. Com Bloqueio Total (Marcadores + Criação)
DEFAULT (Sem properties)


**Telas e Fluxo**

Ao alterar a Lotação mantendo o mesmo órgão:
![image](https://user-images.githubusercontent.com/20362170/209703776-0cd5c84a-df36-4778-9ec6-77c5c667c829.png)

É verificado a quantidade de Marcas o usuário possui, levando em consideração os parâmetros configurados com as properties acima.

![image](https://user-images.githubusercontent.com/20362170/209703903-cbbddac1-53e1-4d65-b763-01ca30b4f1ca.png)

Caso seja maior que 0 (Documentos considerados restritivos para a alteração), será impedido a alteração:
![image](https://user-images.githubusercontent.com/20362170/209710473-4450f7a1-7097-4e02-bf8f-5750b60ac712.png)
