### PR TITLE
RM126684 Personalizar assinatura documentos autenticados

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -191,7 +191,9 @@ public class Documento {
 				/*** Exibe para Documentos Capturados a Funcao / Unidade ***/
 				if (movAssinatura.getExDocumento().isInternoCapturado()
 						&& (movAssinatura.getExTipoMovimentacao() == ExTipoDeMovimentacao.ASSINATURA_COM_SENHA
-								|| movAssinatura.getExTipoMovimentacao() == ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO)) {
+							|| movAssinatura.getExTipoMovimentacao() == ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO
+							|| movAssinatura.getExTipoMovimentacao() == ExTipoDeMovimentacao.CONFERENCIA_COPIA_COM_SENHA
+							|| movAssinatura.getExTipoMovimentacao() == ExTipoDeMovimentacao.CONFERENCIA_COPIA_DOCUMENTO)) {
 					/* Interno Exibe Personalização se realizada */
 					s.append(Ex.getInstance().getBL().extraiPersonalizacaoAssinatura(movAssinatura,true));
 				} else if (movAssinatura.getExDocumento().isExternoCapturado()

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -8495,8 +8495,11 @@ public class ExBL extends CpBL {
 		 *getNmFuncaoSubscritor = [0] - personalizarFuncao [1] - personalizarUnidade [2] - personalizarLocalidade [3] - personalizarNome
 		 */
 		
-		if (movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.ASSINATURA_COM_SENHA && movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO) {
-			throw new RuntimeException("Não é possível extrair personalização de movimentações que não são de assinatura.");
+		if (movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.ASSINATURA_COM_SENHA 
+				&& movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO
+				&& movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.CONFERENCIA_COPIA_COM_SENHA
+				&& movimentacao.getExTipoMovimentacao() != ExTipoDeMovimentacao.CONFERENCIA_COPIA_DOCUMENTO) {
+			throw new RuntimeException("Não é possível extrair personalização de movimentações que não são de assinatura ou autenticação.");
 		}
 		
 		SortedSet<ExMovimentacao> listaMovimentacoes = movimentacao.mob().getExMovimentacaoSet();


### PR DESCRIPTION
### Personalizar assinatura documentos autenticados

Atualmente a personalização de assinatura nas estampas do rodapé do documento ocorre somente para documentos com os tipos  ASSINATURA_COM_SENHA e ASSINATURA_DIGITAL_DOCUMENTO.

Foi solicitado que documentos capturado interno autenticados também tenham esse mesmo comportamento

#### Objetivo extraído do documento de requisitos

Registrar a informação da Unidade e Função quando preenchido a opção Personalizar para os documentos de Modelo Capturados Interno que são Autenticados.

### Resumo da implementação

Foram adicionados os tipos CONFERENCIA_COPIA_COM_SENHA e CONFERENCIA_COPIA_DOCUMENTO na condicional do método getAssinantesStringLista(...) para retornar a string "Autenticado com senha por" concatenada com a assinatura personalizada

### Captura de tela

![image](https://user-images.githubusercontent.com/1022974/214908878-df9cd30c-fccd-4ad3-a5a7-1331cf7f6452.png)

