### PR TITLE
RM113561 Impossibilitando desfazer juntada quando o documento pai estiver arquivado corrente.

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExEstaArquivadoCorrente.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExEstaArquivadoCorrente.java
@@ -14,7 +14,7 @@ public class ExEstaArquivadoCorrente implements Expression {
 
 	@Override
 	public boolean eval() {
-		return mob.isArquivadoCorrente();
+		return mob != null && mob.isArquivadoCorrente();
 	}
 
 	@Override

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarJuntada.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarJuntada.java
@@ -61,9 +61,7 @@ public class ExPodeCancelarJuntada extends CompositeExpressionSupport {
 				new ExEMobilVia(mob),
 				
 				new ExEstaJuntado(mob),
-				
-				Not.of(new ExEstaArquivado(mob)),
-				
+							
 				Not.of(new ExEstaArquivado(mobPai)),  
 				
 				Not.of(new ExEstaEmTransito(mob, titular, lotaTitular)),

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarJuntada.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarJuntada.java
@@ -62,6 +62,10 @@ public class ExPodeCancelarJuntada extends CompositeExpressionSupport {
 				
 				new ExEstaJuntado(mob),
 				
+				Not.of(new ExEstaArquivado(mob)),
+				
+				Not.of(new ExEstaArquivado(mobPai)),  
+				
 				Not.of(new ExEstaEmTransito(mob, titular, lotaTitular)),
 				
 				Not.of(new ExEMobilCancelado(mob)),

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarMovimentacao.java
@@ -158,6 +158,8 @@ public class ExPodeCancelarMovimentacao extends CompositeExpressionSupport {
 
 						new ExEstaResponsavel(mob, titular, lotaTitular)),
 
+				Not.of(new ExEstaArquivadoCorrente(mobRef)),
+				
 				NAnd.of(
 
 						new ExMovimentacaoEDoTipo(exUltMovNaoCanc, ExTipoDeMovimentacao.ATUALIZACAO),

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarMovimentacao.java
@@ -157,8 +157,6 @@ public class ExPodeCancelarMovimentacao extends CompositeExpressionSupport {
 						new ExMovimentacaoELotaTitular(exUltMovNaoCanc, lotaTitular),
 
 						new ExEstaResponsavel(mob, titular, lotaTitular)),
-
-				Not.of(new ExEstaArquivadoCorrente(mobRef)),
 				
 				NAnd.of(
 
@@ -166,7 +164,7 @@ public class ExPodeCancelarMovimentacao extends CompositeExpressionSupport {
 
 						NOr.of(
 
-								new ExEstaArquivado(mobRef),
+								new ExEstaArquivado(mobRef), 
 
 								And.of(
 


### PR DESCRIPTION
Foi solicitado que impossibilite a desfazer juntada quando o documento pai for arquivado.
Por exemplo: Dando que existe um documento do tipo Processo e é incluído um despacho e ambos são assinados, logo, é juntado automaticamente. Porém, quando o documento pai, que é Processo, é arquivado; não é pra deixar o documento Filho, no caso é o despacho, desfazer juntada.

Segue evidência da correção:

**Documento Processo que já tem um despacho não arquivado:**
![DOCUMENTO_PAI_NAO_ARQUIVADO](https://user-images.githubusercontent.com/73559672/222727108-4ef41c50-68ee-47d3-9dd3-2724fb67e33f.png)

**Logo, o despacho ainda pode desfazer juntada:**
![BOTAO_DESFAZER_JUNTADA_HABILITADO](https://user-images.githubusercontent.com/73559672/222727216-5a5d5b7a-f8da-41a2-98c3-e98c9b8b58dd.png)

**Processo arquivado:**
![DOCUMENTO_PAI_ARQUIVADO](https://user-images.githubusercontent.com/73559672/222727287-7a089050-489b-454a-9973-e101fd25366b.png)

**Despacho não pode desfazer juntada:**
![BOTAO_DESFAZER_JUNTADA_DESABILITADO](https://user-images.githubusercontent.com/73559672/222727360-be840a34-af51-475e-90db-4631e8a0296d.png)
