### PR TITLE
RM150661 Adicionar endpoint para reclassificacao na API SIGAEX

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
@@ -51,6 +51,7 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
                 mov.getSubscritor(), mov.getExClassificacao(), mov.getDescrMov(), false);
 
         resp.sigla = mob.doc().getCodigo();
+        resp.classificacao = mob.doc().getExClassificacaoAtual().getDescricaoCompleta();
         resp.status = "OK";
     }
 
@@ -67,7 +68,7 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
         }
 
         final ExClassificacaoSelecao classificacaoSelecao = getClassificacaoSelecaoPorSigla(novaClassificacao);
-        if(Objects.isNull(classificacaoSelecao)){
+        if(Objects.isNull(classificacaoSelecao) || Objects.isNull(classificacaoSelecao.getId())){
             throw new AplicacaoException("Classificação selecionada inválida");
         }
         

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
@@ -14,6 +14,10 @@ import br.gov.jfrj.siga.ex.ExMovimentacao;
 import br.gov.jfrj.siga.vraptor.Transacional;
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
 import java.util.Objects;
 
 @Transacional
@@ -38,15 +42,20 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
                 validarEBuscarClassificacao(mob.doc().getExClassificacaoAtual().getSigla(), req.novaClassificacao);
         
         final String motivo = req.motivo;
-        final String dtMovString = req.data1;
-        final DpPessoaSelecao responsavel = getPessoaSelecaoPorSigla(req.matriculaResponsavel);
+        final Date dataReclassificacao = getDataMovimentacao(req.dataMovimentacao);
+        final DpPessoaSelecao responsavel = validarEBuscarResponsavel(req.matriculaResponsavel);
 
-        final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia().setDescrMov(motivo)
-                .setDtMovString(dtMovString).setCadastrante(cadastrante).setLotaTitular(lotaTitular)
-                .setSubscritorSel(responsavel).setClassificacaoSel(classificacaoSelecao)
+        final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia()
+                .setDescrMov(motivo)
+                .setCadastrante(cadastrante)
+                .setTitularSel(responsavel)
+                .setLotaTitular(lotaTitular)
+                .setResponsavelSel(responsavel)
+                .setClassificacaoSel(classificacaoSelecao)
                 .construir(dao());
         mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
-
+        mov.setDtMov(dataReclassificacao);
+        
         Ex.getInstance().getBL().avaliarReclassificar(cadastrante, lotaCadastrante, mob, mov.getDtMov(),
                 mov.getSubscritor(), mov.getExClassificacao(), mov.getDescrMov(), false);
 
@@ -62,14 +71,14 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
 
     private ExClassificacaoSelecao validarEBuscarClassificacao(final String classificacaoAtual, 
                                                                final String novaClassificacao){
-        if(classificacaoAtual.equals(novaClassificacao)){
-            throw new AplicacaoException("Classificação selecionada para reclassificar é a mesma da atual. "+
-                    "Selecione valores diferentes para a reclassificação");
+        if (classificacaoAtual.equals(novaClassificacao)) {
+            throw new AplicacaoException("Classificação " + novaClassificacao + " é a mesma da atual. " 
+                    + "Selecione valores diferentes para a reclassificação");
         }
 
         final ExClassificacaoSelecao classificacaoSelecao = getClassificacaoSelecaoPorSigla(novaClassificacao);
         if(Objects.isNull(classificacaoSelecao) || Objects.isNull(classificacaoSelecao.getId())){
-            throw new AplicacaoException("Classificação selecionada inválida");
+            throw new AplicacaoException("Classificação " + novaClassificacao + " inválida");
         }
         
         return classificacaoSelecao;
@@ -85,6 +94,17 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
         return exClassificacaoSelecao;
     }
 
+    private DpPessoaSelecao validarEBuscarResponsavel(final String matricula){
+
+        final DpPessoaSelecao dpPessoaSelecao = getPessoaSelecaoPorSigla(matricula);
+        if (StringUtils.isNotEmpty(matricula) && 
+                ( Objects.isNull(dpPessoaSelecao) || Objects.isNull(dpPessoaSelecao.getId()) )) {
+            throw new AplicacaoException("Matrícula do responsável " + matricula + " inválida");
+        }
+
+        return dpPessoaSelecao;
+    }
+    
     private DpPessoaSelecao getPessoaSelecaoPorSigla(String sigla) {
         DpPessoaSelecao dpPessoaSelecao = null;
         if (StringUtils.isNotEmpty(sigla)) {
@@ -93,6 +113,22 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
             dpPessoaSelecao.buscarPorSigla();
         }
         return dpPessoaSelecao;
+    }
+
+    private Date getDataMovimentacao(final String dataMovimentacaoString) throws AplicacaoException {
+        if (StringUtils.isEmpty(dataMovimentacaoString)) {
+            return null;
+        }
+        try {
+            LocalDate localDate = LocalDate.parse(dataMovimentacaoString);
+            if (localDate.isAfter(LocalDate.now())) {
+                throw new AplicacaoException("Data de reclassificação " + dataMovimentacaoString
+                        + " não pode ser maior que a data de hoje");
+            }
+            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException e) {
+            throw new AplicacaoException("Data de reclassificação inválida: " + dataMovimentacaoString);
+        }
     }
 
     private ExDao dao() {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
@@ -7,8 +7,6 @@ import br.gov.jfrj.siga.ex.ExMobil;
 import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.logic.ExPodeReclassificar;
 import br.gov.jfrj.siga.hibernate.ExDao;
-import br.gov.jfrj.siga.model.Selecao;
-import br.gov.jfrj.siga.model.SelecaoGenerica;
 import br.gov.jfrj.siga.vraptor.ExClassificacaoSelecao;
 import br.gov.jfrj.siga.vraptor.builder.ExMovimentacaoBuilder;
 import br.gov.jfrj.siga.ex.ExMovimentacao;
@@ -29,19 +27,17 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
 
         ctx.assertAcesso(mob, titular, lotaTitular);
 
-        Ex.getInstance().getComp().afirmar("O documento " + mob.getSigla() + " não pode ser reclassificado por " 
-                + titular.getSiglaCompleta() + "/" + lotaTitular.getSiglaCompleta(), 
-                ExPodeReclassificar.class, titular, lotaTitular, mob);
-        
+        Ex.getInstance().getComp().afirmar("O documento " + mob.getSigla() + " não pode ser reclassificado por " + titular.getSiglaCompleta() + "/" + lotaTitular.getSiglaCompleta(), ExPodeReclassificar.class, titular, lotaTitular, mob);
+
         final String motivo = req.motivo;
-        final String dtMovString = req.data;
-        final DpPessoaSelecao responsavel = (DpPessoaSelecao) getSelecaoPorSigla(req.matriculaResponsavel);
-        final ExClassificacaoSelecao classificacaoSelecao = (ExClassificacaoSelecao) getSelecaoPorSigla(req.novaClassificacao);
-                
-        final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia()
-                .setDescrMov(motivo).setDtMovString(dtMovString)
-                .setCadastrante(cadastrante).setLotaTitular(lotaTitular)
-                .setSubscritorSel(responsavel).setClassificacaoSel(classificacaoSelecao).construir(dao());
+        final String dtMovString = req.data1;
+        final DpPessoaSelecao responsavel = getPessoaSelecaoPorSigla(req.matriculaResponsavel);
+        final ExClassificacaoSelecao classificacaoSelecao = getClassificacaoSelecaoPorSigla(req.novaClassificacao);
+
+        final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia().setDescrMov(motivo)
+                .setDtMovString(dtMovString).setCadastrante(cadastrante).setLotaTitular(lotaTitular)
+                .setSubscritorSel(responsavel).setClassificacaoSel(classificacaoSelecao)
+                .construir(dao());
         mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
 
         Ex.getInstance().getBL().avaliarReclassificar(cadastrante, lotaCadastrante, mob, mov.getDtMov(),
@@ -56,17 +52,27 @@ public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSig
         return "Reclassificar";
     }
 
-    private Selecao getSelecaoPorSigla(String sigla) {
-        Selecao selecao = null;
-        if(StringUtils.isNotEmpty(sigla)){
-            selecao = new SelecaoGenerica();
-            selecao.setSigla(sigla);
-            selecao.buscarPorSigla();
+    private ExClassificacaoSelecao getClassificacaoSelecaoPorSigla(String sigla) {
+        ExClassificacaoSelecao exClassificacaoSelecao = null;
+        if (StringUtils.isNotEmpty(sigla)) {
+            exClassificacaoSelecao = new ExClassificacaoSelecao();
+            exClassificacaoSelecao.setSigla(sigla);
+            exClassificacaoSelecao.buscarPorSigla();
         }
-        return selecao;
+        return exClassificacaoSelecao;
     }
-    
-    private ExDao dao(){
+
+    private DpPessoaSelecao getPessoaSelecaoPorSigla(String sigla) {
+        DpPessoaSelecao dpPessoaSelecao = null;
+        if (StringUtils.isNotEmpty(sigla)) {
+            dpPessoaSelecao = new DpPessoaSelecao();
+            dpPessoaSelecao.setSigla(sigla);
+            dpPessoaSelecao.buscarPorSigla();
+        }
+        return dpPessoaSelecao;
+    }
+
+    private ExDao dao() {
         return ExDao.getInstance();
     }
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosSiglaReclassificarPost.java
@@ -1,0 +1,72 @@
+package br.gov.jfrj.siga.ex.api.v1;
+
+import br.gov.jfrj.siga.cp.model.DpPessoaSelecao;
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.bl.Ex;
+import br.gov.jfrj.siga.ex.logic.ExPodeReclassificar;
+import br.gov.jfrj.siga.hibernate.ExDao;
+import br.gov.jfrj.siga.model.Selecao;
+import br.gov.jfrj.siga.model.SelecaoGenerica;
+import br.gov.jfrj.siga.vraptor.ExClassificacaoSelecao;
+import br.gov.jfrj.siga.vraptor.builder.ExMovimentacaoBuilder;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.vraptor.Transacional;
+import org.apache.commons.lang3.StringUtils;
+
+@Transacional
+public class DocumentosSiglaReclassificarPost implements IExApiV1.IDocumentosSiglaReclassificarPost {
+
+    @Override
+    public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
+        DpPessoa cadastrante = ctx.getCadastrante();
+        DpPessoa titular = cadastrante;
+        DpLotacao lotaCadastrante = cadastrante.getLotacao();
+        DpLotacao lotaTitular = ctx.getLotaTitular();
+
+        ExMobil mob = ctx.buscarEValidarMobil(req.sigla, req, resp, "Documento a Reclassificar");
+
+        ctx.assertAcesso(mob, titular, lotaTitular);
+
+        Ex.getInstance().getComp().afirmar("O documento " + mob.getSigla() + " não pode ser reclassificado por " 
+                + titular.getSiglaCompleta() + "/" + lotaTitular.getSiglaCompleta(), 
+                ExPodeReclassificar.class, titular, lotaTitular, mob);
+        
+        final String motivo = req.motivo;
+        final String dtMovString = req.data;
+        final DpPessoaSelecao responsavel = (DpPessoaSelecao) getSelecaoPorSigla(req.matriculaResponsavel);
+        final ExClassificacaoSelecao classificacaoSelecao = (ExClassificacaoSelecao) getSelecaoPorSigla(req.novaClassificacao);
+                
+        final ExMovimentacao mov = ExMovimentacaoBuilder.novaInstancia()
+                .setDescrMov(motivo).setDtMovString(dtMovString)
+                .setCadastrante(cadastrante).setLotaTitular(lotaTitular)
+                .setSubscritorSel(responsavel).setClassificacaoSel(classificacaoSelecao).construir(dao());
+        mov.setDtIniMov(dao().consultarDataEHoraDoServidor());
+
+        Ex.getInstance().getBL().avaliarReclassificar(cadastrante, lotaCadastrante, mob, mov.getDtMov(),
+                mov.getSubscritor(), mov.getExClassificacao(), mov.getDescrMov(), false);
+
+        resp.sigla = mob.doc().getCodigo();
+        resp.status = "OK";
+    }
+
+    @Override
+    public String getContext() {
+        return "Reclassificar";
+    }
+
+    private Selecao getSelecaoPorSigla(String sigla) {
+        Selecao selecao = null;
+        if(StringUtils.isNotEmpty(sigla)){
+            selecao = new SelecaoGenerica();
+            selecao.setSigla(sigla);
+            selecao.buscarPorSigla();
+        }
+        return selecao;
+    }
+    
+    private ExDao dao(){
+        return ExDao.getInstance();
+    }
+}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1768,4 +1768,22 @@ public interface IExApiV1 {
         public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
     }
 
+    public interface IDocumentosSiglaReclassificarPost extends ISwaggerMethod {
+        public static class Request implements ISwaggerRequest {
+            public String sigla;
+            public String novaClassificacao;
+            public String data;
+            public String matriculaResponsavel;
+            public String motivo;
+            
+        }
+
+        public static class Response implements ISwaggerResponse {
+            public String sigla;
+            public String status;
+        }
+
+        public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;
+    }
+
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1772,8 +1772,9 @@ public interface IExApiV1 {
         public static class Request implements ISwaggerRequest {
             public String sigla;
             public String novaClassificacao;
-            public String dataMovimentacao;
-            public String matriculaResponsavel;
+            public String data;
+            public String responsavel;
+            public String titular;
             public String motivo;
             
         }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1781,6 +1781,7 @@ public interface IExApiV1 {
         public static class Response implements ISwaggerResponse {
             public String sigla;
             public String status;
+            public String classificacao;
         }
 
         public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1772,7 +1772,7 @@ public interface IExApiV1 {
         public static class Request implements ISwaggerRequest {
             public String sigla;
             public String novaClassificacao;
-            public String data;
+            public String data1;
             public String matriculaResponsavel;
             public String motivo;
             

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/IExApiV1.java
@@ -1772,7 +1772,7 @@ public interface IExApiV1 {
         public static class Request implements ISwaggerRequest {
             public String sigla;
             public String novaClassificacao;
-            public String data1;
+            public String dataMovimentacao;
             public String matriculaResponsavel;
             public String motivo;
             

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -316,6 +316,13 @@ parameters:
     required: false
     type: string
     pattern: ^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])
+  dataMovimentacao:
+    name: dataMovimentacao
+    in: formData
+    description: Data de movimentação que será realizada no documento (por exemplo, `2020-12-02`). Deve ser igual ou menor que o dia corrente!
+    required: false
+    type: string
+    pattern: ^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])  
   idMarcador:
     name: idMarcador
     in: formData

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -279,7 +279,7 @@ parameters:
   motivo:
     name: motivo
     in: formData
-    description: Motivo. Tamanho Máximo = 500.
+    description: Motivo. Tamanho M&aacute;ximo = 500.
     required: true
     maxLength: 500
     type: string
@@ -595,19 +595,6 @@ parameters:
     required: true
     type: string
   
-  novaClassificacao:
-    name: novaClassificacao
-    in: formData
-    description: Nova classificação do documento
-    type: string
-    required: true
-    
-  matriculaResponsavel:
-    name: matriculaResponsavel
-    in: formData
-    description: Matrícula do responsável pela reclassificação
-    type: string
-    required: false
     
 ################################################################################
 #                                           Paths                              #
@@ -2828,16 +2815,38 @@ paths:
   
   /documentos/{sigla}/reclassificar:
     post:
-      description: "Utilize este método para reclassificar o documento."
+      description: "Utilize este m&eacute;todo para reclassificar o documento."
       consumes: ["application/x-www-form-urlencoded"]
       tags: [ acao ]
       security:
         - Bearer: []
       parameters:
         - $ref: "#/parameters/sigla"
-        - $ref: "#/parameters/novaClassificacao"  
-        - $ref: "#/parameters/data1"
-        - $ref: "#/parameters/matriculaResponsavel"
+        - novaClassificacao:
+          name: novaClassificacao
+          in: formData
+          description: Nova classifica&ccedil;&atilde;o do documento
+          type: string
+          required: true
+        - responsavel:
+          name: responsavel
+          in: formData
+          description: Matr&iacute;cula do respons&aacute;vel pela reclassifica&ccedil;&atilde;o
+          type: string
+          required: false
+        - titular:
+          name: titular
+          in: formData
+          description: Matr&iacute;cula do titular ou substituto do respons&aacute;vel pela reclassifica&ccedil;&atilde;o
+          type: string
+          required: false  
+        - data:
+          name: data
+          in: formData
+          description: Data retroativa da reclassifica&ccedil;&atilde;o (por exemplo, `2020-12-02`).
+          required: false
+          type: string
+          pattern: ^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])  
         - $ref: "#/parameters/motivo"  
       summary: Reclassificar documento
       responses:

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2804,6 +2804,37 @@ paths:
           description: Error ocurred
           schema:
             $ref: "#/definitions/Error"
+  
+  /documentos/{sigla}/reclassificar:
+    post:
+      description: "Utilize este método para reclassificar o documento."
+      consumes: [ "application/x-www-form-urlencoded" ]
+      tags: [ acao ]
+      security:
+        - Bearer: [ ]
+      parameters:
+        - $ref: "#/parameters/sigla"
+        - $ref: "#/parameters/classificacao"  
+        - $ref: "#/parameters/data1"
+        - $ref: "#/parameters/matricula"
+        - $ref: "#/parameters/motivo"  
+      summary: Reclassificar documento
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: object
+            properties:
+              sigla:
+                description: Sigla do documento
+                type: string
+              status:
+                type: string
+                default: "OK"
+        500:
+          description: Error ocurred
+          schema:
+            $ref: "#/definitions/Error"
             
   /numeracao-expediente:
     post:

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -587,6 +587,20 @@ parameters:
     description: Informa se a sequência será zerada a cada início de ano.
     required: true
     type: string
+  
+  novaClassificacao:
+    name: novaClassificacao
+    in: formData
+    description: Nova classificação do documento
+    type: string
+    required: true
+    
+  matriculaResponsavel:
+    name: matriculaResponsavel
+    in: formData
+    description: Matrícula do responsável pela reclassificação
+    type: string
+    required: false
     
 ################################################################################
 #                                           Paths                              #
@@ -2808,15 +2822,15 @@ paths:
   /documentos/{sigla}/reclassificar:
     post:
       description: "Utilize este método para reclassificar o documento."
-      consumes: [ "application/x-www-form-urlencoded" ]
+      consumes: ["application/x-www-form-urlencoded"]
       tags: [ acao ]
       security:
-        - Bearer: [ ]
+        - Bearer: []
       parameters:
         - $ref: "#/parameters/sigla"
-        - $ref: "#/parameters/classificacao"  
+        - $ref: "#/parameters/novaClassificacao"  
         - $ref: "#/parameters/data1"
-        - $ref: "#/parameters/matricula"
+        - $ref: "#/parameters/matriculaResponsavel"
         - $ref: "#/parameters/motivo"  
       summary: Reclassificar documento
       responses:

--- a/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
+++ b/sigaex/src/main/resources/br/gov/jfrj/siga/ex/api/v1/swagger.yaml
@@ -2845,6 +2845,9 @@ paths:
               status:
                 type: string
                 default: "OK"
+              classificacao:
+                description: Classificação do documento após a reclassificação
+                type: string
         500:
           description: Error ocurred
           schema:


### PR DESCRIPTION
### Adicionar endpoint para reclassificacao na API SIGAEX

Este pull request visa adicionar um endpoint na API SIGAEX para reclassificar um determinado documento pela sigla.

### Resumo da implementação

1. Adicionado endpoint POST /documentos/{sigla}/reclassificar
1.1. Adicionada classe DocumentosSiglaReclassificarPost
1.2. Documentação do endpoint adicionada no swagger.yaml 

#### Captura com os resultados obtidos

##### Documentação API SIGAEX

![image](https://user-images.githubusercontent.com/1022974/222765257-a1ab4536-f5d9-47c7-804e-0c4b048e2a1a.png)

##### Chamada ao endpoint e resultado

![image](https://user-images.githubusercontent.com/1022974/222765382-d8b11140-21db-4532-9fcf-a3e8e3eb7731.png)

##### Histórico de movimentação do documento ZZPRC202200252 reclassificado

![image](https://user-images.githubusercontent.com/1022974/222765744-7ced9c6b-820d-45f4-bc98-d09e4d000b0f.png)


