### PR TITLE
GOVSP - RM138620 - Erro ao incluir preenchimento automático na reedição de um TMP

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -647,7 +647,7 @@ public class ExDocumentoController extends ExController {
 		} else {
 			exDocumentoDTO.setDoc(daoDoc(exDocumentoDTO.getId()));
 
-			Ex.getInstance()
+			Ex.getInstance() 
 					.getComp()
 					.afirmar("Não é permitido editar documento fechado", ExPodeEditar.class, getTitular(), getLotaTitular(),
 							exDocumentoDTO.getMob());
@@ -1586,6 +1586,9 @@ public class ExDocumentoController extends ExController {
 			final String id = param("exDocumentoDto.id");
 			if (id != null && id.length() != 0) {
 				exDocumentoDto.setDoc(daoDoc(Long.parseLong(id)));
+			} else {
+				if (exDocumentoDto.getId() != null)
+					exDocumentoDto.setDoc(daoDoc(exDocumentoDto.getId()));
 			}
 		}
 		if (exDocumentoDto.getDoc() != null && exDocumentoDto.getMob() == null) {


### PR DESCRIPTION
Ao editar um TMP já criado anteriormente e inserir um preenchimento automático, estava duplicando o TMP ou dando erro de permissão de acesso (v11.0.2). 
Identificado que o id do documento não era passado nos parâmetros e sim no DTO. Corrigido para caso não encontre nos parâmetros, obtenha o documento através do id que está no DTO.

![image](https://user-images.githubusercontent.com/49542320/219094201-325211e3-71dd-4b0a-9f6c-62aa4eb163de.png)

![image](https://user-images.githubusercontent.com/49542320/219094371-6b508c2d-b8ac-45b2-93d4-a366f8336cac.png)

