### PR TITLE
#147082 - Corrige falha inativar registros

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpCargo.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpCargo.java
@@ -86,7 +86,6 @@ public abstract class AbstractDpCargo extends Objeto implements Serializable, Hi
 
 	@Temporal(TemporalType.TIMESTAMP)
 	@Column(name = "DT_FIM_CARGO", length = 19)
-    @Desconsiderar
 	private Date dataFimCargo;
 	
 	@Column(name = "SIGLA_CARGO", length = 30)

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpFuncaoConfianca.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpFuncaoConfianca.java
@@ -85,7 +85,6 @@ public abstract class AbstractDpFuncaoConfianca extends Objeto implements
 	/** Campos que geram versionamento de registro **/
 	@Temporal(TemporalType.TIMESTAMP)
 	@Column(name = "DT_FIM_FUNCAO_CONFIANCA", length = 19)
-    @Desconsiderar
 	private Date dataFimFuncao;
 	
 	@Column(name = "CATEGORIA_FUNCAO_CONFIANCA", length = 15)

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpPessoa.java
@@ -194,7 +194,6 @@ public abstract class AbstractDpPessoa extends DpResponsavel implements
 
 	@Column(name = "DATA_FIM_PESSOA", length = 19)
 	@Temporal(TemporalType.TIMESTAMP)
-    @Desconsiderar
 	private Date dataFimPessoa;
 
 	@Column(name = "DATA_INI_PESSOA", length = 19)


### PR DESCRIPTION
- Realizado correção para inativar / reativar (Usuário, cargo, função e confiança).
- A anotação @Desconsiderar estava desconsiderando os atributo marcados na comparação com o registro NOVO, assim evitando o insert/update do registro no banco (histórico).

> OBS: Para a LOTACAO existe a anotação **@Desconsiderar** em seus atributos de DT_FIM também, porém hoje funciona em produção, pois não está registrando os Logs de alterações insert/updates assim acredito que seja necessário uma implementação futura para registrar os LOGs da LOTAÇÃO.

> RMs Relacionados:
> - https://redmine.prodesp.sp.gov.br/issues/148219
> - https://redmine.prodesp.sp.gov.br/issues/148446
