### PR TITLE
RM134274 - Juntada de Interno Capturado apenas Após Assinatura

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeJuntar.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeJuntar.java
@@ -85,11 +85,7 @@ public class ExPodeJuntar extends CompositeExpressionSupport {
 
 						new ExPodeMovimentar(mob, titular, lotaTitular)),
 
-				Or.of(
-
-						Not.of(new ExEstaPendenteDeAssinatura(mob.doc())),
-
-						new ExEInternoCapturado(mob.doc())),
+				Not.of(new ExEstaPendenteDeAssinatura(mob.doc())),
 
 				Not.of(new ExEstaJuntado(mob)),
 


### PR DESCRIPTION
Conforme solicitação: "A juntada deverá acontecer após assinatura do (os) cossignatário (os)" 

Juntada de documentos Internamente Capturados devem seguir o mesmo comportamento dos documentos Internamente Produzidos.  
Só será permitida a juntada dos DCIs apenas após todos os signatários (subscritor e todos os cossignatários)  assinarem o documento.

Retirada condição que jumpeava a condição do "Não Está Pendente de Assinatura" do Documento Interno Capturado.

**Juntada Automática**
![image](https://user-images.githubusercontent.com/20362170/214873264-98be4efd-e2df-4434-9b36-525400b0ff0a.png)
![image](https://user-images.githubusercontent.com/20362170/214873424-f23e6fb1-ce11-49e0-8afb-6905ca7526fd.png)

**Juntada Manual**
![image](https://user-images.githubusercontent.com/20362170/214873933-c2040481-e3c1-4fea-80d6-824aedf466ba.png)
![image](https://user-images.githubusercontent.com/20362170/214874206-19435130-bc8d-4b57-b59f-c2cb2315d8c0.png)
