### PR TITLE
RM148957 - Correção para evitar marcações duplicadas

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
@@ -88,9 +88,11 @@
 				</form>
 			</div>
 			<div class="modal-footer">
-				<button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
-				<button type="button" class="btn btn-primary"
-					onclick="javascript: sbmt();">Gravar</button>
+				<button id="btnMarcarCancelar" type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+				<button id="btnMarcarGravar" type="button" class="btn btn-primary"
+					onclick="javascript: sbmtMarcar();">
+					<span id="btnMarcarGravar-spinner" class="spinner-border d-none" role="status"></span>
+					Gravar</button>
 			</div>
 		</div>
 	</div>
@@ -299,7 +301,10 @@
 	window.initdefinirMarcaModal = function() {
 	}
 
-	function sbmt() {
+	function sbmtMarcar() {
+		document.getElementById('btnMarcarGravar-spinner').classList.remove('d-none');
+		document.getElementById('btnMarcarGravar').disabled = true;
+		document.getElementById('btnMarcarCancelar').disabled = true;
 		var dtPlanejada = document.getElementById('planejada');
 		var dtLimite = document.getElementById('limite');
 		

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/marcar.jsp
@@ -308,15 +308,26 @@
 		var dtPlanejada = document.getElementById('planejada');
 		var dtLimite = document.getElementById('limite');
 		
-		if (!${podeRetroativa} && dtPlanejada != null)
-			if (!verifica_data(dtPlanejada,0,false,false))
+		if (!${podeRetroativa} && dtPlanejada != null) {
+			if (!verifica_data(dtPlanejada,0,false,false)) {
+				reestabeleceBotoes()
 				return;
-
-		if (!${podeRetroativa} && dtLimite != null)
-			if (!verifica_data(dtLimite,0,false,false))
+			}
+		}
+				
+		if (!${podeRetroativa} && dtLimite != null) {
+			if (!verifica_data(dtLimite,0,false,false)) {
+				reestabeleceBotoes()
 				return;
+			}
+		}
 		
 		document.getElementById('marcarForm').submit();
 	}
-	
+
+	function reestabeleceBotoes() {
+		document.getElementById('btnMarcarGravar-spinner').classList.add('d-none');
+		document.getElementById('btnMarcarGravar').disabled = false;
+		document.getElementById('btnMarcarCancelar').disabled = false;
+	}
 </script>


### PR DESCRIPTION
Na tela de Definição de Marcador, desabilita os botões após clicar em "Gravar" e mostra um spinner indicando que a operação está em andamento para evitar do usuário clicar duas vezes e gerar movimentações duplicadas.

![image](https://user-images.githubusercontent.com/49542320/212120855-6703c0e5-5ecd-4e6d-aa6d-fc00dafd19e7.png)
