### PR TITLE
RM121873: Mesa2: Correção para substituição de unidade

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -348,7 +348,7 @@ public class Mesa2 {
 			return gruposMesa;
 		
 		List<Object[]> listaPessoa = ExDao.getInstance().listarMobilsPorGrupoEMarcas(true, null, null, titular, null, true, marcasAIgnorar, null, filtro);
-		List<Object[]> listaLotacao = ExDao.getInstance().listarMobilsPorGrupoEMarcas(true, null, null, titular, titular.getLotacao(), true, marcasAIgnorar, null, filtro);
+		List<Object[]> listaLotacao = ExDao.getInstance().listarMobilsPorGrupoEMarcas(true, null, null, titular, lotaTitular, true, marcasAIgnorar, null, filtro);
 		
 		if (listaPessoa == null && listaLotacao == null)
 			return gruposMesa;
@@ -377,13 +377,14 @@ public class Mesa2 {
 		return gruposMesa;
 	}
 
-	public static List<GrupoItem> getMesa(final boolean contar, final Integer qtd, final Integer offset, final DpPessoa titular, final Map<String, SelGrupo> selGrupos, 
+	public static List<GrupoItem> getMesa(final boolean contar, final Integer qtd, final Integer offset, final DpPessoa titular, 
+			final DpLotacao lotaTitular, final Map<String, SelGrupo> selGrupos, 
 			final boolean exibeLotacao, final boolean trazerAnotacoes, final boolean trazerComposto, final boolean ordemCrescenteData,
 			final boolean usuarioPosse, List<Integer> marcasAIgnorar, final String filtro) throws Exception {
 //		long tempoIni = System.nanoTime();
 		ExDao dao = ExDao.getInstance();
 
-		List<Mesa2.GrupoItem> gruposMesa = getContadores(contar, titular, titular.getLotacao(), selGrupos, exibeLotacao, marcasAIgnorar, filtro);
+		List<Mesa2.GrupoItem> gruposMesa = getContadores(contar, titular, lotaTitular, selGrupos, exibeLotacao, marcasAIgnorar, filtro);
 
 		int qtTotal = 0;
 		for (Mesa2.GrupoItem g : gruposMesa) {
@@ -396,7 +397,7 @@ public class Mesa2 {
 			int q = (qtd != null && qtd < MESA_QTD_MAX_INICIAL? qtd : MESA_QTD_MAX_INICIAL);
 			if (exibeLotacao) {
 				l = dao.listarMobilsPorGrupoEMarcas(false, q, parmOffset, titular,
-						titular.getLotacao(), ordemCrescenteData, marcasAIgnorar, lGrp, filtro);
+						lotaTitular, ordemCrescenteData, marcasAIgnorar, lGrp, filtro);
 			} else {
 				l = dao.listarMobilsPorGrupoEMarcas(false, q, parmOffset, titular,
 						null, ordemCrescenteData, marcasAIgnorar, lGrp, filtro);
@@ -411,7 +412,7 @@ public class Mesa2 {
 			// Insere no grupo os documentos e seus dados a serem apresentados na mesa
 			for (Map.Entry<String, List<ExMobil>> entry : hashMobGrp.entrySet()) {
 				g.grupoDocs = Mesa2.listarReferencias(entry.getValue(), titular,
-						titular.getLotacao(), g.grupoOrdem, trazerAnotacoes, ordemCrescenteData, 
+						lotaTitular, g.grupoOrdem, trazerAnotacoes, ordemCrescenteData, 
 						usuarioPosse, parmOffset);
 				if (exibeLotacao) {
 					g.grupoQtdLota = g.grupoQtdLota > 0 ? g.grupoQtdLota : l.size();

--- a/siga/src/main/webapp/javascript/mesa2.js
+++ b/siga/src/main/webapp/javascript/mesa2.js
@@ -28,11 +28,14 @@ var appMesa = new Vue({
 		var self = this;
 		self.exibeLota = getParmUser('exibeLota');
 		if (self.exibeLota == null) {
-			setParmUser('exibeLota', false); 
 			self.exibeLota = false; 
 		}
 		self.getItensGrupo();
 		self.contar = false;
+		self.mostrarUsuario = MOSTRAR_USUARIO;
+		if (!self.mostrarUsuario)
+			self.exibeLota = true;
+		setParmUser('exibeLota', self.exibeLota); 
 		// Carrega todas linhas não preenchidas que estiverem na tela
 		var timeoutId;
 		window.addEventListener('scroll', function ( event ) {
@@ -66,7 +69,8 @@ var appMesa = new Vue({
 			trazerCancelados: false,
 			ordemCrescenteData: false,
 			usuarioPosse: false,
-			dtDMA: false
+			dtDMA: false,
+			mostrarUsuario: true
 		};
 	},
 	watch: {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMesa2Controller.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMesa2Controller.java
@@ -82,7 +82,7 @@ public class ExMesa2Controller extends ExController {
 		
 		result.include("ehPublicoExterno", AcessoConsulta.ehPublicoExterno(getTitular()));
 		try {
-			result.include("podeNovoDocumento", Cp.getInstance().getConf().podePorConfiguracao(getTitular(), getTitular().getLotacao(),
+			result.include("podeNovoDocumento", Cp.getInstance().getConf().podePorConfiguracao(getTitular(), getLotaTitular(),
 					ExTipoDeConfiguracao.CRIAR_NOVO_EXTERNO));
 		} catch (Exception e) {
 			throw e;
@@ -107,6 +107,15 @@ public class ExMesa2Controller extends ExController {
 		} else {
 			result.include("idVisualizacao", 0);
 		}
+		
+		if( !getLotaTitular().equivale(getCadastrante().getLotacao()) &&
+				getTitular().equivale(getCadastrante())) {
+			// É substituição de lotação
+			result.include("mostrarUsuario", false);
+		} else {
+			result.include("mostrarUsuario", true);
+		}
+		
 		if (msg != null) {
 			result.include("mensagemCabec", msg);
 			result.include("msgCabecClass", "alert-info fade-close");
@@ -162,10 +171,10 @@ public class ExMesa2Controller extends ExController {
 						 getCadastrante().getLotacao(), 
 						 ExTipoDeConfiguracao.DELEGAR_VISUALIZACAO)) {
 				DpVisualizacao vis = dao().consultar(idVisualizacao, DpVisualizacao.class, false);
-				g = Mesa2.getMesa(contar, qtd, offset, vis.getTitular(), selGrupos,	exibeLotacao, trazerAnotacoes, 
+				g = Mesa2.getMesa(contar, qtd, offset, vis.getTitular(), vis.getTitular().getLotacao(), selGrupos,	exibeLotacao, trazerAnotacoes, 
 						trazerComposto, ordemCrescenteData, usuarioPosse, marcasAIgnorar, filtro);
 			} else {
-				g = Mesa2.getMesa(contar, qtd, offset, getTitular(), selGrupos,	exibeLotacao, trazerAnotacoes, 
+				g = Mesa2.getMesa(contar, qtd, offset, getTitular(), getLotaTitular(), selGrupos, exibeLotacao, trazerAnotacoes, 
 						trazerComposto, ordemCrescenteData, usuarioPosse, marcasAIgnorar, filtro);
 			}
 	

--- a/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMesa2/lista.jsp
@@ -143,7 +143,7 @@
 				<c:if test="${siga_mesaCarregaLotacao && !ehPublicoExterno}">
 					<c:set var="varLotacaoUnidade"><fmt:message key='usuario.lotacao'/></c:set>
 					<div id="radioBtn" class="btn-group mb-1">
-						<a class="btn btn-primary btn-sm" v-bind:class="exibeLota ? 'notActive' : 'active'" id="btnUser"  
+						<a v-if="mostrarUsuario" class="btn btn-primary btn-sm" v-bind:class="exibeLota ? 'notActive' : 'active'" id="btnUser"  
 							accesskey="u" @click="carregarMesaUser('#btnUser');" 
 							title="Visualiza somente os documentos do Usuário">
 							<i class="fas fa-user my-1"></i>
@@ -212,7 +212,7 @@
 									<i class="h5 mb-0" :class="g.grupoIcone"></i>
 									<span class="grupo-nome mr-3">{{g.grupoNome}}</span>
 									<small> 
-										<span class="badge badge-light btn-sm align-middle" :class="{disabled: exibeLota}">
+										<span v-if="mostrarUsuario" class="badge badge-light btn-sm align-middle" :class="{disabled: exibeLota}">
 											<small class="fas fa-user"></small>
 											<span class="badge badge-light">{{g.grupoCounterUser}}</span>
 										</span>
@@ -365,6 +365,7 @@
 		<div id="toastContainer" style="position: fixed; top: 135px; right: 0;z-index: 999999;"></div>
 	</div>
 	<script type="text/javascript">
+		const MOSTRAR_USUARIO = ${mostrarUsuario};
 		const ID_VISUALIZACAO = ${idVisualizacao};
 		$( document ).ready(function() {
 			initPopovers();


### PR DESCRIPTION
Pega a unidade atraves de getLotaTitular ao inves da lotação do titular e não mostra a visão pessoa nesse caso.

![image](https://user-images.githubusercontent.com/49542320/210096050-8b097cab-357e-49f4-8ecd-d7f751e59333.png)
