### PR TITLE
Peticionamento externo da PCRJ reservando IDs (tipo de movimentação e tipo configuração)

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeConfiguracao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeConfiguracao.java
@@ -609,6 +609,11 @@ public enum ExTipoDeConfiguracao implements ITipoDeConfiguracao {
                     CpSituacaoDeConfiguracaoEnum.NAO_PODE },
             CpSituacaoDeConfiguracaoEnum.NAO_PODE, true);	
  
+	/* RESERVAR PCRJ PETICIONAMENTO DO 991 ATÉ O 999
+	PETICIONAMENTO(991 - 999, ...) 
+	*/
+	
+	
 	
 	private final int id; 
 	private final String descr;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/model/enm/ExTipoDeMovimentacao.java
@@ -206,6 +206,8 @@ public enum ExTipoDeMovimentacao implements ITipoDeMovimentacao {
 	ORDEM_ASSINATURA(96, "Ordem de Assinatura"),
 	
 	CANCELAR_PUBLICACAO_DOE(97, "Cancelar Publicação DOE");
+	
+	//NOTIFICACAO_PETICIONAMENTO(100, "Notificação Peticionamento");
 
 	private final int id;
 	private final String descr;


### PR DESCRIPTION
Objetivo é reservar IDs em tipos de configuração e tipo movimentação, para peticionamento externo da PCRJ.