### PR TITLE
Permitir que as marcas sejam aplicadas em documentos com formatos maiores que A4

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -381,16 +381,21 @@ public class Documento {
 			new PdfOutline(cb.getRootOutline(), destination, "teste ");
 		}
 	}
-
+	
 	public byte[] getDocumento(ExMobil mob, ExMovimentacao mov)
 			throws Exception {
+		return getDocumento(mob, mov, false);
+	}
+
+	public byte[] getDocumento(ExMobil mob, ExMovimentacao mov, boolean tamanhoOriginal)
+			throws Exception {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		getDocumento(baos, null, mob, mov, false, true, false, null, null);
+		getDocumento(baos, null, mob, mov, false, true, false, null, null,tamanhoOriginal);
 		return baos.toByteArray();
 	}
 
 	public static boolean getDocumento(OutputStream os, String uuid, ExMobil mob, ExMovimentacao mov,
-			boolean completo, boolean estampar, boolean volumes, String hash, byte[] certificado)
+			boolean completo, boolean estampar, boolean volumes, String hash, byte[] certificado,boolean tamanhoOriginal)
 			throws Exception {
 		PdfReader reader;
 		int n;
@@ -462,7 +467,7 @@ public class Documento {
 						Prop.get("carimbo.texto.superior"), 
 						mob.getExDocumento().getOrgaoUsuario().getDescricao(), 
 						mob.getExDocumento().getMarcaDagua(), 
-						an.getMobil().getDoc().getIdsDeAssinantes());	
+						an.getMobil().getDoc().getIdsDeAssinantes(),tamanhoOriginal);	
 				
 
 				bytes += ab.length;

--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Documento.java
@@ -695,7 +695,7 @@ public class Documento {
 						&& an.getArquivo().getMensagem().trim().length() > 0) {
 					sb.append("</td></tr><tr><td>");
 					sb.append("<div style=\"margin:3pt; padding:3pt; border: 1px solid #ccc; border-radius: 5px; background-color:lightgreen;\" class=\"anexo\">");
-					sb.append(an.getArquivo().getMensagem());
+					sb.append(an.getArquivo().getMensagem(true));
 					sb.append("</div>");
 				}
 				sb.append("</td></tr></table></div>");

--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Stamp.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Stamp.java
@@ -77,22 +77,14 @@ public class Stamp {
 
 		PdfReader pdfIn = new PdfReader(abPdf);
 		Document doc = new Document(PageSize.A4, 0, 0, 0, 0);
-		// final SimpleDateFormat sdf = new SimpleDateFormat(
-		// "EEE MMM dd HH:mm:ss zzz yyyy");
-		// doc.add(new Meta("creationdate", sdf.format(new Date(0L))));
+
 		try (ByteArrayOutputStream boA4 = new ByteArrayOutputStream()) {
-			/*-- Alterado de PdfWriter p/ PdfCopy(Essa classe permite manter os "stamps" originais do arquivo importado) 
-			por Marcos(CMSP) em 21/02/19 --*/
-			// PdfCopy writer = new PdfCopy(doc, boA4);
-			/*-- Alerado de volta pois ficou desabilitado o redimensionamento do PDF de modo
-			 *   a que os códigos de barra 2D e 3D não ficassem por cima do texto. Por Renato em 25/04/2019 --*/
+
 			PdfWriter writer = PdfWriter.getInstance(doc, boA4);
 			doc.open();
 			PdfContentByte cb = writer.getDirectContent();
 
 			// Resize every page to A4 size
-			//
-			// double thetaRotation = 0.0;
 			for (int i = 1; i <= pdfIn.getNumberOfPages(); i++) {
 				int rot = pdfIn.getPageRotation(i);
 				float left = pdfIn.getPageSize(i).getLeft();
@@ -103,9 +95,6 @@ public class Stamp {
 				PdfImportedPage page = writer.getImportedPage(pdfIn, i);
 				float w = page.getWidth();
 				float h = page.getHeight();
-
-				// Logger.getRootLogger().error("----- dimensoes: " + rot + ", " + w
-				// + ", " + h);
 
 				doc.setPageSize((rot != 0 && rot != 180) ^ (w > h) ? PageSize.A4.rotate() : PageSize.A4);
 				doc.newPage();
@@ -144,28 +133,8 @@ public class Stamp {
 					}
 				}
 
-				// Logger.getRootLogger().error(
-				// "----- dimensoes: " + rot + ", " + w + ", " + h);
-				// Logger.getRootLogger().error("----- page: " + pw + ", " + ph);
-
-				// cb.transform(AffineTransform.getTranslateInstance(
-				// ((pw / scale) - w) / 2, ((ph / scale) - h) / 2));
-
 				// put the page
 				cb.addTemplate(page, 0, 0);
-				/*-- Adicionado devido ao PdfCopy - por Marcos(CMSP) em 21/02/19 --*/
-				// writer.addPage(page);
-
-				// draw a red rectangle at the page borders
-				//
-				// cb.saveState();
-				// cb.setColorStroke(Color.red);
-				// cb.rectangle(pdfIn.getPageSize(i).getLeft(), pdfIn.getPageSize(i)
-				// .getBottom(), pdfIn.getPageSize(i).getRight(), pdfIn
-				// .getPageSize(i).getTop());
-				// cb.stroke();
-				// cb.restoreState();
-
 				cb.restoreState();
 			}
 			doc.close();
@@ -239,7 +208,7 @@ public class Stamp {
 				if (stream != null) {
 					byte[] ab = IOUtils.toByteArray(stream);
 					final Image logo = Image.getInstance(ab);
-//				
+			
 					logo.scaleToFit(image39.getHeight(), image39.getHeight());
 					logo.setAbsolutePosition(
 							r.getWidth() - image39.getHeight() + (STAMP_BORDER_IN_CM - PAGE_BORDER_IN_CM) * CM_UNIT,
@@ -268,8 +237,6 @@ public class Stamp {
 						over.addImage(logo);
 					}
 				}
-				// over.addImage(mask, mask.getScaledWidth() * 8, 0, 0,
-				// mask.getScaledHeight() * 8, 100, 450);
 
 				if (qrCode != null) {
 					java.awt.Image imgQRCode = createQRCodeImage(qrCode);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExArquivo.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExArquivo.java
@@ -154,15 +154,27 @@ public abstract class ExArquivo extends Objeto {
 	 * um código gerado.
 	 * 
 	 */
-	public String getMensagem() {
+	public String getMensagem(boolean comLink) {
 		String sMensagem = "";
 		sMensagem += getVinculosCompleto();
 		if (isAssinadoDigitalmente()) {
+			
 			sMensagem += getAssinantesCompleto();
 			sMensagem += "Documento Nº: " + getSiglaAssinatura()
-					+ " - consulta à autenticidade em " + getQRCode();
+					+ " - consulta à autenticidade em ";
+			
+			if (comLink) 
+				sMensagem += "<a href='"+ getQRCode() +"' target='_Blank'>" + getQRCode() + "</a>";
+			else
+				sMensagem += getQRCode();
+			
+
 		}
 		return sMensagem;
+	}
+	
+	public String getMensagem() {
+		return getMensagem(false);
 	}
 
 	/**

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -6955,18 +6955,22 @@ public class ExBL extends CpBL {
 			method.invoke(exBl, new Object[] { doc });
 		}
 	}
-
+	
 	public byte[] obterPdfPorNumeroAssinatura(String num) throws Exception {
+		return obterPdfPorNumeroAssinatura(num,false);
+	}
+
+	public byte[] obterPdfPorNumeroAssinatura(String num, boolean tamanhoOriginal) throws Exception {
 
 		ExArquivo arq = buscarPorNumeroAssinatura(num);
 
 		Documento documento = new Documento();
 
 		if (arq instanceof ExDocumento)
-			return documento.getDocumento(((ExDocumento) arq).getMobilGeral(), null);
+			return documento.getDocumento(((ExDocumento) arq).getMobilGeral(), null, tamanhoOriginal);
 		if (arq instanceof ExMovimentacao) {
 			ExMovimentacao mov = (ExMovimentacao) arq;
-			return documento.getDocumento(mov.getExMobil(), mov);
+			return documento.getDocumento(mov.getExMobil(), mov, tamanhoOriginal);
 		}
 
 		return null;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoGet.java
@@ -68,8 +68,10 @@ public class DocumentosSiglaArquivoGet implements IDocumentosSiglaArquivoGet {
 		boolean estampar = req.estampa == null ? false : req.estampa;
 		boolean volumes = req.volumes == null ? false : req.volumes;
 		boolean exibirReordenacao = req.exibirReordenacao == null ? false : req.exibirReordenacao;
+		boolean tamanhoOriginal = req.tamanhoOriginal == null ? false : req.tamanhoOriginal;
+		
 		DownloadAssincrono task = new DownloadAssincrono(uuid, contenttype, sigla, estampar, volumes, contextpath,
-				servernameport, exibirReordenacao);
+				servernameport, exibirReordenacao, tamanhoOriginal);
 
 		ExApiV1Servlet.submitToExecutor(task);
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoProduzirGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaArquivoProduzirGet.java
@@ -72,7 +72,7 @@ public class DocumentosSiglaArquivoProduzirGet implements IDocumentosSiglaArquiv
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		if ("application/pdf".equals(req.contenttype)) {
 			resp.contenttype = "application/pdf";
-			Documento.getDocumento(baos, null, mob, mov, req.completo, req.estampa, req.volumes, null, null);
+			Documento.getDocumento(baos, null, mob, mov, req.completo, req.estampa, req.volumes, null, null, req.tamanhoOriginal);
 		} else {
 			Documento.getDocumentoHTML(baos, null, mob, mov, req.completo, req.volumes, contextpath, servernameport);
 		}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DownloadAssincrono.java
@@ -24,9 +24,10 @@ public class DownloadAssincrono implements Callable<String> {
 	private String contextpath;
 	String servernameport;
 	private boolean exibirReordenacao;
+	private boolean tamanhoOriginal;
 
 	public DownloadAssincrono(String uuid, String contenttype, String sigla, boolean estampar, boolean volumes,
-			String contextpath, String servernameport, boolean exibirReordenacao) {
+			String contextpath, String servernameport, boolean exibirReordenacao, boolean tamanhoOriginal) {
 		super();
 		this.uuid = uuid;
 		this.contenttype = contenttype;
@@ -36,6 +37,7 @@ public class DownloadAssincrono implements Callable<String> {
 		this.contextpath = contextpath;
 		this.servernameport = servernameport;
 		this.exibirReordenacao = exibirReordenacao;
+		this.tamanhoOriginal = tamanhoOriginal;
 	}
 
 	@Override
@@ -61,7 +63,7 @@ public class DownloadAssincrono implements Callable<String> {
 				Documento.getDocumentoHTML(buf, this.uuid, mob, null, true, volumes, this.contextpath,
 						this.servernameport);
 			else
-				Documento.getDocumento(buf, this.uuid, mob, null, true, estampar, volumes, null, null);
+				Documento.getDocumento(buf, this.uuid, mob, null, true, estampar, volumes, null, null, tamanhoOriginal);
 		} catch (Exception ex) {
 			SwaggerUtils.log(DownloadAssincrono.class).error(RequestExceptionLogger.simplificarStackTrace(ex));
 		}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -575,6 +575,7 @@ public interface IExApiV1 {
             public Boolean completo;
             public Boolean volumes;
             public Boolean exibirReordenacao;
+            public Boolean tamanhoOriginal;
         }
 
         public static class Response implements ISwaggerResponse, ISwaggerResponseFile {
@@ -637,6 +638,7 @@ public interface IExApiV1 {
             public Boolean completo;
             public Boolean volumes;
             public Boolean exibirReordenacao;
+            public Boolean tamanhoOriginal;
         }
 
         public static class Response implements ISwaggerResponse {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/SigaDocPdfUtils.java
@@ -40,7 +40,7 @@ public class SigaDocPdfUtils {
 			final String certificadoB64, boolean completo,
 			final boolean semmarcas, DpPessoa titular, DpLotacao lotaTitular,
 			Date dataEHoraDoServidor, HttpServletRequest request,
-			HttpServletResponse response) {
+			HttpServletResponse response, boolean tamanhoOriginal) {
 		try {
 			final String servernameport = request.getServerName() + ":"
 					+ request.getServerPort();
@@ -107,7 +107,7 @@ public class SigaDocPdfUtils {
 					ab = mov.getConteudoBlobpdf();
 				} else {
 					ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					Documento.getDocumento(baos, null, mob, null, completo, semmarcas, false, null, null);
+					Documento.getDocumento(baos, null, mob, null, completo, semmarcas, false, null, null, tamanhoOriginal);
 					ab = baos.toByteArray();
 				}
 				if (ab == null) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExArquivoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExArquivoController.java
@@ -96,7 +96,7 @@ public class ExArquivoController extends ExController {
 	public Download aExibir(final String sigla, final boolean popup, final String arquivo, byte[] certificado,
 			String hash, final String HASH_ALGORITHM, final String certificadoB64, boolean completo,
 			final boolean semmarcas, final boolean volumes, final Long idVisualizacao, boolean exibirReordenacao, 
-							boolean iframe, final String nomeAcao) throws Exception {
+							boolean iframe, final String nomeAcao, boolean tamanhoOriginal) throws Exception {
 		try {						
 			final String servernameport = getRequest().getServerName() + ":" + getRequest().getServerPort();
 			final String contextpath = getRequest().getContextPath();
@@ -178,6 +178,7 @@ public class ExArquivoController extends ExController {
 				req.completo = completo;
 				req.volumes = volumes;
 				req.exibirReordenacao = exibirReordenacao;
+				req.tamanhoOriginal = tamanhoOriginal;
 				String filename = isPdf ? (volumes ? mob.doc().getReferenciaPDF() : mob.getReferenciaPDF())
 						: (volumes ? mob.doc().getReferenciaHtml() : mob.getReferenciaHtml());
 				DocumentosSiglaArquivoGet.iniciarGeracaoDePdf(req, resp, ContextoPersistencia.getUserPrincipal(),
@@ -192,7 +193,7 @@ public class ExArquivoController extends ExController {
 					ab = mov.getConteudoBlobpdf();
 				} else {
 					ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					Documento.getDocumento(baos, null, mob, mov, completo, estampar, volumes, hash, null);
+					Documento.getDocumento(baos, null, mob, mov, completo, estampar, volumes, hash, null, tamanhoOriginal);
 					ab = baos.toByteArray();
 				}
 				if (ab == null) {
@@ -281,7 +282,7 @@ public class ExArquivoController extends ExController {
 	}
 	
 	@Get("/public/app/arquivo/obterDownloadDocumento")
-	public Download aObterDownloadDocumento(final String t, boolean completo, final boolean semmarcas, final boolean volumes, final String mime) throws Exception  {
+	public Download aObterDownloadDocumento(final String t, boolean completo, final boolean semmarcas, final boolean volumes, final String mime, final boolean tamanhoOriginal) throws Exception  {
 		try {
 
 			boolean isPdf = "PDF".equalsIgnoreCase(mime);
@@ -334,7 +335,7 @@ public class ExArquivoController extends ExController {
 	
 			if (isPdf) {
 				ByteArrayOutputStream baos = new ByteArrayOutputStream();
-				Documento.getDocumento(baos, null, mob, null, completo, semmarcas, volumes, null, null);
+				Documento.getDocumento(baos, null, mob, null, completo, semmarcas, volumes, null, null, tamanhoOriginal);
 				ab = baos.toByteArray();
 				
 				if (ab == null) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAutenticacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExAutenticacaoController.java
@@ -210,7 +210,7 @@ public class ExAutenticacaoController extends ExController {
 	@Get("/public/app/arquivoAutenticado_stream")
 	public Download arquivoAutenticado_stream(final String jwt,
 			final boolean assinado, final Long idMov,
-			final String certificadoB64) throws Exception {
+			final String certificadoB64, boolean tamanhoOriginal) throws Exception {
 
 		if (jwt == null) {
 			setDefaultResults();
@@ -251,9 +251,9 @@ public class ExAutenticacaoController extends ExController {
 		} else {
 			fileName = arq.getReferenciaPDF();
 			contentType = "application/pdf";
-
+			
 			if (assinado)
-				bytes = Ex.getInstance().getBL().obterPdfPorNumeroAssinatura(n);
+				bytes = Ex.getInstance().getBL().obterPdfPorNumeroAssinatura(n, tamanhoOriginal);
 			else
 				bytes = arq.getPdf();
 		}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExProcessoAutenticacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExProcessoAutenticacaoController.java
@@ -155,7 +155,7 @@ public class ExProcessoAutenticacaoController extends ExController {
 
 	@Get("/public/app/processoArquivoAutenticado_stream")
 	public Download processoArquivoAutenticado_stream(final boolean assinado, final Long idMov,
-			final String certificadoB64, final String sigla) throws Exception {
+			final String certificadoB64, final String sigla, final boolean tamanhoOriginal) throws Exception {
 		String jwt = Utils.getCookieValue(request, "jwt-prot");
 		if (jwt == null) {
 			setDefaultResults();
@@ -194,7 +194,7 @@ public class ExProcessoAutenticacaoController extends ExController {
 			fileName = arq.getReferenciaPDF();
 			contentType = "application/pdf";
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			Documento.getDocumento(baos, null, mob, null, false, true, false, null, null);
+			Documento.getDocumento(baos, null, mob, null, false, true, false, null, null, tamanhoOriginal);
 			bytes = baos.toByteArray();
 		} else {			
 			if (idMov != null && idMov != 0) {

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -131,6 +131,13 @@ parameters:
     required: false
     default: false
     type: boolean
+  tamanhoOriginal:
+    name: tamanhoOriginal
+    in: query
+    description: Informar true se deseja receber o PDF no tamanho orginal não redimensionado para A4
+    required: false
+    default: false
+    type: boolean
   volumes:
     name: volumes
     in: query
@@ -994,6 +1001,7 @@ paths:
         - $ref: "#/parameters/completo"
         - $ref: "#/parameters/volumes"
         - $ref: "#/parameters/exibirReordenacao"
+        - $ref: "#/parameters/tamanhoOriginal"
       responses:
         200:
           description: Successful response
@@ -1027,6 +1035,7 @@ paths:
         - $ref: "#/parameters/completo"
         - $ref: "#/parameters/volumes"
         - $ref: "#/parameters/exibirReordenacao"
+        - $ref: "#/parameters/tamanhoOriginal"
       responses:
         200:
           description: Successful response

--- a/sigaex/src/main/webapp/WEB-INF/page/exAutenticacao/arquivoAutenticado.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exAutenticacao/arquivoAutenticado.jsp
@@ -39,14 +39,13 @@
 					<c:if test="${podeVisualizarExternamente}">
 						<div class="card-body">
 							<div>
-								<input type="hidden" id="visualizador"
-									   value="${f:resource('/sigaex.pdf.visualizador') }"/>
-								<c:url var='pdfAssinado'
-									   value='/public/app/arquivoAutenticado_stream?jwt=${jwt}&assinado=true'/>
-								<c:url var='pdf'
-									   value='/public/app/arquivoAutenticado_stream?jwt=${jwt}&assinado=false'/>
-								<iframe id="frameDoc" width="100%" height="600"
-										align="center" style="margin-top: 10px;"></iframe>
+								<input type="hidden" id="visualizador" value="${f:resource('/sigaex.pdf.visualizador') }"/>
+								
+								<c:url var='pdfAssinado' value='/public/app/arquivoAutenticado_stream?jwt=${jwt}&assinado=true&tamanhoOriginal=false'/>
+								<c:url var='pdf' value='/public/app/arquivoAutenticado_stream?jwt=${jwt}&assinado=false&redimensionarParaA4=false'/>
+								<c:url var='pdfTamanhoOriginal' value='/public/app/arquivoAutenticado_stream?jwt=${jwt}&assinado=true&tamanhoOriginal=true'/>
+								
+								<iframe id="frameDoc" width="100%" height="600" align="center" style="margin-top: 10px;"></iframe>
 							</div>
 						</div>
 					</c:if>
@@ -64,7 +63,11 @@
 								</div>
 								<div class="card-body">
 									<i class="fa fa-angle-double-right"></i> <a href="" id="linkDoc" target="_blank">PDF
-									do documento</a>
+									do documento Original (Sem Marcas)</a>
+								</div>
+								<div class="card-body">
+									<i class="fa fa-angle-double-right"></i> <a href="" id="linkDocTamanhoOriginal" target="_blank">PDF
+									do documento Original (Com Marcas)</a>
 								</div>
 							</div>
 						</c:if>
@@ -274,6 +277,7 @@
 	window.onload = function () { 
 		document.getElementById('frameDoc').src = montarUrlDocPDF('${pdfAssinado }',document.getElementById('visualizador').value); 
 		document.getElementById('linkDoc').href = montarUrlDocPDF('${pdf}', document.getElementById('visualizador').value);
+		document.getElementById('linkDocTamanhoOriginal').href = montarUrlDocPDF('${pdfTamanhoOriginal}', document.getElementById('visualizador').value);
 	} 
 </script>
 </siga:pagina>

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibeProcesso.jsp
@@ -262,6 +262,12 @@
 								PDF <u>s</u>em marcas - <a id="pdfsemmarcaslink" accesskey="b"> a<u>b</u>rir</a>
 							</input>
 							</span>
+							<span class="pl-2"></span>			
+							<span style="white-space: nowrap;">
+							<input type="radio" id="radioPDFTamanhoOriginal" name="formato" accesskey="s" value="pdftamanhooriginal" onclick="exibir(htmlAtual,pdfAtual,'');">
+								PDF Tamanho Original - <a id="pdftamanhooriginallink" accesskey="b"> a<u>b</u>rir</a>
+							</input>
+							</span>
 						</div>
 					</div>
 				</c:if>
@@ -432,9 +438,13 @@
 							<a class="btn btn-primary btn-sm notActive" data-toggle="formato" data-title="pdfsemmarcas" id="radioPDFSemMarcas" name="pdfsemmarcas" value="pdfsemmarcas" accesskey="p" onclick="toggleBotaoHtmlPdf($(this)); exibir(htmlAtual,pdfAtual,'semmarcas/'); trackRequest('${sigla}','PDF Sem Marcas');">
 										PDF Sem Marcas
 							</a>
+							<a class="btn btn-primary btn-sm notActive" data-toggle="formato" data-title="pdftamanhooriginal" id="radioPDFTamanhoOriginal" name="pdftamanhooriginal" value="pdftamanhooriginal" accesskey="r" onclick="toggleBotaoHtmlPdf($(this)); exibir(htmlAtual,pdfAtual,''); trackRequest('${sigla}','PDF Sem Redimensionamento');">
+								PDF Tamanho Original
+							</a>
 						</div>
 						<a class="btn-btn-primary btn-sm d-none" id="pdflink" accesskey="a"><u>a</u>brir PDF</a>
 						<a class="btn-btn-primary btn-sm d-none" id="pdfsemmarcaslink" accesskey="b">a<u>b</u>rir PDF</a>
+						<a class="btn-btn-primary btn-sm d-none" id="pdftamanhooriginallink">abrir PDF</a>
 						<input type="hidden" name="formato" id="radio" value="html">
 					</div>
 					<button type="button" class="btn btn-secondary btn-sm" id="TelaCheia" data-toggle="button" aria-pressed="false" autocomplete="off"
@@ -462,6 +472,7 @@
 			//se exibindo documentos reordenados, não permite visualização PDF						
 			$('#radioPDF').attr('data-toggle', 'tooltip').attr('data-placement', 'top').attr('title', 'Indisponível enquanto documento estiver reordenado').removeAttr('onclick').css({'cursor':'not-allowed', 'color':'rgba(0, 0, 0, 0.3)', 'border':'1px solid rgba(0, 0, 0, 0.3)'});		
 			$('#radioPDFSemMarcas').attr('data-toggle', 'tooltip').attr('data-placement', 'top').attr('title', 'Indisponível enquanto documento estiver reordenado').removeAttr('onclick').css({'cursor':'not-allowed', 'color':'rgba(0, 0, 0, 0.3)', 'border':'1px solid rgba(0, 0, 0, 0.3)'});
+			$('#radioPDFTamanhoOriginal').attr('data-toggle', 'tooltip').attr('data-placement', 'top').attr('title', 'Indisponível enquanto documento estiver reordenado').removeAttr('onclick').css({'cursor':'not-allowed', 'color':'rgba(0, 0, 0, 0.3)', 'border':'1px solid rgba(0, 0, 0, 0.3)'});
 		});
 	</script>
 </c:if>
@@ -523,17 +534,26 @@
 		if ('${siga_cliente}' == 'GOVSP') {
 			document.getElementById('pdflink').href = path + refPDF + '&sigla=${sigla}';
 			
+			//sem marcas
 			if ($('#radioPDFSemMarcas').hasClass('active')) {
-				document.getElementById('pdfsemmarcaslink').href = path + refPDF
-					+ "&semmarcas=1";
+				document.getElementById('pdfsemmarcaslink').href = path + refPDF + "&semmarcas=1";
+			//com marcas sem redimensionamento
+			} else if ($('#radioPDFTamanhoOriginal').hasClass('active')) {
+				document.getElementById('pdftamanhooriginallink').href = path + refPDF + "&tamanhoOriginal=true";
 			}
+			//com marcas
 		} else {
 			document.getElementById('pdflink').href = path + refPDF;
 		}
 		
+		//sem marcas
 		if (document.getElementById('radioPDFSemMarcas') != null) {
-			document.getElementById('pdfsemmarcaslink').href = path + refPDF
-					+ "&semmarcas=1";
+			document.getElementById('pdfsemmarcaslink').href = path + refPDF + "&semmarcas=1";
+		}
+		
+		//com marcas sem redimensionamento
+		if (document.getElementById('radioPDFTamanhoOriginal') != null) {
+			document.getElementById('pdftamanhooriginallink').href = path + refPDF + "&tamanhoOriginal=true";
 		}
 	}
 
@@ -556,8 +576,11 @@
 			var refSiglaDocPrincipal = '&sigla=${sigla}';
 			
 			if ($('#radioHTML').hasClass('active') && refHTML != '') {
+				
 				$('#pdflink').addClass('d-none');
 				$('#pdfsemmarcaslink').addClass('d-none');
+				$('#pdftamanhooriginallink').addClass('d-none');
+				
 				ifr.src = path + refHTML + refSiglaDocPrincipal;
 				ifrp.style.border = "0px solid black";
 				ifrp.style.borderBottom = "0px solid black";
@@ -568,11 +591,24 @@
 			} else {
 				if ($('#radioPDFSemMarcas').hasClass('active')) {
 					$('#pdfsemmarcaslink').removeClass('d-none');
+					
 					$('#pdflink').addClass('d-none');
+					$('#pdftamanhooriginallink').addClass('d-none');
+
 					ifr.src = path + refPDF + "&semmarcas=1";
+				} else if ($('#radioPDFTamanhoOriginal').hasClass('active')) {
+						$('#pdftamanhooriginallink').removeClass('d-none');
+						
+						$('#pdflink').addClass('d-none');
+						$('#pdfsemmarcaslink').addClass('d-none');
+
+						ifr.src = path + refPDF + "&tamanhoOriginal=true";
 				} else {
 					$('#pdflink').removeClass('d-none');
+					
 					$('#pdfsemmarcaslink').addClass('d-none');
+					$('#pdftamanhooriginallink').addClass('d-none');
+					
 					ifr.src = path + refPDF + refSiglaDocPrincipal;
 				}
 				
@@ -598,6 +634,8 @@
 			} else {
 				if (document.getElementById('radioPDFSemMarcas').checked)
 					ifr.src = path + refPDF + "&semmarcas=1"
+				else if (document.getElementById('radioPDFTamanhoOriginal').checked)
+						ifr.src = path + refPDF + "&tamanhoOriginal=true"
 				else
 					ifr.src = path + refPDF;
 				


### PR DESCRIPTION
PR anterior de referência: https://github.com/projeto-siga/siga/pull/2164

Implementação do suporte a escolha de obter o PDF Estampado porém sem redimensionamento para o formato A4.

Na tela Ver Dossiê (Documento Completo):

HTML
![image](https://user-images.githubusercontent.com/20362170/219480417-71b65713-3316-4119-91d4-2688f8d23749.png)

PDF Com Marcas (Redimensionado para A4)
![image](https://user-images.githubusercontent.com/20362170/219480519-09ec9bf7-4d59-4e77-bcd7-60e950618171.png)

PDF Sem Marcas (Tamanho Original)
![image](https://user-images.githubusercontent.com/20362170/219480610-cb41f220-8a14-4f6f-8a93-caaf26f87768.png)

PDF Com Marcas e Tamanho Original
![image](https://user-images.githubusercontent.com/20362170/219480720-89b43559-3904-40a6-9f31-a30f7ff051dd.png)

Detalhe do Rodapé em 100%
![image](https://user-images.githubusercontent.com/20362170/219480820-37704e62-c2ef-4908-ab86-b6b46ca6fe3e.png)

*Os elementos (QR Code, Lista de Assinantes, Bar Code...) continuam com o mesmo tamanho e mesma margem, pois entende-se que a folha é maior, mas os elementos não são um " zoom ", assim como ocorre com legenda de mapa por exemplo.

Já na tela de verificação de Autenticidade, mantido os termos do PR #2164 
![image](https://user-images.githubusercontent.com/20362170/219481457-c06e7c7a-b321-4b8d-97ab-3d800bb9fe43.png)


Via API adicionado o suporte a passagem do parâmetro de PDF tamanho original
![image](https://user-images.githubusercontent.com/20362170/219482010-d5652b66-f635-465e-99e7-7cc1797a5662.png)


Testes com A3
![image](https://user-images.githubusercontent.com/20362170/219653906-db59e38f-abf6-4d87-8d37-721a9860ee89.png)

Testes com A5 (menor que A4 há uma certa sobreposição, mas acredito não precisar de controles pois é estampado em tempo de execução e usuário pode usar o PDF estampado tradicional)
![image](https://user-images.githubusercontent.com/20362170/219654191-f9a67ef3-ed3e-45eb-9828-217a7d4796b2.png)
![image](https://user-images.githubusercontent.com/20362170/219654730-f779a16a-09a8-40b7-a680-e0c6d653fe52.png)

Layout de Tela em SP
![image](https://user-images.githubusercontent.com/20362170/219659167-86b88e4e-6383-47fb-9159-37762abed2ff.png)

*Seria muito bom se houvesse uma unificação e enxugamento dessa tela, usando menu dropdown com as opções para visualização e extração do documento. Por ex.:
![image](https://user-images.githubusercontent.com/20362170/219662383-0c6c8aa5-b8b3-4301-b494-b3e7ac5900ce.png)

Teste via API
![image](https://user-images.githubusercontent.com/20362170/219665294-0b0ee454-9b40-4d81-b679-bcfaf1e7e9c3.png)

Sem Redimensionamento
![image](https://user-images.githubusercontent.com/20362170/219665350-a3fe2924-bcc8-4325-946f-1f9b9dada6f8.png)

Com Redimensionamento para A4
![image](https://user-images.githubusercontent.com/20362170/219665927-b6d23205-ba77-48e4-9682-df297701d58a.png)

Link clicável no Ver dossiê
Para não ter que ficar copiando e colando em uma nova aba, transformada URL em Link para com target _Blank
![image](https://user-images.githubusercontent.com/20362170/219666339-fab0a4b2-9062-45f0-a3c7-4734e70ae4db.png)

Teste com uma planta real A0

Com redimensionamento
![image](https://user-images.githubusercontent.com/20362170/219670253-147a8cae-aabe-4744-ba82-edf799be5de4.png)

Sem redimensionamento
![image](https://user-images.githubusercontent.com/20362170/219670534-f09f96d2-e586-4e3f-930f-4885e7115ffd.png)

Detalhe rodapé em 100%
![image](https://user-images.githubusercontent.com/20362170/219670802-4a9d7823-61a7-4725-963c-0f9bf7b8a377.png)
