### PR TITLE
RM151740 - Cria Cache Query Corporativo com lifespan de 10min

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -116,6 +116,7 @@ public class CpDao extends ModeloDao {
 	public static final String CACHE_QUERY_CONFIGURACAO = "queryConfiguracao";
 	public static final String CACHE_QUERY_SECONDS = "querySeconds";
 	public static final String CACHE_QUERY_HOURS = "queryHours";
+	public static final String CACHE_QUERY_CORPORATIVO = "queryCorporativo";
 	public static final String CACHE_CORPORATIVO = "corporativo";
 	public static final String CACHE_HOURS = "hours";
 	public static final String CACHE_SECONDS = "seconds";
@@ -359,7 +360,7 @@ public class CpDao extends ModeloDao {
 			query.setParameter("nome", s);
 
 			query.setHint("org.hibernate.cacheable", true);
-			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 			final List<CpOrgaoUsuario> l = query.getResultList();
 			return l;
@@ -396,7 +397,7 @@ public class CpDao extends ModeloDao {
 			query.setParameter("nome", s);
 
 			query.setHint("org.hibernate.cacheable", true);
-			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 			final List<CpOrgaoUsuario> l = query.getResultList();
 			return l;
@@ -411,7 +412,7 @@ public class CpDao extends ModeloDao {
 		query.setParameter("idOrgaoUsu", o.getIdOrgaoUsu());
 
 		query.setHint("org.hibernate.cacheable", true);
-		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 		final List<CpOrgaoUsuario> l = query.getResultList();
 		if (l.size() != 1)
@@ -456,7 +457,7 @@ public class CpDao extends ModeloDao {
 		query.setParameter("nome", o.getNmOrgaoUsu());
 
 		query.setHint("org.hibernate.cacheable", true);
-		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+		query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 		final List<CpOrgaoUsuario> l = query.getResultList();
 		if (l.size() < 1)
@@ -481,7 +482,7 @@ public class CpDao extends ModeloDao {
 			query.setParameter("nome", s);
 
 			query.setHint("org.hibernate.cacheable", true);
-			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+			query.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 			final int l = ((Long) query.getSingleResult()).intValue();
 			return l;
@@ -2186,10 +2187,8 @@ public class CpDao extends ModeloDao {
 	public List<CpOrgaoUsuario> consultaCpOrgaoUsuario() {
 		final Query qry = em().createNamedQuery("consultarCpOrgaoUsuario");
 
-		// Renato: Alterei para fazer cache. Nao vejo porque nao possamos fazer
-		// cache dessa consulta.
 		qry.setHint("org.hibernate.cacheable", true);
-		qry.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);
+		qry.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);
 
 		final List<CpOrgaoUsuario> lista = qry.getResultList();
 		return lista;
@@ -2333,9 +2332,8 @@ public class CpDao extends ModeloDao {
 		
         Query query = em().createNamedQuery("consultarCpOrgaoUsuario")        	
         		.setHint("org.hibernate.cacheable", true)
-        		.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);                
+        		.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);             
         return (List<CpOrgaoUsuario>) query.getResultList();
-//		return findAndCacheByCriteria(CACHE_QUERY_HOURS, CpOrgaoUsuario.class);
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -2343,9 +2341,8 @@ public class CpDao extends ModeloDao {
 		
         Query query = em().createNamedQuery("consultarCpOrgaoUsuarioTodos")        	
         		.setHint("org.hibernate.cacheable", true)
-        		.setHint("org.hibernate.cacheRegion", CACHE_QUERY_HOURS);                
+        		.setHint("org.hibernate.cacheRegion", CACHE_QUERY_CORPORATIVO);    
         return (List<CpOrgaoUsuario>) query.getResultList();
-//		return findAndCacheByCriteria(CACHE_QUERY_HOURS, CpOrgaoUsuario.class);
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/siga/src/main/webapp/META-INF/persistence.xml
+++ b/siga/src/main/webapp/META-INF/persistence.xml
@@ -181,6 +181,13 @@
 			<property
 				name="hibernate.cache.infinispan.corporativo.expiration.max_idle"
 				value="300000" />
+				
+			<!-- Cache Region CACHE_QUERY_CORPORATIVO 10 minutos-->
+			<property name="hibernate.cache.infinispan.queryCorporativo.eviction.wake_up_interval" value="2500" />
+			<property name="hibernate.cache.infinispan.queryCorporativo.memory.size" value="10000" />
+			<property name="hibernate.cache.infinispan.queryCorporativo.expiration.lifespan" value="600000" />
+			<property name="hibernate.cache.infinispan.queryCorporativo.expiration.max_idle" value="300000" />	
+				
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/siga/src/main/webapp/META-INF/persistence.xml
+++ b/siga/src/main/webapp/META-INF/persistence.xml
@@ -184,7 +184,7 @@
 				
 			<!-- Cache Region CACHE_QUERY_CORPORATIVO 10 minutos-->
 			<property name="hibernate.cache.infinispan.queryCorporativo.eviction.wake_up_interval" value="2500" />
-			<property name="hibernate.cache.infinispan.queryCorporativo.memory.size" value="10000" />
+			<property name="hibernate.cache.infinispan.queryCorporativo.eviction.max_entries" value="10000" />
 			<property name="hibernate.cache.infinispan.queryCorporativo.expiration.lifespan" value="600000" />
 			<property name="hibernate.cache.infinispan.queryCorporativo.expiration.max_idle" value="300000" />	
 				


### PR DESCRIPTION
Queries que traziam dados da tabela CP_ORGAO_USUARIO estavam utilizando o cache "Query Hours" que tem o tempo de vida de 10 HORAS. 

Com a edição do órgão permitida na versão 11, ambientes principalmente standalone estavam apresentando instabilidade de horas após a edição do órgão. 
Ora caia em um servidor atualizado, ora caia em um servidor que estava com dados defasados, provocando falha como se o órgão não existisse.

Foi criado um novo cache region com tempo de vida de 10min visto que as queries são razoavelmente leves e o órgão razoavelmente imutável, o que deve dar 144 execuções por JVM máximo durante o dia, salvo execuções adicionais por estouro no número de entradas e memória.