### PR TITLE
RM149506 Bug da assinatura do cossignatário constando como EM EXERCÍCIO

### DIFF
--- a/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
+++ b/siga-ex/src/main/resources/br/gov/jfrj/siga/ex/util/default.ftl
@@ -2793,11 +2793,13 @@ Pede deferimento.</span><br/><br/><br/>
                 	${pessoaVO.nmFuncao}
 	            [#elseif (pessoaVO.titular.funcaoConfianca.nomeFuncao)??]
 	                ${pessoaVO.titular.funcaoConfianca.nomeFuncao}
-	                [#if (doc.titular.idPessoa)! != (doc.subscritor.idPessoa)! || substituicao!false && ((doc.titular.idPessoa)!-1) != ((doc.subscritor.idPessoa)!-1)] EM EXERCÍCIO [/#if]
-            		[#elseif (pessoaVO.subscritor.funcaoConfianca.nomeFuncao)??]
-                		${pessoaVO.subscritor.funcaoConfianca.nomeFuncao}
-            		[#else]
-                		${(pessoaVO.subscritor.cargo.nomeCargo)!}
+	                [#if ((doc.titular.idPessoa)! != (doc.subscritor.idPessoa)!) && (pessoaVO.subscritor.idPessoa == doc.subscritor.idPessoa)]
+                        EM EXERCÍCIO
+                    [/#if]
+                [#elseif (pessoaVO.subscritor.funcaoConfianca.nomeFuncao)??]
+                    ${pessoaVO.subscritor.funcaoConfianca.nomeFuncao}
+                [#else]
+                    ${(pessoaVO.subscritor.cargo.nomeCargo)!}
             	[/#if]
         	[/#if]
 


### PR DESCRIPTION
### Bug da assinatura do cossignatário constando como EM EXERCÍCIO

O sistema está concatenando a string EM EXERCÍCIO na assinatura do cossignatário caso o mesmo tenha  uma função de confiança cadastrada

![image](https://user-images.githubusercontent.com/1022974/217544757-2a5bdc39-2142-4a44-89fa-e4e9ce896236.png)

#### Origem do bug

A condicional que faz a concatenação da string EM EXERCÍCIO verificava somente se o titular e subscritor do documento eram diferentes, caracterizando uma substituição

#### Resumo da correção

default.ftl: Foi adicionada a condição para verificar se o cossignatário é o subscritor do documento

#### Captura de tela com a correção aplicada

![20230207-RM149506-CorrecaoBugCossignatarioConstandoEMEXERCICIO](https://user-images.githubusercontent.com/1022974/217538921-751ae0f1-2d8a-41f1-b63b-956aa09a04f5.gif)
