### PR TITLE
RM140416 Alterar atendente do documento desentranhado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -133,6 +133,11 @@ public class ExMarcadorBL {
 				// com o cadastrante e sua lotação, em vez do responsável
 				acrescentarMarca(m, dt, mov.getCadastrante(), mov.getLotaCadastrante());
 			}
+			if (t == ExTipoDeMovimentacao.CANCELAMENTO_JUNTADA) {
+				// Quando é desentranhado, a marca deve ficar com o cadastrante da movimentação 
+				// em vez do cadastrante do documento
+				acrescentarMarca(CpMarcadorEnum.EM_ANDAMENTO.getId(), dt, mov.getCadastrante(), mov.getLotaCadastrante());
+			}
 //			if ((t == ExTipoDeMovimentacao.DESPACHO_TRANSFERENCIA
 //					|| t == ExTipoDeMovimentacao.TRANSFERENCIA) && !apensadoAVolumeDoMesmoProcesso) {
 //				m = CpMarcadorEnum.CAIXA_DE_ENTRADA.getId();
@@ -146,7 +151,6 @@ public class ExMarcadorBL {
 					|| t == ExTipoDeMovimentacao.DESOBRESTAR
 					|| t == ExTipoDeMovimentacao.ASSINATURA_DIGITAL_DOCUMENTO
 					|| t == ExTipoDeMovimentacao.ASSINATURA_COM_SENHA
-					|| t == ExTipoDeMovimentacao.CANCELAMENTO_JUNTADA
 					|| t == ExTipoDeMovimentacao.DESAPENSACAO) {
 				m = 0L;
 			}


### PR DESCRIPTION
### RM140416 Alterar atendente do documento desentranhado

Cenário de atuação
   * Usuário A cria um novo processo e inclui/junta um despacho ao processo
   * Usuário A tramita o processo para um usuário B
   * Usuário B recebe o processo tramitado
   * Usuário B desentranha o despacho do processo
   * O processo permanece na mesa do usuário B, porém o despacho desentranhado retorna para a mesa do Usuário

O sistema retorna o documento desentranhado para o usuário cadastrante Esta alteração muda esse comportamento para manter o documento desentranhado na mesa do usuário que efetuou o desentranhamento Para isso, foi adicionado o marcador de EM_ANDAMENTO nas regras de atualização de marcas quando houver uma movimentação do tipo CANCELAMENTO_JUNTADA que reflete o desentranhamento