### PR TITLE
PCRJ-3181 correção nas passagens de parâmetros anoEmissao e flAtivo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -267,16 +267,16 @@ public class ExDao extends CpDao {
 	public void updateMantemRangeNumeroDocumento(Long docNumeracao)
 			throws SQLException {
 		
-		final Query query = em().createNamedQuery("ExDocumentoNumeracao.mantemRangeNumeroDocumento");
-		
-		Calendar c = Calendar.getInstance();
-		
-		query.setParameter("anoEmissao", c.get(Calendar.YEAR));
-		query.setParameter("flAtivo", 1);
-		query.setParameter("increment", 1L);
-		query.setParameter("id", docNumeracao);
-		
-		query.executeUpdate();
+	    final Query query = em().createNamedQuery("ExDocumentoNumeracao.mantemRangeNumeroDocumento");
+
+        Calendar c = Calendar.getInstance();
+
+        query.setParameter("anoEmissao", Long.valueOf(c.get(Calendar.YEAR)));
+        query.setParameter("flAtivo", "1");
+        query.setParameter("increment", 1L);
+        query.setParameter("id", docNumeracao);
+
+        query.executeUpdate();
 		
 	}
 	


### PR DESCRIPTION
Recentemente nos deparamos com o  erro ao gerar a numeração do expediente.

Identificamos que o mesmo era provocado ao tentar gerar a numeração de um expediente, com a configuração 
"Reiniciar Numeração Todo Ano" = Não pode.

O método responsável por  executa a namedQuery ExDocumentoNumeracao.mantemRangeNumeroDocumento  e atualizar a tabela siga.ex_documento_numeracao,  passa  parâmetros com tipos diferentes do esperado (anoEmissao e flAtivo).

![imagem_2023-01-05_110641002](https://user-images.githubusercontent.com/107485449/210798801-d1d535e7-ca14-43af-83ca-1dceec3c323b.png)
![imagem_2023-01-05_110709964](https://user-images.githubusercontent.com/107485449/210798908-622ec983-2f56-4e83-b69f-97740426cecc.png)