### PR TITLE
RM150876 Apresentação de erros de documentos não tramitados na tramitação em lote

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -192,6 +192,7 @@ import br.gov.jfrj.siga.integracao.ws.pubnet.mapping.AuthHeader;
 import br.gov.jfrj.siga.integracao.ws.pubnet.service.PubnetConsultaService;
 import br.gov.jfrj.siga.vraptor.builder.BuscaDocumentoBuilder;
 import br.gov.jfrj.siga.vraptor.builder.ExMovimentacaoBuilder;
+import org.json.JSONObject;
 
 @Controller
 public class ExMovimentacaoController extends ExController {
@@ -5664,16 +5665,8 @@ public class ExMovimentacaoController extends ExController {
 									   final String siglasDocumentosNaoTramitados,
 									   final DpLotacaoSelecao lotaResponsavelSel,
 									   final DpPessoaSelecao responsavelSel,
-									   final CpOrgaoSelecao cpOrgaoSel) throws Exception {
-
-		final ExMovimentacaoBuilder movimentacaoBuilder = ExMovimentacaoBuilder
-				.novaInstancia();
-		movimentacaoBuilder.setLotaResponsavelSel(lotaResponsavelSel)
-				.setResponsavelSel(responsavelSel)
-				.setCpOrgaoSel(cpOrgaoSel)
-				.setCadastrante(getCadastrante());
-		ExMovimentacao mov = movimentacaoBuilder.construir(dao());
-		mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
+									   final CpOrgaoSelecao cpOrgaoSel,
+									   final String errosDocumentosNaoTramitadosJson) throws Exception {
 
 		String[] arraySiglasDocumentosTramitados = { };
 		if (siglasDocumentosTramitados != null) {
@@ -5686,7 +5679,6 @@ public class ExMovimentacaoController extends ExController {
 		}
 		
 		final List<ExMobil> mobisDocumentosTramitados = new ArrayList<ExMobil>();
-		final List<ExMobil> mobisDocumentosNaoTramitados = new ArrayList<ExMobil>();
 
 		BuscaDocumentoBuilder documentoBuilder;
 				
@@ -5697,18 +5689,27 @@ public class ExMovimentacaoController extends ExController {
 			mobisDocumentosTramitados.add(mob);
 		}
 
-		for(String sigla : arraySiglasDocumentosNaoTramitados){
-			documentoBuilder = BuscaDocumentoBuilder.novaInstancia().setSigla(sigla);
-			buscarDocumento(documentoBuilder);
-			ExMobil mob = documentoBuilder.getMob();
-			mobisDocumentosNaoTramitados.add(mob);
-		}
+        List<ExMovimentacao> listaMovimentacaoDocumentosNaoTramitados =
+                montarListaResultadosMovimentacaoEmLote(lotaResponsavelSel,
+                        responsavelSel,
+                        cpOrgaoSel,
+                        errosDocumentosNaoTramitadosJson);
+
+        if (( mobisDocumentosTramitados == null 
+                || mobisDocumentosTramitados.isEmpty() ) 
+                && listaMovimentacaoDocumentosNaoTramitados == null 
+                || listaMovimentacaoDocumentosNaoTramitados.isEmpty()) {
+
+            throw new AplicacaoException("Não foi possível tramitar em lote");
+        }
 
 		ExMobil mobIni = mobisDocumentosTramitados.isEmpty() ? null : mobisDocumentosTramitados.get(0);
 		ExMovimentacao movIni = null;
-		if(mobIni != null){
-			movIni = mobIni.getUltimaMovimentacao();
-		}
+        if (mobIni != null) {
+            movIni = mobIni.getUltimaMovimentacao();
+        } else {
+            movIni = listaMovimentacaoDocumentosNaoTramitados.get(0);
+        }
 
 		ExMobil mobFim = mobisDocumentosTramitados.isEmpty() ? null :
 				mobisDocumentosTramitados.get(mobisDocumentosTramitados.size() - 1);
@@ -5718,8 +5719,7 @@ public class ExMovimentacaoController extends ExController {
 		}
 
 		result.include("mobisDocumentosTramitados", mobisDocumentosTramitados);
-		result.include("mobisDocumentosNaoTramitados", mobisDocumentosNaoTramitados);
-
+		result.include("movsDocumentosNaoTramitados", listaMovimentacaoDocumentosNaoTramitados);
 
 		result.include("lotaTitular", getLotaTitular());
 		result.include("movIni", movIni);
@@ -5729,7 +5729,38 @@ public class ExMovimentacaoController extends ExController {
 		
 		result.include("dtIni", dtIni);
 		result.include("dtFim", dtFim);
-		result.include("mov", mov);
+	}
+	
+	private List<ExMovimentacao> montarListaResultadosMovimentacaoEmLote(final DpLotacaoSelecao lotaResponsavelSel,
+                                                                         final DpPessoaSelecao responsavelSel,
+                                                                         final CpOrgaoSelecao cpOrgaoSel,
+                                                                         final String resultadosMovimentacaoMapJson){
+        
+		List<ExMovimentacao> listaResultadosMovimentacaoEmLote = null;
+
+		JSONObject jsonObject = new JSONObject(resultadosMovimentacaoMapJson);
+		
+		jsonObject.keys().forEachRemaining(key -> {
+            BuscaDocumentoBuilder documentoBuilder;
+            documentoBuilder = BuscaDocumentoBuilder.novaInstancia().setSigla(key);
+            buscarDocumento(documentoBuilder);
+            ExMobil mob = documentoBuilder.getMob();
+            String mensagemResultadoMovimentacao = jsonObject.get(key).toString();
+                
+            final ExMovimentacaoBuilder movimentacaoBuilder = ExMovimentacaoBuilder.novaInstancia();
+            movimentacaoBuilder.setLotaResponsavelSel(lotaResponsavelSel)
+                    .setResponsavelSel(responsavelSel)
+                    .setCpOrgaoSel(cpOrgaoSel)
+                    .setCadastrante(getCadastrante())
+                    .setMob(mob)
+                    .setMensagemResultadoMovimentacao(mensagemResultadoMovimentacao);
+            ExMovimentacao mov = movimentacaoBuilder.construir(dao());
+            mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
+
+            listaResultadosMovimentacaoEmLote.add(mov);
+		});
+		
+		return listaResultadosMovimentacaoEmLote;
 	}
 	
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5662,7 +5662,6 @@ public class ExMovimentacaoController extends ExController {
 
 	@Post("/app/expediente/mov/listar_docs_tramitados")
 	public void listar_docs_tramitados(final String siglasDocumentosTramitados, 
-									   final String siglasDocumentosNaoTramitados,
 									   final DpLotacaoSelecao lotaResponsavelSel,
 									   final DpPessoaSelecao responsavelSel,
 									   final CpOrgaoSelecao cpOrgaoSel,
@@ -5671,11 +5670,6 @@ public class ExMovimentacaoController extends ExController {
 		String[] arraySiglasDocumentosTramitados = { };
 		if (siglasDocumentosTramitados != null) {
 			arraySiglasDocumentosTramitados = siglasDocumentosTramitados.split(",");
-		}
-		
-		String[] arraySiglasDocumentosNaoTramitados = { };
-		if (siglasDocumentosNaoTramitados != null) {
-			arraySiglasDocumentosNaoTramitados = siglasDocumentosNaoTramitados.split(",");
 		}
 		
 		final List<ExMobil> mobisDocumentosTramitados = new ArrayList<ExMobil>();
@@ -5697,8 +5691,8 @@ public class ExMovimentacaoController extends ExController {
 
         if (( mobisDocumentosTramitados == null 
                 || mobisDocumentosTramitados.isEmpty() ) 
-                && listaMovimentacaoDocumentosNaoTramitados == null 
-                || listaMovimentacaoDocumentosNaoTramitados.isEmpty()) {
+                && (listaMovimentacaoDocumentosNaoTramitados == null 
+                || listaMovimentacaoDocumentosNaoTramitados.isEmpty())) {
 
             throw new AplicacaoException("Não foi possível tramitar em lote");
         }
@@ -5736,12 +5730,14 @@ public class ExMovimentacaoController extends ExController {
                                                                          final CpOrgaoSelecao cpOrgaoSel,
                                                                          final String resultadosMovimentacaoMapJson){
         
-		List<ExMovimentacao> listaResultadosMovimentacaoEmLote = null;
+		List<ExMovimentacao> listaResultadosMovimentacaoEmLote = new ArrayList<>();
 
 		JSONObject jsonObject = new JSONObject(resultadosMovimentacaoMapJson);
-		
-		jsonObject.keys().forEachRemaining(key -> {
-            BuscaDocumentoBuilder documentoBuilder;
+
+		for (Iterator<String> it = jsonObject.keys(); it.hasNext(); ) {
+			String key = it.next();
+			
+			BuscaDocumentoBuilder documentoBuilder;
             documentoBuilder = BuscaDocumentoBuilder.novaInstancia().setSigla(key);
             buscarDocumento(documentoBuilder);
             ExMobil mob = documentoBuilder.getMob();
@@ -5753,12 +5749,12 @@ public class ExMovimentacaoController extends ExController {
                     .setCpOrgaoSel(cpOrgaoSel)
                     .setCadastrante(getCadastrante())
                     .setMob(mob)
-                    .setMensagemResultadoMovimentacao(mensagemResultadoMovimentacao);
+                    .setDescrMov(mensagemResultadoMovimentacao);
             ExMovimentacao mov = movimentacaoBuilder.construir(dao());
             mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
 
             listaResultadosMovimentacaoEmLote.add(mov);
-		});
+		}
 		
 		return listaResultadosMovimentacaoEmLote;
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/builder/ExMovimentacaoBuilder.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/builder/ExMovimentacaoBuilder.java
@@ -51,6 +51,7 @@ public final class ExMovimentacaoBuilder {
 	private Long idMarcador;
 	private String contentType;
 	private String fileName;
+	private String mensagemResultadoMovimentacao;
 
 	private ExMovimentacaoBuilder() {
 		substituicao = false;
@@ -323,6 +324,10 @@ public final class ExMovimentacaoBuilder {
 		return fileName;
 	}
 
+	public String getMensagemResultadoMovimentacao() {
+		return mensagemResultadoMovimentacao;
+	}
+
 	public ExMovimentacaoBuilder setLotaTitular(DpLotacao lotaTitular) {
 		this.lotaTitular = lotaTitular;
 		return this;
@@ -455,6 +460,11 @@ public final class ExMovimentacaoBuilder {
 
 	public ExMovimentacaoBuilder setFileName(String fileName) {
 		this.fileName = fileName;
+		return this;
+	}
+	
+	public ExMovimentacaoBuilder setMensagemResultadoMovimentacao(String mensagemResultadoMovimentacao){
+		this.mensagemResultadoMovimentacao = mensagemResultadoMovimentacao;
 		return this;
 	}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/builder/ExMovimentacaoBuilder.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/builder/ExMovimentacaoBuilder.java
@@ -51,7 +51,6 @@ public final class ExMovimentacaoBuilder {
 	private Long idMarcador;
 	private String contentType;
 	private String fileName;
-	private String mensagemResultadoMovimentacao;
 
 	private ExMovimentacaoBuilder() {
 		substituicao = false;
@@ -324,10 +323,6 @@ public final class ExMovimentacaoBuilder {
 		return fileName;
 	}
 
-	public String getMensagemResultadoMovimentacao() {
-		return mensagemResultadoMovimentacao;
-	}
-
 	public ExMovimentacaoBuilder setLotaTitular(DpLotacao lotaTitular) {
 		this.lotaTitular = lotaTitular;
 		return this;
@@ -460,11 +455,6 @@ public final class ExMovimentacaoBuilder {
 
 	public ExMovimentacaoBuilder setFileName(String fileName) {
 		this.fileName = fileName;
-		return this;
-	}
-	
-	public ExMovimentacaoBuilder setMensagemResultadoMovimentacao(String mensagemResultadoMovimentacao){
-		this.mensagemResultadoMovimentacao = mensagemResultadoMovimentacao;
 		return this;
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_tramitar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_tramitar_lote.jsp
@@ -33,7 +33,7 @@
                 </thead>
                 <tbody class="table-bordered">
 
-                <siga:paginador maxItens="200" maxIndices="200"
+                <siga:paginador maxItens="200" maxIndices="50"
                                 totalItens="${tamanho}" itens="${itens}" var="documento">
 
                     <c:set var="chk" scope="request">process_chk_${documento.id}</c:set>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
@@ -347,7 +347,6 @@
 
         function enviarParaListagemDocumentosTramitados() {
             document.getElementsByName('siglasDocumentosTramitados')[0].value = siglasDocumentosTramitados;
-            document.getElementsByName('siglasDocumentosNaoTramitados')[0].value = siglasDocumentosNaoTramitados;
 
             let errosDocumentosNaoTramitadosJson = JSON.stringify(Object.fromEntries(errosDocumentosNaoTramitadosMap));
             document.getElementsByName('errosDocumentosNaoTramitadosJson')[0].value = errosDocumentosNaoTramitadosJson;

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
@@ -18,10 +18,9 @@
             </div>
             <div class="card-body">
                 <form name="frm" id="frm" class="form" method="post" action="listar_docs_tramitados" theme="simple">
-                    <input type="hidden" id="siglasDocumentosTramitados" name="siglasDocumentosTramitados"
-                           value=""/>
-                    <input type="hidden" id="siglasDocumentosNaoTramitados" name="siglasDocumentosNaoTramitados"
-                           value=""/>
+                    <input type="hidden" name="siglasDocumentosTramitados" value=""/>
+                    <input type="hidden" name="siglasDocumentosNaoTramitados" value=""/>
+                    <input type="hidden" name="errosDocumentosNaoTramitadosJson" value=""/>
 
                     <div class="row campo-orgao-externo" style="display: none;">
                         <div class="col-sm">
@@ -270,7 +269,7 @@
         }
 
         let siglasDocumentosTramitados = [];
-        let siglasDocumentosNaoTramitados = [];
+        let errosDocumentosNaoTramitadosMap = new Map();
 
         function confirmar() {
             document.getElementById('btnOk').disabled = true;
@@ -336,14 +335,12 @@
                     observacao: obsOrgao,
                     dataDevolucao: dtDevolucaoMovString
                 },
+                dataType: 'json',
                 success: function () {
                     siglasDocumentosTramitados.push(documentoSelSigla);
                 },
-                error: function (textStatus, errorThrown) {
-                    siglasDocumentosNaoTramitados.push(documentoSelSigla);
-                    console.error(
-                        "Ocorreu um erro na tramitação: " + textStatus, errorThrown
-                    );
+                error: function (response) {
+                    errosDocumentosNaoTramitadosMap.set(documentoSelSigla, response.responseJSON.errormsg);
                 }
             });
         }
@@ -351,6 +348,10 @@
         function enviarParaListagemDocumentosTramitados() {
             document.getElementsByName('siglasDocumentosTramitados')[0].value = siglasDocumentosTramitados;
             document.getElementsByName('siglasDocumentosNaoTramitados')[0].value = siglasDocumentosNaoTramitados;
+
+            let errosDocumentosNaoTramitadosJson = JSON.stringify(Object.fromEntries(errosDocumentosNaoTramitadosMap));
+            document.getElementsByName('errosDocumentosNaoTramitadosJson')[0].value = errosDocumentosNaoTramitadosJson;
+
             document.frm.submit();
         }
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTramitarLote.jsp
@@ -19,7 +19,6 @@
             <div class="card-body">
                 <form name="frm" id="frm" class="form" method="post" action="listar_docs_tramitados" theme="simple">
                     <input type="hidden" name="siglasDocumentosTramitados" value=""/>
-                    <input type="hidden" name="siglasDocumentosNaoTramitados" value=""/>
                     <input type="hidden" name="errosDocumentosNaoTramitadosJson" value=""/>
 
                     <div class="row campo-orgao-externo" style="display: none;">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/listar_docs_tramitados.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/listar_docs_tramitados.jsp
@@ -14,7 +14,7 @@
         <input type="hidden" name="isTransf" value="true"/>
 
         <!-- main content bootstrap -->
-        <div class="container-fluid">
+        <c class="container-fluid">
             <div class="card bg-light mb-3">
                 <div class="card-header">
                     <h5><fmt:message key='protocolo.transferencia'/></h5>
@@ -28,11 +28,11 @@
                             <input type="hidden" name="sigla" id="pessoa" value="${cadastrante.sigla}"/>
                         </tr>
                         <td>Para</td>
-                        <td>${mov.respString}</td>
+                        <td>${movIni.respString}</td>
                         </tr>
                         <tr>
                             <td>Data</td>
-                            <td colspan="2">${mov.dtRegMovDDMMYYYYHHMMSS}</td>
+                            <td colspan="2">${movIni.dtRegMovDDMMYYYYHHMMSS}</td>
                             <input type="hidden" name="dtIni" value="${dtIni}"/>
                             <input type="hidden" name="dtFim" value="${dtFim}"/>
                         </tr>
@@ -40,6 +40,8 @@
 
                 </div>
             </div>
+            
+            <c:if test="${not empty movsDocumentosNaoTramitados}">
             <div class="card bg-light mb-3">
                 <div class="card-header">
                     <h5><fmt:message key='documentos.nao.transferidos'/></h5>
@@ -57,25 +59,25 @@
                             <th>Descrição</th>
                         </tr>
                         </thead>
-                        <c:forEach var="mob" items="${mobisDocumentosNaoTramitados}">
+                        <c:forEach var="mov" items="${movsDocumentosNaoTramitados}">
                             <tr>
                                 <td align="center">
-                                    <a href="${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${mob.sigla}">
-                                            ${mob.codigo}
+                                    <a href="${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${mov.mob.sigla}">
+                                            ${mov.mob.codigo}
                                     </a>
                                 <td align="center">
-                                    <siga:selecionado sigla="${mob.doc.lotaSubscritor.sigla}"
-                                                      descricao="${mob.doc.lotaSubscritor.descricao}"/>
+                                    <siga:selecionado sigla="${mov.mob.doc.lotaSubscritor.sigla}"
+                                                      descricao="${mov.mob.doc.lotaSubscritor.descricao}"/>
                                 </td>
                                 <td align="center">
-                                    <siga:selecionado sigla="${mob}" descricao="${mob}"/>
+                                    <siga:selecionado sigla="${mov.mob}" descricao="${mov.mob}"/>
                                 </td>
                             </tr>
                         </c:forEach>
                     </table>
                 </div>
             </div>
-
+            </c:if>
 
             <c:if test="${not empty mobisDocumentosTramitados}">
             <div class="card bg-light mb-3">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/listar_docs_tramitados.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/listar_docs_tramitados.jsp
@@ -49,29 +49,32 @@
 
                 <div class="card-body">
                     <table class="table table-hover table-striped">
+                        <col width="20%"/>
+                        <col width="10%"/>
                         <col width="30%"/>
-                        <col width="16%"/>
-                        <col width="54%"/>
+                        <col width="40%"/>
                         <thead class="${thead_color} align-middle text-center">
                         <tr>
                             <th>Documento</th>
                             <th>Lotação</th>
                             <th>Descrição</th>
+                            <th>Mensagem</th>
                         </tr>
                         </thead>
                         <c:forEach var="mov" items="${movsDocumentosNaoTramitados}">
                             <tr>
                                 <td align="center">
-                                    <a href="${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${mov.mob.sigla}">
-                                            ${mov.mob.codigo}
+                                    <a href="${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${mov.exMobil.sigla}">
+                                            ${mov.exMobil.codigo}
                                     </a>
                                 <td align="center">
-                                    <siga:selecionado sigla="${mov.mob.doc.lotaSubscritor.sigla}"
-                                                      descricao="${mov.mob.doc.lotaSubscritor.descricao}"/>
+                                    <siga:selecionado sigla="${mov.exMobil.exDocumento.lotaSubscritor.sigla}"
+                                                      descricao="${mov.exMobil.exDocumento.lotaSubscritor.descricao}"/>
                                 </td>
                                 <td align="center">
-                                    <siga:selecionado sigla="${mov.mob}" descricao="${mov.mob}"/>
+                                    <siga:selecionado sigla="${mov.exMobil}" descricao="${mov.exMobil}"/>
                                 </td>
+                                <td class="text-left">${mov.descrMov}</td>
                             </tr>
                         </c:forEach>
                     </table>


### PR DESCRIPTION
### Apresentação de erros de documentos não tramitados na tramitação em lote

A funcionalidade de tramitar em lote originalmente impedia a tramitação de todos os documentos selecionados caso um deles apresentasse uma restrição.
No refatoramento da funcionalidade optou-se por não bloquear e executar a tramitação em lote dos demais documentos.
Após esse refatoramento havia ficado pendente a apresentação dos retornos com erros de documentos não tramitados das chamadas do endpoint DocumentosSiglaTramitarPost.
Assim, este pull request visa adicionar na tela de documentos tramitados/não tramitados o motivo que impossibilitou a tramitação de um determinado documento.

#### Resumo da implementação

1. Adicionado map errosDocumentosNaoTramitadosMap na página aTramitarLote.jsp para armazenar os retornos com erros das chamadas ajax do endpoint DocumentosSiglaTramitarPost
2. Adicionado método montarListaResultadosMovimentacaoEmLote na classe ExMovimentacaoController.java para montar uma lista de movimentações a partir do map JSON obtido na página aTramitarLote.jsp
3. Alterada página listar_docs_tramitados.jsp para apresentar os erros coletados

#### Capturas de telas

![image](https://user-images.githubusercontent.com/1022974/213446327-ad177a79-6a22-4a38-aea4-eb7a665b5ecd.png)
