### PR TITLE
Gerar paginação na tela de assinatura em lote Feature/gov/rm150068

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -211,9 +211,6 @@ import br.gov.jfrj.siga.ex.model.enm.ExTipoDePrincipal;
 		@NamedQuery(name = "listarDocPendenteAssinatura", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
 				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
-		@NamedQuery(name = "listarQuantidadeDocPendenteAssinatura", query = "select COUNT(doc) "
-				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
-				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
 		@NamedQuery(name = "listarDocPendenteAssinaturaERevisado", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
 				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 71 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/AbstractExDocumento.java
@@ -211,6 +211,9 @@ import br.gov.jfrj.siga.ex.model.enm.ExTipoDePrincipal;
 		@NamedQuery(name = "listarDocPendenteAssinatura", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
 				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
+		@NamedQuery(name = "listarQuantidadeDocPendenteAssinatura", query = "select COUNT(doc) "
+				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
+				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 25 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),
 		@NamedQuery(name = "listarDocPendenteAssinaturaERevisado", query = "select doc "
 				+ "			from ExDocumento doc where doc.idDoc in (select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in "
 				+ "			(select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = 71 and label.dpPessoaIni.idPessoa = :idPessoaIni)) order by doc.dtDoc desc"),

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1716,12 +1716,12 @@ public class ExDao extends CpDao {
 			return null;
 		}
 	}
-	
+
 	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, boolean apenasComSolicitacaoDeAssinatura) {
 		final Query query = em().createNamedQuery(
 				"listarDocPendenteAssinatura" + (apenasComSolicitacaoDeAssinatura ? "ERevisado" : ""));
 		query.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
-		return  query.getResultList();
+		return query.getResultList();
 	}
 
 	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1718,14 +1718,16 @@ public class ExDao extends CpDao {
 	}
 	
 	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, boolean apenasComSolicitacaoDeAssinatura) {
-		return listarDocPendenteAssinatura(pessoa, apenasComSolicitacaoDeAssinatura, null, null);
+		final Query query = em().createNamedQuery(
+				"listarDocPendenteAssinatura" + (apenasComSolicitacaoDeAssinatura ? "ERevisado" : ""));
+		query.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
+		return  query.getResultList();
 	}
 
 	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, 
 											boolean apenasComSolicitacaoDeAssinatura, Integer offset, Integer tamPagina) {
-		final Query query = em().createNamedQuery(
-				"listarDocPendenteAssinatura" + (apenasComSolicitacaoDeAssinatura ? "ERevisado" : ""));
-		query.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
+		final Query query = em().createQuery(getHqlListarDocPendenteAssinatura(apenasComSolicitacaoDeAssinatura, Boolean.FALSE))
+								.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
 		if (Objects.nonNull(offset)) {
 			query.setFirstResult(offset);
 		}
@@ -1735,10 +1737,22 @@ public class ExDao extends CpDao {
 		return query.getResultList();
 	}
 	
-	public Long listarQuantidadeDocPendenteAssinatura(DpPessoa pessoa) {
-		return (Long) em().createNamedQuery("listarQuantidadeDocPendenteAssinatura", Long.class)
+	public Long listarQuantidadeDocPendenteAssinatura(DpPessoa pessoa, boolean apenasComSolicitacaoDeAssinatura) {
+		return (Long) em().createQuery(getHqlListarDocPendenteAssinatura(apenasComSolicitacaoDeAssinatura, Boolean.TRUE), Long.class)
 								.setParameter("idPessoaIni", pessoa.getIdPessoaIni())
 								.getSingleResult();
+	}
+	
+	private String getHqlListarDocPendenteAssinatura(boolean apenasComSolicitacaoDeAssinatura, boolean queryContar) {
+		StringBuilder sb = new StringBuilder("select  " + (queryContar ? " COUNT(doc) " : " doc "));
+		sb.append("	from ExDocumento doc where doc.idDoc in (");
+		sb.append("				select distinct(exDocumento.idDoc) from ExMobil mob where mob.idMobil in (");
+		sb.append("						select exMobil.idMobil from ExMarca label where label.cpMarcador.idMarcador = ");
+		sb.append(apenasComSolicitacaoDeAssinatura ? CpMarcadorEnum.PRONTO_PARA_ASSINAR.getId() : CpMarcadorEnum.COMO_SUBSCRITOR.getId());
+		sb.append("						and label.dpPessoaIni.idPessoa = :idPessoaIni)) ");
+		sb.append(" and dtFinalizacao is not null ");
+		sb.append(" order by doc.dtDoc desc  ");
+		return sb.toString();
 	}
 	
 	public List<ExMovimentacao> listarAnexoPendenteAssinatura(DpPessoa pessoa) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/hibernate/ExDao.java
@@ -1701,14 +1701,31 @@ public class ExDao extends CpDao {
 			return null;
 		}
 	}
-
+	
 	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, boolean apenasComSolicitacaoDeAssinatura) {
+		return listarDocPendenteAssinatura(pessoa, apenasComSolicitacaoDeAssinatura, null, null);
+	}
+
+	public List<ExDocumento> listarDocPendenteAssinatura(DpPessoa pessoa, 
+											boolean apenasComSolicitacaoDeAssinatura, Integer offset, Integer tamPagina) {
 		final Query query = em().createNamedQuery(
 				"listarDocPendenteAssinatura" + (apenasComSolicitacaoDeAssinatura ? "ERevisado" : ""));
 		query.setParameter("idPessoaIni", pessoa.getIdPessoaIni());
+		if (Objects.nonNull(offset)) {
+			query.setFirstResult(offset);
+		}
+		if (Objects.nonNull(tamPagina)) {
+			query.setMaxResults(tamPagina);
+		}
 		return query.getResultList();
 	}
-
+	
+	public Long listarQuantidadeDocPendenteAssinatura(DpPessoa pessoa) {
+		return (Long) em().createNamedQuery("listarQuantidadeDocPendenteAssinatura", Long.class)
+								.setParameter("idPessoaIni", pessoa.getIdPessoaIni())
+								.getSingleResult();
+	}
+	
 	public List<ExMovimentacao> listarAnexoPendenteAssinatura(DpPessoa pessoa) {
 		final Query query = em().createNamedQuery(
 				"listarAnexoPendenteAssinatura");

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -203,7 +203,8 @@ public class ExMovimentacaoController extends ExController {
 			.getLogger(ExMovimentacaoController.class);
 	
 	
-	private static final int MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE = 30;
+	private static final int MAX_ITENS_PAGINA_TRINTA = 30;
+	private static final int MAX_ITENS_PAGINA_DUZENTOS = 200;
 	
 	/**
 	 * @deprecated CDI eyes only
@@ -2484,12 +2485,12 @@ public class ExMovimentacaoController extends ExController {
 		Long tamanho = dao().consultarQuantidadeParaAcompanhamentoEmLote(getTitular(), chkGestorInteressado);
 
 		int offset = Objects.nonNull(paramoffset)
-				? ((paramoffset >= tamanho) ? ((paramoffset / MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE - 1) * MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE)
+				? ((paramoffset >= tamanho) ? ((paramoffset / MAX_ITENS_PAGINA_TRINTA - 1) * MAX_ITENS_PAGINA_TRINTA)
 						: paramoffset) : 0;
 
-		final List<ExMobil> provItens = (tamanho <= MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE)
+		final List<ExMobil> provItens = (tamanho <= MAX_ITENS_PAGINA_TRINTA)
 				? dao().consultarParaAcompanhamentoEmLote(getTitular(), chkGestorInteressado, null, null)
-				: dao().consultarParaAcompanhamentoEmLote(getTitular(), chkGestorInteressado, offset, MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE);
+				: dao().consultarParaAcompanhamentoEmLote(getTitular(), chkGestorInteressado, offset, MAX_ITENS_PAGINA_TRINTA);
 		
 		result.include("sigla", sigla);
 		result.include("listaTipoRespPerfil", this.getListaTipoRespPerfil());
@@ -2501,9 +2502,9 @@ public class ExMovimentacaoController extends ExController {
 		result.include("chkGestorInteressado", chkGestorInteressado);
 		
 		result.include("itens", provItens);
-		result.include("maxItems", MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE);
+		result.include("maxItems", MAX_ITENS_PAGINA_TRINTA);
 		result.include("tamanho", tamanho);
-		result.include("currentPageNumber", (offset / MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE + 1));
+		result.include("currentPageNumber", (offset / MAX_ITENS_PAGINA_TRINTA + 1));
 	}
 	
 	private List<ExPapel> obterApenasPapeisParaVinculo(){
@@ -3009,25 +3010,15 @@ public class ExMovimentacaoController extends ExController {
 	public void assina_lote(Integer paramoffset) throws Exception {
 		boolean apenasComSolicitacaoDeAssinatura = !Ex.getInstance().getConf().podePorConfiguracao(getTitular(), ExTipoDeConfiguracao.PODE_ASSINAR_SEM_SOLICITACAO);
 		
-		Long tamanho = dao().listarQuantidadeDocPendenteAssinatura(getTitular());
-		
+		Long tamanho = dao().listarQuantidadeDocPendenteAssinatura(getTitular(), apenasComSolicitacaoDeAssinatura);
 		int offset = Objects.nonNull(paramoffset)
-				? ((paramoffset >= tamanho) ? ((paramoffset / MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE - 1) * MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE)
+				? ((paramoffset >= tamanho) ? ((paramoffset / MAX_ITENS_PAGINA_DUZENTOS - 1) * MAX_ITENS_PAGINA_DUZENTOS)
 						: paramoffset) : 0;
 		
-		final List<ExDocumento> itensComoSubscritor = (tamanho <= MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE)
+		final List<ExDocumento> itensFinalizados = (tamanho <= MAX_ITENS_PAGINA_DUZENTOS)
 				? dao().listarDocPendenteAssinatura(getTitular(), apenasComSolicitacaoDeAssinatura, null, null)
-				: dao().listarDocPendenteAssinatura(getTitular(), apenasComSolicitacaoDeAssinatura, offset, MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE);
+				: dao().listarDocPendenteAssinatura(getTitular(), apenasComSolicitacaoDeAssinatura, offset, MAX_ITENS_PAGINA_DUZENTOS);
 		
-		
-		//final List<ExDocumento> itensComoSubscritor = dao().listarDocPendenteAssinatura(getTitular(), apenasComSolicitacaoDeAssinatura);
-		final List<ExDocumento> itensFinalizados = new ArrayList<ExDocumento>();
-
-		for (final ExDocumento doc : itensComoSubscritor) {
-
-			if (doc.isFinalizado())
-				itensFinalizados.add(doc);
-		}
 		final List<ExDocumento> documentosQuePodemSerAssinadosComSenha = new ArrayList<ExDocumento>();
 		Boolean podeAssinarComCertDigital = false;
 
@@ -3053,9 +3044,9 @@ public class ExMovimentacaoController extends ExController {
 		result.include("itensSolicitados", itensFinalizados);
 		result.include("request", getRequest());
 		
-		result.include("maxItems", MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE);
+		result.include("maxItems", MAX_ITENS_PAGINA_DUZENTOS);
 		result.include("tamanho", tamanho);
-		result.include("currentPageNumber", (offset / MAX_ITENS_PAGINA_ACOMPANHAMENTO_LOTE + 1));
+		result.include("currentPageNumber", (offset / MAX_ITENS_PAGINA_DUZENTOS + 1));
 	}
 
 	@Get("/app/expediente/mov/assinar_tudo")

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
@@ -107,7 +107,7 @@
 				<div class="card-body">
 					<div id="dados-assinatura" style="visible: hidden">
 						<input type="hidden" name="ad_url_base" value="" /> <input
-								type="hidden" name="ad_url_next" value="/siga/app/principal" />
+								type="hidden" name="ad_url_next" value="/sigaex/app/expediente/mov/assinar_lote" />
 						<c:set var="botao" value="" />
 							<c:if test="${autenticando}">
 								<c:set var="botao" value="autenticando" />
@@ -139,6 +139,7 @@
 			</div>
 			<c:if test="${(not empty itensSolicitados)}">
 				<h5>Documentos pendentes de assinatura: <fmt:message key="tela.assina.lote.subscritor" /></h5>
+				<h5>Atenção: Na Assinatura em Lote – Permitido até 200 documentos por operação.</h5>
 				<div>
 					<table class="table table-hover table-striped">
 						<thead class="${thead_color} align-middle text-center">
@@ -164,7 +165,6 @@
 							</tr>
 						</thead>
 						<tbody class="table-bordered">
-<%-- 							<c:forEach var="doc" items="${itensSolicitados}"> --%>
 							<siga:paginador maxItens="${maxItems}" maxIndices="10"
 										totalItens="${tamanho}" itens="${itensSolicitados}" var="doc">
 								<c:set var="x" scope="request">ad_chk_${doc.idDoc}</c:set>
@@ -207,7 +207,6 @@
 								<input type="hidden" name="ad_kind_${doc.idDoc}"
 									value="${doc.descrFormaDoc}" />
 							
-<%-- 							</c:forEach> --%>
 							</siga:paginador>
 						</tbody>
 					</table>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
@@ -166,7 +166,7 @@
 						<tbody class="table-bordered">
 <%-- 							<c:forEach var="doc" items="${itensSolicitados}"> --%>
 							<siga:paginador maxItens="${maxItems}" maxIndices="10"
-										totalItens="${tamanho}" itens="${itensSolicitados}" var="documento">
+										totalItens="${tamanho}" itens="${itensSolicitados}" var="doc">
 								<c:set var="x" scope="request">ad_chk_${doc.idDoc}</c:set>
 								<c:remove var="x_checked" scope="request" />
 								<c:if test="${param[x] == 'true'}">
@@ -176,7 +176,7 @@
 									<td width="3%" align="center">
 										<input type="checkbox" name="${x}" value="true" ${x_checked} />
 									</td>
-									<td width="13%" align="left"><a
+									<td width="17%" align="left"><a
 										href="/sigaex/app/expediente/doc/exibir?sigla=${doc.sigla}">${doc.codigo}</a>
 									</td>
 									<td width="5%" align="center">${doc.dtDocDDMMYY}</td>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/assina_lote.jsp
@@ -24,6 +24,19 @@
 	</script>
 
 	<script type="text/javascript" language="Javascript1.1">
+	
+		function sbmt(offset) {
+			if (offset == null) {
+				offset = 0;
+			}
+			let form = document.forms['frm'];
+			form ["paramoffset"].value = offset;
+			form.action = "assinar_lote";
+			form.method = "GET";
+			form ["p.offset"].value = offset;
+	
+			form.submit();
+		}
 		function checkUncheckAll(theElement) {
 			var theForm = theElement.form, z = 0;
 			for (z = 0; z < theForm.length; z++) {
@@ -85,6 +98,8 @@
 	<div class="container-fluid">
 		<form name="frm" id="frm" cssClass="form" theme="simple">
 			<input type="hidden" name="postback" value="1" />
+			<input type="hidden" name="paramoffset" value="0" />
+			<input type="hidden" name="p.offset" value="0" />
 			<div class="card bg-light mb-3">
 				<div class="card-header">
 					<h5>Assinatura em Lote</h5>
@@ -149,7 +164,9 @@
 							</tr>
 						</thead>
 						<tbody class="table-bordered">
-							<c:forEach var="doc" items="${itensSolicitados}">
+<%-- 							<c:forEach var="doc" items="${itensSolicitados}"> --%>
+							<siga:paginador maxItens="${maxItems}" maxIndices="10"
+										totalItens="${tamanho}" itens="${itensSolicitados}" var="documento">
 								<c:set var="x" scope="request">ad_chk_${doc.idDoc}</c:set>
 								<c:remove var="x_checked" scope="request" />
 								<c:if test="${param[x] == 'true'}">
@@ -190,7 +207,8 @@
 								<input type="hidden" name="ad_kind_${doc.idDoc}"
 									value="${doc.descrFormaDoc}" />
 							
-							</c:forEach>
+<%-- 							</c:forEach> --%>
+							</siga:paginador>
 						</tbody>
 					</table>
 				</div>


### PR DESCRIPTION
Necessário criar paginação, poisa funcionalidade Assinatura em Lote não possui paginação na seleção de documentos.

4.	Regra de Negócio:
RN – 01 Criar paginação padrão de exibição de lista de documentos na Funcionalidade Assinar em Lote.
RN – 02 Deverá ser listado até 200 documentos por página.
RN – 03 - Permitir a seleção de todos, um ou mais documentos dentro da mesa página através do checkbox, limitado a 200 documentos exibidos na página.Assim como é feito na tramitação em Lote.
RN–04- Necessário incluir o aviso na tela Assinar em Lote, informando o limite máximo de até 200 documentos por operação(página) na Assinatura em Lote vide Fig.03.
RN–05 – Ao realizar Assinatura de documentos no assinar em Lote, após a operação o sistema deverá retornar para a tela de assinatura em lote, caso o usuário possua mais documentos além do que foi assinado, o sistema deverá carregar novamente os documentos para uma nova operação.

Prints após Implementação:

![image](https://user-images.githubusercontent.com/15185675/214399142-d2ea9511-2704-4372-bbec-ae55f21f7a08.png)

------------------------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/214399412-6c6d9554-934b-4a64-bc41-62bc97001300.png)

------------------------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/15185675/214399260-20f4ab3d-0d53-433d-b3a6-d99c9d954608.png)

![image](https://user-images.githubusercontent.com/15185675/214399603-9c85d25e-7fac-4b55-949a-bc7a4cb7cf1c.png)

