### PR TITLE
GOVSP - RM105884: WS para trazer modelo atual ativo e inclusão idInicial nos resultados das pesquisas

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -44,6 +44,7 @@ import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
 import javax.persistence.TemporalType;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
@@ -1992,17 +1993,46 @@ public class ExDao extends CpDao {
 		Root<ExModelo> c = q.from(ExModelo.class);
 		q.select(c);
 		List<Predicate> whereList = new LinkedList<Predicate>();
-		if(flt.getSigla() != null) {
+		if(flt.getSigla() != null || flt.getNome() != null) {
 			Expression<String> path = c.get("nmMod");
 			path = cb().upper(path);
-			whereList.add(cb().like(path, "%" + flt.getSigla() + "%"));
-			whereList.add(cb().equal(c.get("hisAtivo"), 1));
+			whereList.add(cb().like(path, "%" 
+					+ (flt.getSigla() != null ? flt.getSigla().toUpperCase().replaceAll(" ", "%") + "%" : "") 
+					+ (flt.getNome() != null ? flt.getNome().toUpperCase().replaceAll(" ", "%") + "%" : "")));
 		}
+
+		if(flt.getDescricao() != null) {
+			Expression<String> path = c.get("descMod");
+			path = cb().upper(path);
+			whereList.add(cb().like(path, "%" + flt.getDescricao().toUpperCase().replaceAll(" ", "%") + "%"));
+		}
+
+		if (flt.getExFormaDocumento() != null)
+			whereList.add(cb().equal(c.get("exFormaDocumento"), flt.getExFormaDocumento()));
+
+		if (flt.getExClassificacao() != null)
+			whereList.add(cb().equal(c.get("exClassificacao"), flt.getExClassificacao()));
+
+		if (flt.getExNivelAcesso() != null)
+			whereList.add(cb().equal(c.get("exNivelAcesso"), flt.getExNivelAcesso()));
+		
+		if(flt.getAtivos() == null || flt.getAtivos()) 
+			whereList.add(cb().equal(c.get("hisAtivo"), 1));
+
 		Predicate[] whereArray = new Predicate[whereList.size()];
 		whereList.toArray(whereArray);
 		q.where(whereArray);
-			q.orderBy(cb().desc(c.get("nmMod")));
-		return em().createQuery(q).getResultList();
+		q.orderBy(cb().desc(c.get("nmMod")));
+		
+		TypedQuery<ExModelo> query = em().createQuery(q);
+		
+		if (offset > 0) 
+			query.setFirstResult(offset);
+
+		if (itemPagina > 0) 
+			query.setMaxResults(itemPagina);
+		
+		return query.getResultList();
 	}
 
 	public int consultarQuantidade(final ExModeloDaoFiltro flt) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExModeloDaoFiltro.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/persistencia/ExModeloDaoFiltro.java
@@ -18,10 +18,18 @@
  ******************************************************************************/
 package br.gov.jfrj.siga.persistencia;
 
+import br.gov.jfrj.siga.ex.ExClassificacao;
+import br.gov.jfrj.siga.ex.ExFormaDocumento;
+import br.gov.jfrj.siga.ex.ExNivelAcesso;
 import br.gov.jfrj.siga.model.dao.DaoFiltroSelecionavel;
 
 public class ExModeloDaoFiltro extends DaoFiltroSelecionavel {
 	private String nome;
+	private String descricao;
+	private ExFormaDocumento exFormaDocumento;
+	private ExNivelAcesso exNivelAcesso;
+	private ExClassificacao exClassificacao;
+	private Boolean ativos;
 
 	public String getNome() {
 		return nome;
@@ -30,4 +38,45 @@ public class ExModeloDaoFiltro extends DaoFiltroSelecionavel {
 	public void setNome(String nome) {
 		this.nome = nome;
 	}
+
+	public ExFormaDocumento getExFormaDocumento() {
+		return exFormaDocumento;
+	}
+
+	public void setExFormaDocumento(ExFormaDocumento exFormaDocumento) {
+		this.exFormaDocumento = exFormaDocumento;
+	}
+
+	public ExNivelAcesso getExNivelAcesso() {
+		return exNivelAcesso;
+	}
+
+	public void setExNivelAcesso(ExNivelAcesso exNivelAcesso) {
+		this.exNivelAcesso = exNivelAcesso;
+	}
+
+	public ExClassificacao getExClassificacao() {
+		return exClassificacao;
+	}
+
+	public void setExClassificacao(ExClassificacao exClassificacao) {
+		this.exClassificacao = exClassificacao;
+	}
+
+	public String getDescricao() {
+		return descricao;
+	}
+
+	public void setDescricao(String descricao) {
+		this.descricao = descricao;
+	}
+
+	public Boolean getAtivos() {
+		return ativos;
+	}
+
+	public void setAtivo(Boolean ativos) {
+		this.ativos = ativos;
+	}
+	
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaModelosParaAutuarGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaModelosParaAutuarGet.java
@@ -35,6 +35,7 @@ public class DocumentosSiglaModelosParaAutuarGet implements IDocumentosSiglaMode
 		for (ExModelo m : modelos) {
 			ModeloItem mi = new ModeloItem();
 			mi.idModelo = m.getId().toString();
+			mi.idModeloInicial = m.getIdInicial().toString();
 			mi.nome = m.getNmMod();
 			mi.descr = m.getDescMod();
 			resp.list.add(mi);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaModelosParaIncluirGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaModelosParaIncluirGet.java
@@ -32,6 +32,7 @@ public class DocumentosSiglaModelosParaIncluirGet implements IDocumentosSiglaMod
 		for (ExModelo m : modelos) {
 			ModeloItem mi = new ModeloItem();
 			mi.idModelo = m.getId().toString();
+			mi.idModeloInicial = m.getIdInicial().toString();
 			mi.nome = m.getNmMod();
 			mi.descr = m.getDescMod();
 			resp.list.add(mi);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -231,16 +231,19 @@ public interface IExApiV1 {
         public String referenciaPDFCompletoDocPrincipal;
     }
 
-    public interface IModelosGet extends ISwaggerMethod {
-        public static class Request implements ISwaggerRequest {
-        }
+	public interface IModelosGet extends ISwaggerMethod {
+		public static class Request implements ISwaggerRequest {
+			public Boolean permitidos;
+			public String nomemodelo;
+		}
 
-        public static class Response implements ISwaggerResponse {
-            public List<ModeloItem> list = new ArrayList<>();
-        }
+		public static class Response implements ISwaggerResponse {
+			public List<ModeloItem> list = new ArrayList<>();
+		}
 
-        public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
-    }
+		public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
+	}
+
 
     public interface IModelosListaHierarquicaGet extends ISwaggerMethod {
         public static class Request implements ISwaggerRequest {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -180,6 +180,7 @@ public interface IExApiV1 {
 
     public static class ModeloItem implements ISwaggerModel {
         public String idModelo;
+        public String idModeloInicial;
         public String nome;
         public String descr;
     }
@@ -192,6 +193,7 @@ public interface IExApiV1 {
 
     public static class ModeloListaHierarquicaItem implements ISwaggerModel {
         public String idModelo;
+        public String idModeloInicial;
         public String nome;
         public String descr;
         public Long level;
@@ -286,6 +288,7 @@ public interface IExApiV1 {
 
         public static class Response implements ISwaggerResponse {
             public String idModelo;
+            public String idModeloInicial;
             public String nome;
             public String descr;
             public String especie;
@@ -301,6 +304,30 @@ public interface IExApiV1 {
 
         public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
     }
+
+	public interface IModelosIdAtivoGet extends ISwaggerMethod {
+		public static class Request implements ISwaggerRequest {
+			public String id;
+		}
+
+		public static class Response implements ISwaggerResponse {
+			public String idModelo;
+			public String idModeloInicial;
+			public String nome;
+			public String descr;
+			public String especie;
+			public String nivelDeAcesso;
+			public String classificacao;
+			public String classificacaoParaCriacaoDeVias;
+			public String tipoDeSubscritor;
+			public String tipoDeDestinatario;
+			public String tipoDeConteudo;
+			public String tipoDeDocumento;
+			public String conteudo;
+		}
+
+		public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
+	}
 
     public interface IModelosIdProcessarEntrevistaPost extends ISwaggerMethod {
         public static class Request implements ISwaggerRequest {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosGet.java
@@ -35,6 +35,7 @@ public class ModelosGet implements IModelosGet {
 		for (ExModelo m : modelos) {
 			ModeloItem mi = new ModeloItem();
 			mi.idModelo = m.getId().toString();
+			mi.idModeloInicial = m.getIdInicial().toString();
 			mi.nome = m.getNmMod();
 			mi.descr = m.getDescMod();
 			resp.list.add(mi);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosGet.java
@@ -10,6 +10,8 @@ import br.gov.jfrj.siga.ex.ExModelo;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IModelosGet;
 import br.gov.jfrj.siga.ex.api.v1.IExApiV1.ModeloItem;
 import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.persistencia.ExModeloDaoFiltro;
 
 public class ModelosGet implements IModelosGet {
 
@@ -20,17 +22,19 @@ public class ModelosGet implements IModelosGet {
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-		boolean isEditandoAnexo = false;
-		boolean isCriandoSubprocesso = false;
-		ExMobil mobPai = null;
-		String headerValue = null;
-		boolean isAutuando = false;
+		if (req.permitidos != null && !req.permitidos) {
+			listarModelos(req, resp, ctx);
+		} else {
+			listarModelosPermitidosAoUsuario(req, resp, ctx);
+		}
+	}
 
-		DpPessoa titular = ctx.getTitular();
-		DpLotacao lotaTitular = ctx.getLotaTitular();
-		List<ExModelo> modelos = Ex.getInstance().getBL().obterListaModelos(null, null, isEditandoAnexo,
-				isCriandoSubprocesso, mobPai, headerValue, true, titular, lotaTitular, isAutuando);
-
+	private void listarModelos(Request req, Response resp, ExApiV1Context ctx) 
+			throws Exception {
+		final ExModeloDaoFiltro flt = new ExModeloDaoFiltro();
+		flt.setNome(req.nomemodelo);
+		List<ExModelo> modelos = ExDao.getInstance().consultarPorFiltro(flt);
+		
 		resp.list = new ArrayList<>();
 		for (ExModelo m : modelos) {
 			ModeloItem mi = new ModeloItem();
@@ -42,4 +46,42 @@ public class ModelosGet implements IModelosGet {
 		}
 	}
 
+	private void listarModelosPermitidosAoUsuario(Request req, Response resp, ExApiV1Context ctx) 
+			throws Exception {
+		boolean isEditandoAnexo = false;
+		boolean isCriandoSubprocesso = false;
+		ExMobil mobPai = null;
+		String headerValue = null;
+		boolean isAutuando = false;
+		
+		DpPessoa titular = ctx.getTitular();
+		DpLotacao lotaTitular = ctx.getLotaTitular();
+		List<ExModelo> modelos = Ex.getInstance().getBL().obterListaModelos(null, null, isEditandoAnexo,
+				isCriandoSubprocesso, mobPai, headerValue, true, titular, lotaTitular, isAutuando);
+		
+		String[] args = new String[] {};
+		if (req.nomemodelo != null && !req.nomemodelo.isEmpty())
+			args = req.nomemodelo.split(" ");
+		
+		resp.list = new ArrayList<>();
+		for (ExModelo m : modelos) {
+			ModeloItem mi = new ModeloItem();
+			if (args.length == 0 || contemTexto(m.getNmMod(), args)) {
+				mi.idModelo = m.getId().toString();
+				mi.idModeloInicial = m.getIdInicial().toString();
+				mi.nome = m.getNmMod();
+				mi.descr = m.getDescMod();
+				resp.list.add(mi);
+			}
+		}
+	}
+		
+	private boolean contemTexto(String str, String[] args) {
+		for (String arg : args) {
+			if (!(str != null && str.toUpperCase()
+					.contains(arg.toUpperCase()))) 
+				return false;
+		}
+		return true;
+	}
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdAtivoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdAtivoGet.java
@@ -4,14 +4,15 @@ import java.nio.charset.StandardCharsets;
 
 import br.gov.jfrj.siga.ex.ExModelo;
 import br.gov.jfrj.siga.ex.ExTipoDocumento;
-import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IModelosIdGet;
+import br.gov.jfrj.siga.ex.api.v1.IExApiV1.IModelosIdAtivoGet;
 import br.gov.jfrj.siga.hibernate.ExDao;
 
-public class ModelosIdGet implements IModelosIdGet {
+public class ModelosIdAtivoGet implements IModelosIdAtivoGet {
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-		ExModelo mod = ExDao.getInstance().consultar(Long.parseLong(req.id), ExModelo.class, false);
+		ExModelo modBase = ExDao.getInstance().consultar(Long.parseLong(req.id), ExModelo.class, false);
+		ExModelo mod = ExDao.getInstance().consultarModeloAtual(modBase);
 		resp.idModelo = mod.getId().toString();
 		resp.idModeloInicial = mod.getIdInicial().toString();
 		resp.nome = mod.getNmMod();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosListaHierarquicaGet.java
@@ -40,6 +40,7 @@ public class ModelosListaHierarquicaGet implements IModelosListaHierarquicaGet {
 		for (ListaHierarquicaItem m : getListaHierarquica(modelos).getList()) {
 			ModeloListaHierarquicaItem mi = new ModeloListaHierarquicaItem();
 			mi.idModelo = (m.getValue() != null ? m.getValue().toString() : "");
+			mi.idModeloInicial = (m.getIdInicial() != null ? m.getIdInicial().toString() : "");
 			mi.nome = m.getText();
 			mi.descr = m.getSearchText();
 			mi.level = (long) m.getLevel();
@@ -53,7 +54,7 @@ public class ModelosListaHierarquicaGet implements IModelosListaHierarquicaGet {
 	private ListaHierarquica getListaHierarquica(List<ExModelo> modelos) {
 		ListaHierarquica lh = new ListaHierarquica();
 		for (ExModelo m : modelos) {
-			lh.add(m.getNmMod(), m.getDescMod(), m.getId(), false);
+			lh.add(m.getIdInicial().toString(), m.getNmMod(), m.getDescMod(), m.getId(), false);
 		}
 		return lh;
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/util/ListaHierarquica.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/util/ListaHierarquica.java
@@ -11,7 +11,7 @@ public class ListaHierarquica {
 	List<String> groups = new ArrayList<String>();
 	List<ListaHierarquicaItem> l = new ArrayList<ListaHierarquicaItem>();
 
-	public void add(String text, Long value, boolean selected) {
+	public void add(String idInicial, String text, Long value, boolean selected) {
 		if (text == null || value == null)
 			return;
 		String as[] = text.split(DIVIDER);
@@ -25,14 +25,14 @@ public class ListaHierarquica {
 				groups = groups.subList(0, i);
 				groups.add(s);
 				boolean group = i < as.length - 1;
-				l.add(new ListaHierarquicaItem(i + 1, s, group ? null : Texto.removeAcentoMaiusculas(text),
+				l.add(new ListaHierarquicaItem(i + 1, (group ? null : idInicial), s, group ? null : Texto.removeAcentoMaiusculas(text),
 						group ? null : value, group, group ? false : selected));
 			}
 		}
 	}
 	
 	/* Com Busca complementar*/
-	public void add(String text, String keywords, Long value, boolean selected) {
+	public void add(String idInicial, String text, String keywords, Long value, boolean selected) {
 		if (text == null || value == null)
 			return;
 		String as[] = text.split(DIVIDER);
@@ -46,7 +46,7 @@ public class ListaHierarquica {
 				groups = groups.subList(0, i);
 				groups.add(s);
 				boolean group = i < as.length - 1;
-				l.add(new ListaHierarquicaItem(i + 1, s, group ? null : Texto.removeAcentoMaiusculas(text.concat(" - " + keywords)), keywords,
+				l.add(new ListaHierarquicaItem(i + 1, (group ? null : idInicial), s, group ? null : Texto.removeAcentoMaiusculas(text.concat(" - " + keywords)), keywords,
 						group ? null : value, group, group ? false : selected));
 			}
 		}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/util/ListaHierarquicaItem.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/util/ListaHierarquicaItem.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties({ "selected" })
 public class ListaHierarquicaItem {
 	public int level;
+	public String idInicial;
 	public String text;
 	public String searchText;
 	public String keywords;
@@ -15,9 +16,10 @@ public class ListaHierarquicaItem {
 	public ListaHierarquicaItem() {
 	}
 	
-	public ListaHierarquicaItem(int level, String text, String searchText, Long value, boolean group,
+	public ListaHierarquicaItem(int level, String idInicial, String text, String searchText, Long value, boolean group,
 			boolean selected) {
 		this.level = level;
+		this.idInicial = idInicial;
 		this.text = text;
 		this.searchText = searchText;
 		this.value = value;
@@ -25,9 +27,10 @@ public class ListaHierarquicaItem {
 		this.selected = selected;
 	}
 	
-	public ListaHierarquicaItem(int level, String text, String searchText, String keywords, Long value, boolean group,
+	public ListaHierarquicaItem(int level, String idInicial, String text, String searchText, String keywords, Long value, boolean group,
 			boolean selected) {
 		this.level = level;
+		this.idInicial = idInicial;
 		this.text = text;
 		this.searchText = searchText;
 		this.keywords = keywords;
@@ -38,6 +41,10 @@ public class ListaHierarquicaItem {
 
 	public int getLevel() {
 		return level;
+	}
+
+	public String getIdInicial() {
+		return idInicial;
 	}
 
 	public String getText() {

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -682,6 +682,54 @@ paths:
             properties:
               idModelo:
                 type: string
+              idModeloInicial:
+                type: string
+              nome:
+                type: string
+              descr:
+                type: string
+              especie:
+                type: string
+              nivelDeAcesso:
+                type: string
+              classificacao:
+                type: string
+              classificacaoParaCriacaoDeVias:
+                type: string
+              tipoDeSubscritor:
+                type: string
+              tipoDeDestinatario:
+                type: string
+              tipoDeConteudo:
+                type: string
+              tipoDeDocumento:
+                type: string
+              conteudo:
+                type: string
+        
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
+
+  /modelos/{id}/ativo:
+    get:
+      summary: Obtem o modelo ativo (versão corrente atual) de um modelo específico. O id pode ser de qualquer versão do modelo, ativo ou não.
+      tags: [modelo]
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: "#/parameters/id"
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              idModelo:
+                type: string
+              idModeloInicial:
+                type: string
               nome:
                 type: string
               descr:
@@ -3222,6 +3270,8 @@ definitions:
     properties:
       idModelo:
         type: string
+      idModeloInicial:
+        type: string
       nome:
         type: string
       descr:
@@ -3243,6 +3293,8 @@ definitions:
     type: object
     properties:        
       idModelo:
+        type: string
+      idModeloInicial:
         type: string
       nome:
         type: string

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -90,6 +90,19 @@ parameters:
     description: Sigla do mobil do documento a ser vinculado
     type: string
     required: true
+  nomemodelo:
+    name: nomemodelo
+    in: query
+    description: String contida no nome do modelo a ser pesquisado
+    type: string
+    required: false
+  permitidos:
+    name: permitidos
+    in: query
+    description: Informar true se deseja trazer somente os permitidos para o usuário logado
+    required: false
+    default: true
+    type: boolean    
   completo:
     name: completo
     in: query
@@ -574,11 +587,13 @@ parameters:
 paths:
   /modelos:
     get:
-      summary: Obtem a lista de modelos que o usuário pode criar.
+      summary: Obtem a lista de modelos ativos que o usuário pode criar (permitidos) ou de todos modelos.
       tags: [modelo]
       security:
         - Bearer: []
-      parameters: [] 
+      parameters: 
+        - $ref: "#/parameters/permitidos"
+        - $ref: "#/parameters/nomemodelo"
       responses:
         200:
           description: Successful response


### PR DESCRIPTION
**Webservice para trazer modelo atual ativo** 
Criado o webservice GET /modelos/{id}/ativo que a partir de um id de qualquer versão do modelo traz a versão ativa dele.

**Inclusão idInicial nos resultados das pesquisas**
O campo idInicial passa a ser mostrado no resultado dos seguintes webservices:

- GET /modelos
- GET /modelos/lista-hierarquica
- GET /documentos/{sigla}/modelos-para-incluir
- GET /documentos/{sigla}/modelos-para-autuar
- GET /modelos/{id}

Exemplos do response:

![image](https://user-images.githubusercontent.com/49542320/213554812-cded9a56-f0a2-4896-92e4-6e9ad7d05278.png)

![image](https://user-images.githubusercontent.com/49542320/213554970-982b0a49-1a36-4477-9334-555297e25cbe.png)

**Consulta modelos permitidos ou não e por nome**
Passa a permitir a consulta por nome ou modelos permitidos (o default é somente permitidos para manter compatibilidade).

![image](https://user-images.githubusercontent.com/49542320/213742134-b23a5c83-618a-4e23-9b52-f07dea0f6e8f.png)

A consulta por filtro do modelo foi alterada e corrigida para prever mais parâmetros, trazer inativos, etc.