### PR TITLE
GOVSP - RM128421 - Mesa2: Correção da coluna Origem

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
@@ -95,6 +95,16 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 			ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA_EXTERNA,
 			ExTipoDeMovimentacao.DESPACHO_INTERNO_TRANSFERENCIA
 		};
+
+	public final static ITipoDeMovimentacao[] tpMovimentacoesDeTramite = new ITipoDeMovimentacao[] {ExTipoDeMovimentacao.CRIACAO, 
+			ExTipoDeMovimentacao.TRANSFERENCIA,
+			ExTipoDeMovimentacao.TRAMITE_PARALELO,
+			ExTipoDeMovimentacao.NOTIFICACAO,
+			ExTipoDeMovimentacao.TRANSFERENCIA_EXTERNA,
+			ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA,
+			ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA_EXTERNA,
+			ExTipoDeMovimentacao.DESPACHO_INTERNO_TRANSFERENCIA
+		};
 	/**
 	 * Simple constructor of ExMovimentacao instances.
 	 */

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
@@ -96,15 +96,6 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 			ExTipoDeMovimentacao.DESPACHO_INTERNO_TRANSFERENCIA
 		};
 
-	public final static ITipoDeMovimentacao[] tpMovimentacoesDeTramite = new ITipoDeMovimentacao[] {ExTipoDeMovimentacao.CRIACAO, 
-			ExTipoDeMovimentacao.TRANSFERENCIA,
-			ExTipoDeMovimentacao.TRAMITE_PARALELO,
-			ExTipoDeMovimentacao.NOTIFICACAO,
-			ExTipoDeMovimentacao.TRANSFERENCIA_EXTERNA,
-			ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA,
-			ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA_EXTERNA,
-			ExTipoDeMovimentacao.DESPACHO_INTERNO_TRANSFERENCIA
-		};
 	/**
 	 * Simple constructor of ExMovimentacao instances.
 	 */

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -145,31 +145,36 @@ public class Mesa2 {
 				r.descr = StringEscapeUtils.unescapeHtml4(mobil.doc().getDescrCurta(255).replace("\r", " ").replace("\f", " ").replace("\n", " "));
 				r.tipoDoc = (mobil.doc().isComposto()? "Composto" : "Avulso");
 				ExMovimentacao ultMovPosse = null;
-	
-				if (mobil.doc().getSubscritor() != null
-						&& mobil.doc().getSubscritor().getLotacao() != null) {
-					if (SigaMessages.isSigaSP()) {
-						ultMovPosse = mobil
-								.getUltimaMovimentacao(ExMovimentacao.tpMovimentacoesDePosse, 
-										new ITipoDeMovimentacao[] {}, mobil, false, null, false);
-						
-						if (ultMovPosse != null) {
-							r.origem = ultMovPosse.getLotacao()
-									.getOrgaoUsuario().getSigla() + " / "
-									+ ultMovPosse.getLotacao().getSigla();
-						} else {
+				if (SigaMessages.isSigaSP()) 
+					ultMovPosse = mobil
+							.getUltimaMovimentacao(ExMovimentacao.tpMovimentacoesDePosse, 
+									new ITipoDeMovimentacao[] {}, mobil, false, null, false);
+				
+				ExMovimentacao movUltTramite = null;
+
+				if (SigaMessages.isSigaSP()) {
+					movUltTramite = mobil
+							.getUltimaMovimentacao(ExMovimentacao.tpMovimentacoesDeTramite, 
+									new ITipoDeMovimentacao[] {}, mobil, false, null, false);
+
+					if (movUltTramite != null) {
+						r.origem = movUltTramite.getLotacao()
+								.getOrgaoUsuario().getSigla() + " / "
+								+ movUltTramite.getLotacao().getSigla();
+					} else {
+						if (mobil.doc().getSubscritor() != null
+								&& mobil.doc().getSubscritor().getLotacao() != null) 
 							r.origem = mobil.doc().getSubscritor().getLotacao()
 									.getOrgaoUsuario() + " / "
 									+ mobil.doc().getSubscritor().getLotacao()
 											.getSigla();
-						}
-					} else {
+					}
+				} else {
+					if (mobil.doc().getSubscritor() != null
+							&& mobil.doc().getSubscritor().getLotacao() != null) 
 						r.origem = mobil.doc().getSubscritor().getLotacao()
 								.getSigla();
-					}
 				}
-				
-				r.dataDevolucao = "ocultar";
 				
 				if (mobil.doc().getSubscritor() != null
 						&& mobil.doc().getLotacao() != null) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/Mesa2.java
@@ -154,8 +154,15 @@ public class Mesa2 {
 
 				if (SigaMessages.isSigaSP()) {
 					movUltTramite = mobil
-							.getUltimaMovimentacao(ExMovimentacao.tpMovimentacoesDeTramite, 
-									new ITipoDeMovimentacao[] {}, mobil, false, null, false);
+							.getUltimaMovimentacao(new ITipoDeMovimentacao[] {ExTipoDeMovimentacao.CRIACAO, 
+									ExTipoDeMovimentacao.TRANSFERENCIA,
+									ExTipoDeMovimentacao.TRAMITE_PARALELO,
+									ExTipoDeMovimentacao.NOTIFICACAO,
+									ExTipoDeMovimentacao.TRANSFERENCIA_EXTERNA,
+									ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA,
+									ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA_EXTERNA,
+									ExTipoDeMovimentacao.DESPACHO_INTERNO_TRANSFERENCIA
+								}, new ITipoDeMovimentacao[] {}, mobil, false, null, false);
 
 					if (movUltTramite != null) {
 						r.origem = movUltTramite.getLotacao()


### PR DESCRIPTION
A coluna "Origem" na mesa virtual Beta estava trazendo o usuário em posse do documento ao invés do último trâmite como era o comportamento anterior à essa versão.
![image](https://user-images.githubusercontent.com/49542320/213007674-28fcaef4-eb74-42fa-b62c-e43b5430103a.png)
