### PR TITLE
RM151536 Seleção de itens em múltiplas páginas na paginação

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -93,7 +93,7 @@ public class ExMobilController extends
 	private static final String SIGA_DOC_PESQ_DTLIMITADA = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;DTLIMITADA:Pesquisar somente com data limitada";
 
 	private static final int MAX_ITENS_PAGINA_TRAMITACAO_LOTE = 200;
-	private static final int MAX_ITENS_PAGINA_RECLASSIFICACAO_LOTE = 50;
+	private static final int MAX_ITENS_PAGINA_RECLASSIFICACAO_LOTE = 200;
 	/**
 	 * @deprecated CDI eyes only
 	 */

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5613,7 +5613,7 @@ public class ExMovimentacaoController extends ExController {
 										  final DpPessoaSelecao subscritorSel, 
 										  final ExClassificacaoSelecao classificacaoAtualSel, 
 										  final ExClassificacaoSelecao classificacaoNovaSel, 
-										  final List<Long> documentosSelecionados, 
+										  final String siglasDocumentosSelecionados, 
 										  final int offset) throws Exception {
 		
 		assertAcesso("RECLALOTE:Reclassificar em Lote");
@@ -5637,7 +5637,12 @@ public class ExMovimentacaoController extends ExController {
 			return;
 		}
 
-		if(documentosSelecionados.isEmpty()){
+		String[] arraySiglasDocumentosSelecionados = { };
+		if (siglasDocumentosSelecionados != null) {
+			arraySiglasDocumentosSelecionados = siglasDocumentosSelecionados.split(",");
+		}
+		
+		if(arraySiglasDocumentosSelecionados.length == 0){
 			result.include("msgCabecClass", "alert-danger");
 			result.include("mensagemCabec", "Não foram selecionados documentos para a reclassificação");
 			result.redirectTo(this).reclassificar_lote(motivo, dtMovString, obsOrgao, substituicao, titularSel,
@@ -5652,8 +5657,8 @@ public class ExMovimentacaoController extends ExController {
 		mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
 		
 		try {
-			for (Long idDocumento : documentosSelecionados) {
-				final ExMobil mob = dao().consultar(idDocumento, ExDocumento.class, false).getMobilGeral();
+			for (String idDocumento : arraySiglasDocumentosSelecionados) {
+				final ExMobil mob = dao().consultar(Long.valueOf(idDocumento), ExDocumento.class, false).getMobilGeral();
 
 				if (Ex.getInstance().getComp().pode(ExPodeReclassificar.class, getTitular(), getLotaTitular(), mob)) {
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5645,8 +5645,8 @@ public class ExMovimentacaoController extends ExController {
 			return;
 		}
 
-		final ExMovimentacao mov = ExMovimentacaoBuilder
-				.novaInstancia().setDescrMov(motivo).setDtMovString(dtMovString).setObsOrgao(obsOrgao)
+		final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia()
+				.setDescrMov(motivo).setDtMovString(dtMovString).setObsOrgao(obsOrgao).setCadastrante(getCadastrante())
 				.setSubstituicao(substituicao).setTitularSel(titularSel).setSubscritorSel(subscritorSel)
 				.setClassificacaoSel(classificacaoNovaSel).construir(dao());
 		mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
@@ -5657,7 +5657,7 @@ public class ExMovimentacaoController extends ExController {
 
 				if (Ex.getInstance().getComp().pode(ExPodeReclassificar.class, getTitular(), getLotaTitular(), mob)) {
 
-					Ex.getInstance().getBL().avaliarReclassificar(mov.getTitular(), mov.getLotaTitular(), mob,
+					Ex.getInstance().getBL().avaliarReclassificar(mov.getCadastrante(), mov.getLotaCadastrante(), mob,
 							mov.getDtMov(), mov.getSubscritor(), mov.getExClassificacao(), mov.getDescrMov(), false);
 				}
 			}

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
@@ -23,13 +23,10 @@
 
             <siga:paginador maxItens="50" maxIndices="50" totalItens="${tamanho}"
                             itens="${itens}" var="documento">
-                <c:set var="x" scope="request">
-                    chk_${documento.idDoc}
-                </c:set>
                 <tr class="even">
                     <td width="3%" align="center">
-                        <input type="checkbox" name="documentosSelecionados"
-                               value="${documento.idDoc}" id="${x}" class="chkDocumento" onclick="displaySel()"/>
+                        <input type="checkbox" id="${documento.idDoc}" class="chkDocumento"
+                               onclick="atualizaDocumentoSelecionado(this)"/>
                     </td>
                     <td width="13%" align="right">${documento.sigla}</td>
                     <td width="5%" align="center">${documento.classificacaoSigla}</td>
@@ -48,13 +45,19 @@
         listarDocumentosParaReclassificarEmLote(offset);
     }
 
-    function checkUncheckAll(theElement) {
-        let isChecked = theElement.checked;
-        Array.from(document.getElementsByClassName('chkDocumento')).forEach(chk => chk.checked = isChecked);
+    function checkUncheckAll(el) {
+
+        Array.from(document.getElementsByClassName('chkDocumento'))
+            .forEach(chk => {
+                chk.checked = el.checked;
+                atualizaDocumentoSelecionado(el);
+            });
     }
 
-    function displaySel() {
-        document.getElementById('checkall').checked =
-            Array.from(document.getElementsByClassName('chkDocumento')).every(chk => chk.checked);
-    }
+    Array.from(obtemDocumentosSelecionados())
+        .forEach(sel => {
+            if (document.getElementById(sel))
+                document.getElementById(sel).checked = true;
+        });
+
 </script>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
@@ -21,7 +21,7 @@
             </thead>
             <tbody class="table-bordered">
 
-            <siga:paginador maxItens="50" maxIndices="50" totalItens="${tamanho}"
+            <siga:paginador maxItens="200" maxIndices="50" totalItens="${tamanho}"
                             itens="${itens}" var="documento">
                 <tr class="even">
                     <td width="3%" align="center">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
@@ -5,6 +5,8 @@
 <%@ taglib uri="http://localhost/jeetags" prefix="siga" %>
 
 <c:if test="${not empty itens}">
+    <p>Atenção: Na Reclassificação em Lote – Permitido até 200 documentos por operação.</p>
+    <p>Quantidade de documentos selecionados: <span id="qtdDocumentosSelecionados"></span></p>
     <div class="gt-content-box gt-for-table">
         <table class="table table-hover table-striped">
             <thead class="thead-dark align-middle text-center">
@@ -50,14 +52,15 @@
         Array.from(document.getElementsByClassName('chkDocumento'))
             .forEach(chk => {
                 chk.checked = el.checked;
-                atualizaDocumentoSelecionado(el);
+                atualizaDocumentoSelecionado(chk);
             });
     }
 
     Array.from(obtemDocumentosSelecionados())
         .forEach(sel => {
-            if (document.getElementById(sel))
-                document.getElementById(sel).checked = true;
+            if (document.getElementById(sel.toString()))
+                document.getElementById(sel.toString()).checked = true;
         });
+    document.getElementById('qtdDocumentosSelecionados').innerHTML = obtemDocumentosSelecionados().length.toString();
 
 </script>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/reclassificar_lote.jsp
@@ -14,7 +14,7 @@
             <div class="card-body">
                 <form name="frm" id="frm" class="form" method="post" action="reclassificar_lote_gravar" theme="simple">
                     <input type="hidden" name="siglasDocumentosSelecionados" value=""/>
-                    
+
                     <div class="row">
                         <div class="col-sm-2">
                             <div class="form-group">
@@ -107,6 +107,10 @@
         </siga:siga-modal>
     </div>
     <script type="text/javascript">
+        window.onload = function(){
+            limparDocumentosSelecionados();    
+        }
+        
         function listarDocumentosParaReclassificarEmLote(offset) {
             sigaSpinner.mostrar();
 
@@ -129,25 +133,30 @@
             });
         }
 
-        let checkedElements = [];
+        let checkedElements = [200];
 
-        function atualizaDocumentoSelecionado(el){
-            
+        function atualizaDocumentoSelecionado(el) {
             const indexId = checkedElements.indexOf(el.id);
-            if(indexId < 0 && el.checked)
+            if (indexId < 0 && el.checked && checkedElements.length < 200) {
                 checkedElements.push(el.id);
-            else if(indexId >= 0 && !el.checked)
+            } else if (indexId >= 0 && !el.checked) {
                 checkedElements.splice(indexId, 1);
+            } else {
+                el.checked = false;
+                sigaModal.alerta('Na Reclassificação em Lote – Permitido até 200 documentos por operação.');
+            }
+            
+            document.getElementById('qtdDocumentosSelecionados').innerHTML = checkedElements.length.toString();
         }
 
-        function obtemDocumentosSelecionados(){
+        function obtemDocumentosSelecionados() {
             return checkedElements;
         }
-        
-        function limparDocumentosSelecionados(){
+
+        function limparDocumentosSelecionados() {
             checkedElements = [];
         }
-        
+
         function validar() {
             let classificacaoAtualSelSpan = document.getElementById('classificacaoAtualSelSpan');
             if (classificacaoAtualSelSpan.textContent.trim() === '') {
@@ -187,7 +196,7 @@
             sigaSpinner.mostrar();
             document.getElementById("btnOk").disabled = true;
             sigaModal.fechar('confirmacaoModal');
-            
+
             document.getElementsByName('siglasDocumentosSelecionados')[0].value = obtemDocumentosSelecionados();
             document.frm.submit();
         }

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/reclassificar_lote.jsp
@@ -13,6 +13,8 @@
             </div>
             <div class="card-body">
                 <form name="frm" id="frm" class="form" method="post" action="reclassificar_lote_gravar" theme="simple">
+                    <input type="hidden" name="siglasDocumentosSelecionados" value=""/>
+                    
                     <div class="row">
                         <div class="col-sm-2">
                             <div class="form-group">
@@ -54,7 +56,7 @@
                                 <siga:selecao titulo="Classifica&ccedil;&atilde;o Atual"
                                               propriedade="classificacaoAtual"
                                               modulo="sigaex" urlAcao="buscar" urlSelecionar="selecionar"/>
-                                <a href="javascript: listarDocumentosParaReclassificarEmLote()"
+                                <a href="javascript: listarDocumentosParaReclassificarEmLote();limparDocumentosSelecionados();"
                                    class="btn btn-cancel btn-primary">Buscar Documentos</a>
                             </div>
                         </div>
@@ -127,6 +129,25 @@
             });
         }
 
+        let checkedElements = [];
+
+        function atualizaDocumentoSelecionado(el){
+            
+            const indexId = checkedElements.indexOf(el.id);
+            if(indexId < 0 && el.checked)
+                checkedElements.push(el.id);
+            else if(indexId >= 0 && !el.checked)
+                checkedElements.splice(indexId, 1);
+        }
+
+        function obtemDocumentosSelecionados(){
+            return checkedElements;
+        }
+        
+        function limparDocumentosSelecionados(){
+            checkedElements = [];
+        }
+        
         function validar() {
             let classificacaoAtualSelSpan = document.getElementById('classificacaoAtualSelSpan');
             if (classificacaoAtualSelSpan.textContent.trim() === '') {
@@ -154,8 +175,8 @@
                 return;
             }
 
-            let checkedElements = $("input[name='documentosSelecionados']:checked");
-            if (checkedElements.length == 0) {
+            let checkedElements = obtemDocumentosSelecionados();
+            if (checkedElements.length === 0) {
                 sigaModal.alerta('Selecione pelo menos um documento');
             } else {
                 sigaModal.abrir('confirmacaoModal');
@@ -166,6 +187,8 @@
             sigaSpinner.mostrar();
             document.getElementById("btnOk").disabled = true;
             sigaModal.fechar('confirmacaoModal');
+            
+            document.getElementsByName('siglasDocumentosSelecionados')[0].value = obtemDocumentosSelecionados();
             document.frm.submit();
         }
 


### PR DESCRIPTION
### Seleção de itens em múltiplas páginas na paginação

Atualmente o sistema permite somente a seleção de itens em uma única página na tela de reclassificação em lote.
Este pull request visa possibilitar a seleção de documentos entre as páginas, acumulando os itens selecionados.


### Resumo da implementação

1. Aumento da quantidade de documentos apresentados por página para 200
2. 

### Captura de tela

![20230127-RM148622-ReclassificacaoLote-Captura](https://user-images.githubusercontent.com/1022974/215868274-8bf3fe82-0b2a-4a34-8925-da1ab6677ca8.gif)
