### PR TITLE
RM148623 Aumento quantidade documentos por página na reclassificação em lote

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMobilController.java
@@ -93,7 +93,7 @@ public class ExMobilController extends
 	private static final String SIGA_DOC_PESQ_DTLIMITADA = "SIGA:Sistema Integrado de Gestão Administrativa;DOC:Módulo de Documentos;PESQ:Pesquisar;DTLIMITADA:Pesquisar somente com data limitada";
 
 	private static final int MAX_ITENS_PAGINA_TRAMITACAO_LOTE = 200;
-	private static final int MAX_ITENS_PAGINA_RECLASSIFICACAO_LOTE = 50;
+	private static final int MAX_ITENS_PAGINA_RECLASSIFICACAO_LOTE = 200;
 	/**
 	 * @deprecated CDI eyes only
 	 */

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -5645,8 +5645,8 @@ public class ExMovimentacaoController extends ExController {
 			return;
 		}
 
-		final ExMovimentacao mov = ExMovimentacaoBuilder
-				.novaInstancia().setDescrMov(motivo).setDtMovString(dtMovString).setObsOrgao(obsOrgao)
+		final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia()
+				.setDescrMov(motivo).setDtMovString(dtMovString).setObsOrgao(obsOrgao).setCadastrante(getCadastrante())
 				.setSubstituicao(substituicao).setTitularSel(titularSel).setSubscritorSel(subscritorSel)
 				.setClassificacaoSel(classificacaoNovaSel).construir(dao());
 		mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
@@ -5657,7 +5657,7 @@ public class ExMovimentacaoController extends ExController {
 
 				if (Ex.getInstance().getComp().pode(ExPodeReclassificar.class, getTitular(), getLotaTitular(), mob)) {
 
-					Ex.getInstance().getBL().avaliarReclassificar(mov.getTitular(), mov.getLotaTitular(), mob,
+					Ex.getInstance().getBL().avaliarReclassificar(mov.getCadastrante(), mov.getLotaCadastrante(), mob,
 							mov.getDtMov(), mov.getSubscritor(), mov.getExClassificacao(), mov.getDescrMov(), false);
 				}
 			}

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
@@ -5,6 +5,7 @@
 <%@ taglib uri="http://localhost/jeetags" prefix="siga" %>
 
 <c:if test="${not empty itens}">
+    <p>Atenção: Na Reclassificação em Lote – Permitido até 200 documentos por operação.</p>
     <div class="gt-content-box gt-for-table">
         <table class="table table-hover table-striped">
             <thead class="thead-dark align-middle text-center">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMobil/listar_docs_para_reclassificar_lote.jsp
@@ -21,7 +21,7 @@
             </thead>
             <tbody class="table-bordered">
 
-            <siga:paginador maxItens="50" maxIndices="50" totalItens="${tamanho}"
+            <siga:paginador maxItens="200" maxIndices="50" totalItens="${tamanho}"
                             itens="${itens}" var="documento">
                 <c:set var="x" scope="request">
                     chk_${documento.idDoc}


### PR DESCRIPTION
### Aumento quantidade documentos por página na reclassificação em lote

Atualmente o sistema permite somente a seleção de 50 documentos por página
Este pull request visa aumentar essa quantidade para 200

#### Captura de tela

![image](https://user-images.githubusercontent.com/1022974/215878550-f73dae76-1008-49b0-973c-8408f9ee5710.png)
