### PR TITLE
RM151751 CKEditor Bug borda e alinhamento tabela

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/util/ProcessadorHtml.java
@@ -168,7 +168,7 @@ public class ProcessadorHtml {
 			add(myTags, "p", "align=left,right,center,justify;class", styleP,
 					true);
 			add(myTags, "ol", "class", "list-style-type=roman", true);
-			add(myTags, "ul", "class", null, true);
+			add(myTags, "ul", "class", styleP, true);
 			add(myTags, "li", "class;data-footnote-id;id", null, true);
 
 			add(myTags, "hr", "class", null, false);
@@ -180,7 +180,8 @@ public class ProcessadorHtml {
 					+ ",61%,62%,63%,64%,65%,66%,67%,68%,69%,70%,71%,72%,73%,74%,75%,76%,77%,78%,79%,80%"
 					+ ",81%,82%,83%,84%,85%,86%,87%,88%,89%,90%,91%,92%,93%,94%,95%,96%,97%,98%,99%,100%";
 
-			String styleT = "border;border-style=solid;border-color;border-width;border-collapse=collapse;float=none;clear=both;width;";
+			String styleT = "border;border-style=solid;border-color;border-width;border-collapse=collapse;"
+					+ "border-bottom;border-left;border-top;border-right;float=none;clear=both;width;";
 
 			add(myTags,
 					"table",
@@ -201,7 +202,7 @@ public class ProcessadorHtml {
 			add(myTags,
 					"td",
 					"width;class;align=left,right,center,justify;valign=bottom,top,middle;bgcolor;headers;colspan;rowspan;"
-							+ sWidth, styleP, true);
+							+ sWidth, styleT, true);
 			add(myTags, "thead", null, null, true);
 			add(myTags, "tfoot", null, null, true);
 

--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -1755,8 +1755,11 @@ CKEDITOR.replace( '${var}',
 
 								CKEDITOR.config.extraPlugins = ['footnotes','strinsert'];
 								CKEDITOR.config.disallowedContent = '*[data*]';
-
-                                CKEDITOR.replace('${var}', {toolbar: 'SigaToolbar'});
+                                CKEDITOR.config.extraAllowedContent = 'td[align*];td{border*}',
+                                    
+                                CKEDITOR.replace('${var}', {
+                                    toolbar: 'SigaToolbar'
+                                });
 
                             </script>
                             


### PR DESCRIPTION
### Bug de perda de bordas e alinhamento de tabelas durante edição no editor de texto CKEditor

Ao inserir tabelas no editor de texto o sistema perde as propriedades das bordas e alinhamento, após a edição do documento. Verificou-se que ocorre uma filtragem no CKEditor e depois uma sanitização do HTML na classe ProcessadorHtml.

#### Resumo implementação

1. Foi adicionado o parâmetro de configuração extraAllowedContent do CKEditor para permitir o atributo de alinhamento e estilo de borda na tag <td>
2. Adicionalmente, o tratamento da tag <td> na classe ProcessadorHtml foi alterada para não remover as propriedades de estilo das bordas

Ref.: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html

#### Captura de tela

![20230130-RM151751-CorrecaoBordaTabelaAlinhamentoItens](https://user-images.githubusercontent.com/1022974/216387735-1dfcd9ae-45b4-404d-9ce6-4600be42d02e.gif)
