### PR TITLE
RM135943 - Constraint para Impedir Serviço Null para Configuração tipo 200

### DIFF
--- a/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V136_0__check_constraint_configuracao_servico.sql
+++ b/siga-cp/src/main/resources/db/migration/CORPORATIVO_UTF8_V136_0__check_constraint_configuracao_servico.sql
@@ -1,0 +1,17 @@
+-- Check Constraint
+-- Se tipo de configuração igual a 200 (Configuração de Serviço) não permite que serviço seja null
+
+-- Pré-Script: Encerramento de Configurações tipo 200 sem Serviço Especificado
+UPDATE CORPORATIVO.CP_CONFIGURACAO SET HIS_DT_FIM = sysdate 
+WHERE
+		ID_TP_CONFIGURACAO = 200 
+    AND ID_SERVICO IS NULL
+    AND HIS_DT_FIM IS NULL;
+COMMIT;
+
+ALTER TABLE CORPORATIVO.CP_CONFIGURACAO
+ADD CONSTRAINT CHK_CONFIGURACAO_SERVICO
+CHECK (
+	   (ID_TP_CONFIGURACAO != 200) 
+    OR (ID_TP_CONFIGURACAO = 200 AND (ID_SERVICO IS NOT NULL OR HIS_DT_FIM IS NOT NULL ))
+);

--- a/siga-cp/src/main/resources/db/mysql/sigacp/V136.0__check_constraint_configuracao_servico.sql
+++ b/siga-cp/src/main/resources/db/mysql/sigacp/V136.0__check_constraint_configuracao_servico.sql
@@ -1,0 +1,17 @@
+-- Check Constraint
+-- Se tipo de configuração igual a 200 (Configuração de Serviço) não permite que serviço seja null
+
+-- Pré-Script: Encerramento de Configurações tipo 200 sem Serviço Especificado
+UPDATE corporativo.cp_configuracao SET HIS_DT_FIM = current_timestamp() 
+WHERE
+		ID_TP_CONFIGURACAO = 200 
+    AND ID_SERVICO IS NULL
+    AND HIS_DT_FIM IS NULL;
+COMMIT;
+
+ALTER TABLE corporativo.cp_configuracao
+ADD CONSTRAINT CHK_CONFIGURACAO_SERVICO 
+CHECK (
+	   (ID_TP_CONFIGURACAO != 200) 
+    OR (ID_TP_CONFIGURACAO = 200 AND (ID_SERVICO IS NOT NULL OR HIS_DT_FIM IS NOT NULL ))
+);


### PR DESCRIPTION
**Objetivo:** Adicionar constraint para garantir que não haja configurações ATIVAS do tipo 200 (Configuração de Serviços) sem serviços especificados.

Configurações do Tipo 200 (Configuração de Serviço) requer que o ID_SERVICO seja informado, caso contrário corre o risco de cadastrar um PODE para qualquer coisa e para qualquer usuário.

Criada constraint CHK_CONFIGURACAO_SERVICO que se for diferente de 200 (não serviço) permite inserir normalmente, mas se for igual a 200 obriga o ID_SERVICO não ser NULL, desconsiderando as configurações com DT_FIM preenchida (configurações encerradas).

O pré-script encerra as configurações defeituosas:
       Tipo 200 + Servico Null + DT_FIM Null