### PR TITLE
Tenta obter valor da chave no Messages Default

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaMessages.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaMessages.java
@@ -4,24 +4,26 @@ import java.util.ResourceBundle;
 
 public class SigaMessages {
 	public static ResourceBundle bundle;
-
-//	private static void changeLocale(final String local) {
-//		if (SigaBaseProperties.getString("siga.local") == "TRF2") {
-//			// TO DO 
-//		} else {
-//			// TO DO
-//		}
-//	}
+	private final static String MESSAGES_DEFAULT = "messages_SIGA";
 
 	public static String getMessage(String key) {
 		try {
-	    	if (bundle == null) {
+			
+	    	if (bundle == null) 
 		    	bundle = getBundle();
-	    	}
+
 		    String message = bundle.getString(key);
 			return message;
+			
 		} catch (Exception e) {
-			return "???." + key + ".???";
+			try {
+				//Tenta carregar do messages DEFAULT messages_SIGA
+				bundle = ResourceBundle.getBundle(MESSAGES_DEFAULT);
+				String message = bundle.getString(key);
+				return message;
+			} catch (Exception ex) {
+				return "???." + key + ".???";
+			}
 		}
 	}
 


### PR DESCRIPTION
Caso chave não seja encontrada no message do local de instalação, ao invés de devolver chave de erro logo de cara ???....??? tenta obter antes do messages default (messages_SIGA)  e caso ainda não encontre, devolve o erro.

Isso permite trabalhar com as exceções. Onde ao criar uma chave, seja registrada no _SIGA e apenas caso tenha internacionalização seria necessário colocar no _<siga.local>