### PR TITLE
RM59508 - Ajustes na rotina de Restrição de Acesso

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaModal.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaModal.java
@@ -11,6 +11,11 @@ public class SigaModal {
 	private String linkBotaoDeAcao;
 	private String classBotaoDeAcao = "btn-primary";
 	private String classBotaoDeFechar = "btn-secondary";
+	
+	private String  descricaoBotaoFechaModalDoRodape = "Não";
+	private String  descricaoBotaoDeAcao = "Sim";
+	
+	
 	private boolean inverterBotoes;
 	
 
@@ -79,6 +84,26 @@ public class SigaModal {
 	
 	public boolean isInverterBotoes() {
 		return inverterBotoes;
+	}
+	
+	
+	public String getDescricaoBotaoFechaModalDoRodape() {
+		return descricaoBotaoFechaModalDoRodape;
+	}
+
+	public SigaModal descricaoBotaoFechaModalDoRodape(String descricaoBotaoFechaModalDoRodape) {
+		this.descricaoBotaoFechaModalDoRodape = descricaoBotaoFechaModalDoRodape;
+		return this;
+	}
+	
+	
+	public String getDescricaoBotaoDeAcao() {
+		return descricaoBotaoDeAcao;
+	}
+
+	public SigaModal descricaoBotaoDeAcao(String descricaoBotaoDeAcao) {
+		this.descricaoBotaoDeAcao = descricaoBotaoDeAcao;
+		return this;
 	}
 
 }

--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaModal.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaModal.java
@@ -3,11 +3,17 @@ package br.gov.jfrj.siga.base;
 public class SigaModal {
 	
 	public static final String ALERTA = "sigaModalAlerta";
+	public static final String CONFIRMACAO = "sigaModalConfirmacao";
 		
 	private String titulo;
 	private String mensagem;	
 	private boolean centralizar;
+	private String linkBotaoDeAcao;
+	private String classBotaoDeAcao = "btn-primary";
+	private String classBotaoDeFechar = "btn-secondary";
+	private boolean inverterBotoes;
 	
+
 	public SigaModal(String mensagem) {		
 		this.mensagem = mensagem;
 	}
@@ -36,6 +42,43 @@ public class SigaModal {
 	
 	public boolean isCentralizar() {
 		return centralizar;
+	}
+	
+	public String getLinkBotaoDeAcao() {
+		return linkBotaoDeAcao;
+	}
+
+	public SigaModal linkBotaoDeAcao(String linkBotaoDeAcao) {
+		this.linkBotaoDeAcao = linkBotaoDeAcao;
+		return this;
+	}
+	
+	public String getClassBotaoDeAcao() {
+		return classBotaoDeAcao;
+	}
+
+	public SigaModal classBotaoDeAcao(String classBotaoDeAcao) {
+		this.classBotaoDeAcao = classBotaoDeAcao;
+		return this;
+	}
+
+	public String getClassBotaoDeFechar() {
+		return classBotaoDeFechar;
+	}
+
+	public SigaModal classBotaoDeFechar(String classBotaoDeFechar) {
+		this.classBotaoDeFechar = classBotaoDeFechar;
+		return this;
+	}
+	
+	
+	public SigaModal inverterBotoes() {
+		this.inverterBotoes = true;
+		return this;
+	}
+	
+	public boolean isInverterBotoes() {
+		return inverterBotoes;
 	}
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExDocumento.java
@@ -152,6 +152,7 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 
 	/**
 	 * Retorna o nível de acesso (não a descrição) atual do documento.
+	 * COM Atualização da DnmNivelAcesso
 	 */
 	public ExNivelAcesso getExNivelAcessoAtual() {
 		ExNivelAcesso nivel = getDnmExNivelAcesso();
@@ -159,6 +160,22 @@ public class ExDocumento extends AbstractExDocumento implements Serializable,
 			return Ex.getInstance().getBL().atualizarDnmNivelAcesso(this);
 		return nivel;
 	}
+	
+	
+	/**
+	 * Retorna o nível de acesso (não a descrição) atual do documento.
+	 * SEM Atualização da DnmNivelAcesso
+	 */
+	public ExNivelAcesso getExNivelAcessoAnterior() {
+		ExNivelAcesso nivel = null;
+		if (this.getMobilGeral() != null && this.getMobilGeral().getPenultimaMovimentacaoAlteracaoNivelAcessoNaoCancelada() != null)
+			nivel = this.getMobilGeral().getPenultimaMovimentacaoAlteracaoNivelAcessoNaoCancelada().getExNivelAcesso();
+		if (nivel == null)
+			nivel = this.getExNivelAcesso();
+		return nivel;
+	}
+	
+	
 
 	/**
 	 * Retorna o nível de acesso (não a descrição) atual do documento.

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -809,6 +809,19 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 	public ExMovimentacao getUltimaMovimentacao(ITipoDeMovimentacao tpMov) {
 		return getUltimaMovimentacao(new ITipoDeMovimentacao[] { tpMov }, new ITipoDeMovimentacao[] {}, this, true, null, false);
 	}
+	
+	
+	/**
+	 * Retorna a última movimentação não cancelada que o móbil recebeu que altera
+	 * o nível de acesso ao documento
+	 * 
+	 * @return ExMovimentacao
+	 */
+	public ExMovimentacao getUltimaMovimentacaoAlteracaoNivelAcessoNaoCancelada() {
+		return getUltimaMovimentacao(new ITipoDeMovimentacao[] { ExTipoDeMovimentacao.REDEFINICAO_NIVEL_ACESSO, 
+				ExTipoDeMovimentacao.RESTRINGIR_ACESSO},  new ITipoDeMovimentacao[] {}, this, false, null, false);
+	}	
+
 
 	/**
 	 * Retorna a última movimentação (cancelada ou não, conforme o parâmetro

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -101,6 +101,34 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return penMov;
 	}
 
+	
+	/**
+	 * Retorna A penúltima movimentação não cancelada e não canceladora de um Mobil dentre os tipos informados
+	 * 
+	 * @return Penúltima movimentação não cancelada de um Mobil dentre os tipos informados
+	 * 
+	 */
+	public ExMovimentacao getPenultimaMovimentacaoPorTipoNaoCancelada(ITipoDeMovimentacao[] tpMovs) {
+		final Set<ExMovimentacao> movs = getMovsNaoCanceladas(tpMovs);
+				
+		ExMovimentacao mov = null;
+		ExMovimentacao penMov = null;
+		for (final Object element : movs) {
+			final ExMovimentacao movIterate = (ExMovimentacao) element;
+
+			if (movIterate.getExTipoMovimentacao() != ExTipoDeMovimentacao.CANCELAMENTO_DE_MOVIMENTACAO) {
+				if (mov == null && penMov == null) {
+					mov = movIterate;
+				} else {
+					penMov = mov;
+					mov = movIterate;
+				}
+			}
+		}
+		return penMov;
+	}
+	
+	
 	/**
 	 * Retorna as movimentações de um Mobil de acordo com um tipo específico de
 	 * movimentação.
@@ -821,6 +849,17 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return getUltimaMovimentacao(new ITipoDeMovimentacao[] { ExTipoDeMovimentacao.REDEFINICAO_NIVEL_ACESSO, 
 				ExTipoDeMovimentacao.RESTRINGIR_ACESSO},  new ITipoDeMovimentacao[] {}, this, false, null, false);
 	}	
+	
+	/**
+	 * Retorna a Penúltima movimentação não cancelada que o móbil recebeu que altera
+	 * o nível de acesso ao documento.
+	 * 
+	 * @return ExMovimentacao
+	 */
+	public ExMovimentacao getPenultimaMovimentacaoAlteracaoNivelAcessoNaoCancelada() {
+		return getPenultimaMovimentacaoPorTipoNaoCancelada(new ITipoDeMovimentacao[] { ExTipoDeMovimentacao.REDEFINICAO_NIVEL_ACESSO, 
+				ExTipoDeMovimentacao.RESTRINGIR_ACESSO});
+	}
 
 
 	/**

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -126,6 +126,19 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return movsTp;
 	}
 	
+	public List<DpPessoa> getSubscitoresMovimentacoesPorTipo(ITipoDeMovimentacao tpMov, boolean somenteAtivas) {
+		List<ExMovimentacao> movimentacoes = getMovimentacoesPorTipo(tpMov, somenteAtivas);
+		List<DpPessoa> subscritores = new ArrayList<DpPessoa>();
+		
+		if (movimentacoes != null) {
+			for (ExMovimentacao movimentacao : movimentacoes) {
+				subscritores.add(movimentacao.getSubscritor());
+			}
+		}
+		return subscritores;
+		
+	}
+	
 	public List<ExMovimentacao> getMovimentacoesPorNome (String descr, boolean somenteAtivas) {
 		return getMovimentacoesPorTipo(ExTipoDeMovimentacao.valueOf(descr), somenteAtivas); 
 	}
@@ -2522,6 +2535,14 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 
 	public ExRef getRef() {
 		return new ExRef(this);
+	}
+	
+	
+	/**
+	 * Verifica se o mobil geral está com registro de Restrição de Acesso ativo
+	 */
+	public boolean isAcessoRestrito() {
+		return sofreuMov(ExTipoDeMovimentacao.RESTRINGIR_ACESSO,null,doc().getMobilGeral());
 	}
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java
@@ -154,7 +154,7 @@ public class ExMobil extends AbstractExMobil implements Serializable, Selecionav
 		return movsTp;
 	}
 	
-	public List<DpPessoa> getSubscitoresMovimentacoesPorTipo(ITipoDeMovimentacao tpMov, boolean somenteAtivas) {
+	public List<DpPessoa> getSubscritoresMovimentacoesPorTipo(ITipoDeMovimentacao tpMov, boolean somenteAtivas) {
 		List<ExMovimentacao> movimentacoes = getMovimentacoesPorTipo(tpMov, somenteAtivas);
 		List<DpPessoa> subscritores = new ArrayList<DpPessoa>();
 		

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExAcesso.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import br.gov.jfrj.siga.cp.util.XjusUtils;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
@@ -362,14 +363,19 @@ public class ExAcesso {
 				}
 			}
 		} else {
+			boolean adicionaAcesso = false;
 			for (ExMovimentacao exMovimentacao : doc.getMobilGeral().getMovsNaoCanceladas (ExTipoDeMovimentacao.RESTRINGIR_ACESSO)) {
 				//Mantém último cadastrante de Restrição de Acesso na lista de Acesso para que não perca acesso imediato após ação
 				//Não usado a Cancelada, para na exclusão o cadastrante da última restrição não perder o acesso
 				//Então no mínimo, se houver a exclusão de todas as restrições, o operador não perde o acesso
 				add(doc.getMobilGeral().getUltimaMovimentacao(ExTipoDeMovimentacao.RESTRINGIR_ACESSO).getCadastrante());
 				
-				//Adiciona as pessoas objetos da restrição na lista de acesso
-				if (!acessos.contains(exMovimentacao.getSubscritor()))
+				//Adiciona as pessoas objetos da restrição na lista de acesso caso não esteja
+				adicionaAcesso = !acessos
+									.stream()
+									.anyMatch(acesso -> exMovimentacao.getSubscritor().equivale(acesso));
+				
+				if (adicionaAcesso)
 					add(exMovimentacao.getSubscritor());
 			}
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5908,7 +5908,7 @@ public class ExBL extends CpBL {
 	
 	public void restringirAcesso(final DpPessoa cadastrante, final DpLotacao lotaCadastrante, final ExDocumento doc,
 			final Date dtMov, DpLotacao lotaResponsavel, final DpPessoa responsavel,
-			final List<DpPessoa> listaSubscritor, final DpPessoa titular, String nmFuncaoSubscritor,
+			final List<DpPessoa> listaPessoasRestricaoAcesso, final DpPessoa titular, String nmFuncaoSubscritor,
 			ExNivelAcesso nivelAcesso) throws AplicacaoException {
 
 		if (nivelAcesso == null) {
@@ -5920,11 +5920,24 @@ public class ExBL extends CpBL {
 
 			List<ExDocumento> documentos = new ArrayList<>();
 			List<ExMovimentacao> listaMov = new ArrayList<ExMovimentacao>();
+			List<DpPessoa> listaPessoasSubscritoresRestricaoAcesso = new ArrayList<DpPessoa>();
+			
+			
 			documentos.add(doc);
 			documentos.addAll(doc.getExDocumentoFilhoSet());
 			for (ExDocumento exDocumento : documentos) {
-				for (DpPessoa subscritor : listaSubscritor) {					
-					
+				
+				listaPessoasSubscritoresRestricaoAcesso.clear();
+				listaPessoasSubscritoresRestricaoAcesso.addAll(listaPessoasRestricaoAcesso);
+				
+				//mantém Subscritores e Cossignatários caso esteja pendente de assinatura
+				if (exDocumento.isPendenteDeAssinatura()) {
+					listaPessoasSubscritoresRestricaoAcesso.addAll(exDocumento.getSubscritorECosignatarios());
+				}
+				
+				
+				for (DpPessoa subscritor : listaPessoasSubscritoresRestricaoAcesso) {				
+
 					final ExMovimentacao mov = criarNovaMovimentacao(
 							ExTipoDeMovimentacao.RESTRINGIR_ACESSO, cadastrante, lotaCadastrante,
 							exDocumento.getMobilGeral(), dtMov, subscritor, null, titular, null, dtMov);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -186,6 +186,7 @@ import br.gov.jfrj.siga.ex.logic.ExPodeCancelarDespacho;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarMarcacao;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarMovimentacao;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarOuAlterarPrazoDeAssinatura;
+import br.gov.jfrj.siga.ex.logic.ExPodeCancelarRestringirAcesso;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarVia;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarVinculacao;
 import br.gov.jfrj.siga.ex.logic.ExPodeCancelarVinculacaoPapel;
@@ -3053,7 +3054,7 @@ public class ExBL extends CpBL {
 		} else if (movCancelar.getExTipoMovimentacao() == ExTipoDeMovimentacao.REFERENCIA) {
 			getComp().afirmar("não é possível cancelar vinculação de documento", ExPodeCancelarVinculacao.class, titular, lotaTitular, movCancelar);
 		} else if (movCancelar.getExTipoMovimentacao() == ExTipoDeMovimentacao.RESTRINGIR_ACESSO) {
-			getComp().afirmar("não é possível cancelar Restrição de Acesso de documento", ExPodeRestringirAcesso.class, titular, lotaTitular, mob);
+			getComp().afirmar("não é possível cancelar Restrição de Acesso de documento", ExPodeCancelarRestringirAcesso.class, titular, lotaTitular, movCancelar);
 		} else if (!forcar && movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.AGENDAMENTO_DE_PUBLICACAO_BOLETIM
 				&& movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_EM_EDITAL_DE_ELIMINACAO
 				&& movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.SOLICITACAO_DE_ASSINATURA
@@ -4564,7 +4565,7 @@ public class ExBL extends CpBL {
 				});
 		}
 	}
-
+	
 	public void juntarDocumento(final DpPessoa cadastrante, final DpPessoa docTitular, final DpLotacao lotaCadastrante,
 			final String idDocExterno, final ExMobil mob, ExMobil mobPai, final Date dtMov, final DpPessoa subscritor,
 			final DpPessoa titular, final String idDocEscolha) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4713,7 +4713,7 @@ public class ExBL extends CpBL {
 			//Se tem Restrição de Acesso no Pai, herda movimentações e nível de acesso do Pai
 			restringirAcesso(cadastrante, titular.getLotacao(), mobFilho.getDoc(), null, null, null, 
 					mobPai.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, false), 
-					titular, null, mobPai.getDoc().getExNivelAcesso());
+					titular, null, mobPai.getDoc().getExNivelAcessoAtual());
 
 		}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -8981,6 +8981,20 @@ public class ExBL extends CpBL {
 			}
 		}
 	}
+	
+	
+	public void restringirAcessoAntes(final ExDocumento documento , final DpPessoa pessoaASerAdicionada, DpPessoa cadastrante, final DpLotacao lotaCadastrante) {
+		Ex.getInstance().getComp().afirmar("Não é possível restringir acesso", ExPodeRestringirAcesso.class, cadastrante, lotaCadastrante, documento.getMobilGeral());
+
+		List<DpPessoa> listaPessoasRestricaoAcesso = new ArrayList<DpPessoa>();
+		listaPessoasRestricaoAcesso.add(pessoaASerAdicionada);
+		
+		ExNivelAcesso nivelAcesso = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_PESSOAS, ExNivelAcesso.class, false);
+
+		Ex.getInstance()
+				.getBL()
+				.restringirAcesso(cadastrante, lotaCadastrante, documento, null, null, null, listaPessoasRestricaoAcesso, null, null, nivelAcesso);
+	}
 
 }
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4559,7 +4559,7 @@ public class ExBL extends CpBL {
 		if (mob.isAcessoRestrito()) {
 			mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 				.stream()
-				.filter(movRestricao -> movRestricao.getSubscritor().equals(pessoa))
+				.filter(movRestricao -> pessoa.equivale(movRestricao.getSubscritor()))
 				.forEach(movRestricaoAcessoParaPessoa-> {
 					try {
 						cancelar(cadastrante, lotaCadastrante, mob, movRestricaoAcessoParaPessoa, null, null, null, "Restrição: " + movRestricaoAcessoParaPessoa.getDescrMov());

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4196,8 +4196,8 @@ public class ExBL extends CpBL {
 	public ExNivelAcesso atualizarDnmNivelAcesso(ExDocumento doc) {
 		log.debug("[getExNivelAcesso] - Obtendo nível de acesso atual do documento...");
 		ExNivelAcesso nivel = null;
-		if (doc.getMobilGeral() != null && doc.getMobilGeral().getUltimaMovimentacaoNaoCancelada() != null)
-			nivel = doc.getMobilGeral().getUltimaMovimentacaoNaoCancelada().getExNivelAcesso();
+		if (doc.getMobilGeral() != null && doc.getMobilGeral().getUltimaMovimentacaoAlteracaoNivelAcessoNaoCancelada() != null)
+			nivel = doc.getMobilGeral().getUltimaMovimentacaoAlteracaoNivelAcessoNaoCancelada().getExNivelAcesso();
 		if (nivel == null)
 			nivel = doc.getExNivelAcesso();
 		doc.setDnmExNivelAcesso(nivel);
@@ -5960,7 +5960,6 @@ public class ExBL extends CpBL {
 								+ subscritor.getDescricaoIniciaisMaiusculas());
 	
 						mov.setExNivelAcesso(nivelAcesso);
-						exDocumento.setExNivelAcesso(nivelAcesso);
 						
 						if (isMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso()) {
 							listaMov.add(mov);
@@ -6013,8 +6012,7 @@ public class ExBL extends CpBL {
 						movPrincipal = mov;
 
 				}
-				exDocumento.setExNivelAcesso(nivelAcesso);
-				dao().gravar(exDocumento);
+
 				concluirAlteracaoComRecalculoAcesso(movPrincipal);
 			}
 		} catch (final Exception e) {

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3052,6 +3052,8 @@ public class ExBL extends CpBL {
 			ExPodeCancelarMarcacao.afirmar(movCancelar, titular, lotaTitular);
 		} else if (movCancelar.getExTipoMovimentacao() == ExTipoDeMovimentacao.REFERENCIA) {
 			getComp().afirmar("não é possível cancelar vinculação de documento", ExPodeCancelarVinculacao.class, titular, lotaTitular, movCancelar);
+		} else if (movCancelar.getExTipoMovimentacao() == ExTipoDeMovimentacao.RESTRINGIR_ACESSO) {
+			getComp().afirmar("não é possível cancelar Restrição de Acesso de documento", ExPodeRestringirAcesso.class, titular, lotaTitular, mob);
 		} else if (!forcar && movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.AGENDAMENTO_DE_PUBLICACAO_BOLETIM
 				&& movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.INCLUSAO_EM_EDITAL_DE_ELIMINACAO
 				&& movCancelar.getExTipoMovimentacao() != ExTipoDeMovimentacao.SOLICITACAO_DE_ASSINATURA

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4712,7 +4712,7 @@ public class ExBL extends CpBL {
 		} else {
 			//Se tem Restrição de Acesso no Pai, herda movimentações e nível de acesso do Pai
 			restringirAcesso(cadastrante, titular.getLotacao(), mobFilho.getDoc(), null, null, null, 
-					mobPai.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, false), 
+					mobPai.getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, false), 
 					titular, null, mobPai.getDoc().getExNivelAcessoAtual());
 
 		}
@@ -5940,7 +5940,7 @@ public class ExBL extends CpBL {
 				boolean pessoaEstaRestricaoAcesso = false;
 				for (DpPessoa subscritor : listaPessoasSubscritoresRestricaoAcesso) {		
 					
-					pessoaEstaRestricaoAcesso = doc.getMobilGeral().getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
+					pessoaEstaRestricaoAcesso = doc.getMobilGeral().getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 													.stream()
 													.anyMatch(pessoaRestrita -> subscritor.equivale(pessoaRestrita));
 					

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3265,7 +3265,7 @@ public class ExBL extends CpBL {
 			
 			if(mov.getExTipoMovimentacao().equals(ExTipoDeMovimentacao.INCLUSAO_DE_COSIGNATARIO)) {
 				this.excluirRegistroDaOrdenacaoAssinatura(mob, mov, cadastrante, lotaCadastrante);
-				this.excluirRestricaoAcessoCossignatario(mob, mov, cadastrante, lotaCadastrante);
+				this.excluirRestricaoAcessoPessoa(mob, mov.getSubscritor(), cadastrante, lotaCadastrante);
 			}
 			
 			concluirAlteracao(mov);
@@ -4551,16 +4551,16 @@ public class ExBL extends CpBL {
 	/**
 	 *Se Documento com Acesso Restrito, verifica se há restrição para cossignatário na exclusão de cossignatário e remove restrição
 	 */
-	private void excluirRestricaoAcessoCossignatario(ExMobil mob, ExMovimentacao mov, DpPessoa cadastrante, DpLotacao lotaCadastrante) {
+	public void excluirRestricaoAcessoPessoa(ExMobil mob, DpPessoa pessoa, DpPessoa cadastrante, DpLotacao lotaCadastrante) {
 		if (mob.isAcessoRestrito()) {
 			mob.getMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 				.stream()
-				.filter(movRestricao -> movRestricao.getSubscritor().equals(mov.getSubscritor()))
-				.forEach(movRestricaoAcessoDeCossignatario -> {
+				.filter(movRestricao -> movRestricao.getSubscritor().equals(pessoa))
+				.forEach(movRestricaoAcessoParaPessoa-> {
 					try {
-						cancelar(cadastrante, lotaCadastrante, mob, movRestricaoAcessoDeCossignatario, null, null, null, "Restrição: " + movRestricaoAcessoDeCossignatario.getDescrMov());
+						cancelar(cadastrante, lotaCadastrante, mob, movRestricaoAcessoParaPessoa, null, null, null, "Restrição: " + movRestricaoAcessoParaPessoa.getDescrMov());
 					} catch (Exception e) {
-						throw new RuntimeException("Erro ao excluir a Restrição de Acesso para o Cossignatário. ", e);
+						throw new RuntimeException(String.format("Erro ao excluir a Restrição de Acesso para %s. ", pessoa.getSigla() + "-" + pessoa.getNomePessoa()) , e);
 					}
 				});
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -4689,7 +4689,7 @@ public class ExBL extends CpBL {
 			if (!movs.isEmpty())
 				removerPendenciaDeDevolucao(movs, mob);
 				
-			if (podeRestringir) {
+			if (podeRestringir) {// precisa rever se trata em caso que será juntado em documento sem restricao
 				this.copiarRestringir(mob, mobPai, cadastrante, titular, dtMov);
 			}
 			
@@ -4704,28 +4704,29 @@ public class ExBL extends CpBL {
 	
 	public void copiarRestringir(ExMobil mobFilho, ExMobil mobPai, DpPessoa cadastrante, DpPessoa titular, Date dtMov)
 			throws AplicacaoException, SQLException {
+		
 		List<ExMovimentacao> listFilho = new ArrayList<ExMovimentacao>();
-		listFilho.addAll(mobFilho.getDoc().getMobilGeral()
-				.getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
+		listFilho.addAll(mobFilho.getDoc().getMobilGeral().getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
+		
 		List<ExMovimentacao> listPai = new ArrayList<ExMovimentacao>();
-		listPai.addAll(mobPai.getDoc().getMobilGeral()
-				.getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
+		listPai.addAll(mobPai.getDoc().getMobilGeral().getMovsNaoCanceladas(ExTipoDeMovimentacao.RESTRINGIR_ACESSO));
+		
+		ExNivelAcesso exTipoSig = mobPai.getDoc().getExNivelAcesso();
+		
 		if (!listFilho.isEmpty() || !listPai.isEmpty()) {
 
-			if (listPai.isEmpty()) {
-				ExNivelAcesso exTipoSig = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_LOTACOES, ExNivelAcesso.class,
-						false);
+			if (mobPai.getDoc().getMobilGeral().isAcessoRestrito()) {
 				desfazerRestringirAcesso(cadastrante, cadastrante.getLotacao(), mobFilho.getDoc(), null, exTipoSig);
 			} else {
-				ExNivelAcesso exTipoSig = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_PESSOAS, ExNivelAcesso.class,
-						false);
 				if (!listFilho.isEmpty()) {
 					for (ExMovimentacao exMov : listFilho) {
+						// remover cancelamento
 						final ExMovimentacao mov1 = criarNovaMovimentacao(
 								ExTipoDeMovimentacao.CANCELAMENTO_DE_MOVIMENTACAO, cadastrante,
 								cadastrante.getLotacao(), mobFilho.getDoc().getMobilGeral(), dtMov,
 								exMov.getSubscritor(), null, null, null, dtMov);
 
+						// add do pai se nao tiver no filho
 						mov1.setDescrMov("Nível de acesso do documento alterado de "
 								+ mobFilho.getDoc().getMobilGeral().getDoc().getExNivelAcessoAtual().getNmNivelAcesso()
 								+ " para " + exTipoSig.getNmNivelAcesso() + ". Restrição de acesso retirada para "

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -2721,9 +2721,6 @@ public class ExBL extends CpBL {
 
 			mov.setDescrMov(textoMotivo);
 
-			if (mov.getExNivelAcesso() == null)
-				mov.setExNivelAcesso(ultMov.getExNivelAcesso());
-
 			if (!mob.sofreuMov(ExTipoDeMovimentacao.JUNTADA_EXTERNO,
 					ExTipoDeMovimentacao.CANCELAMENTO_JUNTADA)) {
 				mov.setExMovimentacaoRef(
@@ -2930,14 +2927,12 @@ public class ExBL extends CpBL {
 				gravarMovimentacao(mov);
 
 				mov.setExMovimentacaoRef(ultMovNaoCancelada);
-				if (ultMovNaoCancelada.getExTipoMovimentacao()
-						 == ExTipoDeMovimentacao.REDEFINICAO_NIVEL_ACESSO) {
-					if (penultMovNaoCancelada != null)
-						mov.setExNivelAcesso(penultMovNaoCancelada.getExNivelAcesso());
+				if ( (ultMovNaoCancelada.getExTipoMovimentacao() == ExTipoDeMovimentacao.REDEFINICAO_NIVEL_ACESSO) 
+						|| (ultMovNaoCancelada.getExTipoMovimentacao() == ExTipoDeMovimentacao.RESTRINGIR_ACESSO) ) {
+					if (m.getUltimaMovimentacaoAlteracaoNivelAcessoNaoCancelada() != null)
+						mov.setExNivelAcesso(m.getUltimaMovimentacaoAlteracaoNivelAcessoNaoCancelada().getExNivelAcesso());
 					else
 						mov.setExNivelAcesso(m.doc().getExNivelAcesso());
-				} else {
-					mov.setExNivelAcesso(ultMovNaoCancelada.getExNivelAcesso());
 				}
 
 				if (ultMovNaoCancelada.getExTipoMovimentacao()
@@ -5885,6 +5880,9 @@ public class ExBL extends CpBL {
 		}
 
 		try {
+			//Não previsto no requisito, mas
+			//Deveria ter uma verificação aqui se o documento tem restrição de acesso para desfazer a restrição se for diferente de Limitado entre Pessoas 
+			// ou impedir a redefinição
 			iniciarAlteracao();
 
 			final ExMovimentacao mov = criarNovaMovimentacao(
@@ -6405,11 +6403,10 @@ public class ExBL extends CpBL {
 		mov.setExTipoMovimentacao(tpmov);
 
 		final ExMovimentacao ultMov = mob.getUltimaMovimentacao();
+		
 		if (ultMov != null) {
 			// if (mov.getExMobilPai() == null)
 			// mov.setExMobilPai(ultMov.getExMobilPai());
-			if (mov.getExNivelAcesso() == null)
-				mov.setExNivelAcesso(ultMov.getExNivelAcesso());
 			if (mov.getExClassificacao() == null)
 				mov.setExClassificacao(ultMov.getExClassificacao());
 			if (mov.getLotaResp() == null)
@@ -6620,8 +6617,6 @@ public class ExBL extends CpBL {
 		if (ultMov != null) {
 			// if (mov.getExMobilPai() == null)
 			// mov.setExMobilPai(ultMov.getExMobilPai());
-			if (mov.getExNivelAcesso() == null)
-				mov.setExNivelAcesso(ultMov.getExNivelAcesso());
 			if (mov.getExClassificacao() == null)
 				mov.setExClassificacao(ultMov.getExClassificacao());
 			if (mov.getLotaResp() == null)

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExEComposto.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExEComposto.java
@@ -1,0 +1,25 @@
+package br.gov.jfrj.siga.ex.logic;
+
+import com.crivano.jlogic.Expression;
+import com.crivano.jlogic.JLogic;
+
+import br.gov.jfrj.siga.ex.ExDocumento;
+
+public class ExEComposto implements Expression {
+	ExDocumento doc;
+
+	public ExEComposto(ExDocumento doc) {
+		this.doc = doc;
+	}
+
+	@Override
+	public boolean eval() {
+		return doc.isComposto();
+	}
+
+	@Override
+	public String explain(boolean result) {
+		return JLogic.explain("é composto", result);
+	}
+
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarRestringirAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeCancelarRestringirAcesso.java
@@ -1,0 +1,72 @@
+package br.gov.jfrj.siga.ex.logic;
+
+import com.crivano.jlogic.And;
+import com.crivano.jlogic.CompositeExpressionSupport;
+import com.crivano.jlogic.Expression;
+import com.crivano.jlogic.Not;
+import com.crivano.jlogic.Or;
+
+import br.gov.jfrj.siga.dp.DpLotacao;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import br.gov.jfrj.siga.ex.ExDocumento;
+import br.gov.jfrj.siga.ex.ExMobil;
+import br.gov.jfrj.siga.ex.ExMovimentacao;
+import br.gov.jfrj.siga.ex.model.enm.ExTipoDeConfiguracao;
+import br.gov.jfrj.siga.ex.model.enm.ExTipoDeMovimentacao;
+
+public class ExPodeCancelarRestringirAcesso extends CompositeExpressionSupport {
+
+	private ExMobil mob;
+	private ExDocumento doc;
+	private DpPessoa titular;
+	private DpLotacao lotaTitular;
+	private ExMovimentacao mov;
+
+	/**
+	 * Retorna se é possível cancelar uma movimentação de vinculação de perfil,
+	 * passada através do parâmetro mov. As regras são as seguintes:
+	 * <ul>
+	 * <li>Vinculação de perfil não pode estar cancelada</li>
+	 * <li>Lotação do usuário tem de ser a lotação cadastrante da movimentação</li>
+	 * <li>Não pode haver configuração impeditiva. Tipo de configuração: Cancelar
+	 * Movimentação</li>
+	 * </ul>
+	 * 
+	 * @param titular
+	 * @param lotaTitular
+	 * @param mob
+	 * @param mov
+	 * @return
+	 * @throws Exception
+	 */
+	public ExPodeCancelarRestringirAcesso(ExMovimentacao mov, DpPessoa titular, DpLotacao lotaTitular) {
+		this.mov = mov;
+		this.mob = mov.getExMobil();
+		this.doc = mob.doc();
+		this.titular = titular;
+		this.lotaTitular = lotaTitular;
+	}
+
+	@Override
+	protected Expression create() {
+		return And.of(
+				Not.of(new ExMovimentacaoEstaCancelada(mov)),
+				
+				new ExPodePorConfiguracao(titular, lotaTitular)
+						.withIdTpConf(ExTipoDeConfiguracao.CANCELAR_MOVIMENTACAO)
+						.withExTpMov(ExTipoDeMovimentacao.RESTRINGIR_ACESSO),
+				
+				Or.of(
+						And.of(
+								Not.of(new ExEstaFinalizado(doc)),
+								
+								new ExECadastrante(doc, lotaTitular)),
+						
+						new ExPodeMovimentar(mob.getDoc().getMobilDefaultParaReceberJuntada(), titular, lotaTitular)),			
+				
+				Not.of(new ExEstaEmTransito(mob, titular, lotaTitular)));
+
+
+
+	}
+}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
@@ -24,19 +24,12 @@ public class ExPodeRestringirAcesso extends CompositeExpressionSupport {
 	private ExDocumento doc;
 	private DpPessoa titular;
 	private DpLotacao lotaTitular;
-	private List<ExMovimentacao> listMovJuntada;
 
 	public ExPodeRestringirAcesso(ExMobil mob, DpPessoa titular, DpLotacao lotaTitular) {
 		this.mob = mob;
 		this.doc = mob.doc();
 		this.titular = titular;
 		this.lotaTitular = lotaTitular;
-
-		listMovJuntada = new ArrayList<ExMovimentacao>();
-		if (mob.getDoc().getMobilDefaultParaReceberJuntada() != null) {
-			listMovJuntada.addAll(mob.getDoc().getMobilDefaultParaReceberJuntada()
-					.getMovsNaoCanceladas(ExTipoDeMovimentacao.JUNTADA));
-		}
 	}
 
 	@Override
@@ -62,8 +55,8 @@ public class ExPodeRestringirAcesso extends CompositeExpressionSupport {
 						Not.of(new ExPodePorConfiguracao(titular, lotaTitular).withExMod(mob.doc().getExModelo())
 								.withIdTpConf(ExTipoDeConfiguracao.INCLUIR_DOCUMENTO)),
 
-						Not.of(new ExTemMobilPai(mob.doc()))),
-
-				new CpIgual(listMovJuntada.size(), "juntadas", 0, "zero"));
+						Not.of(new ExTemMobilPai(mob.doc()))), 
+				
+				Not.of(new ExTemJuntados(mob))); // ExTemJuntada
 	}
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
@@ -43,10 +43,19 @@ public class ExPodeRestringirAcesso extends CompositeExpressionSupport {
 	protected Expression create() {
 		return And.of(
 
-				new ExPodePorConfiguracao(titular, lotaTitular).withIdTpConf(ExTipoDeConfiguracao.MOVIMENTAR)
+				new ExPodePorConfiguracao(titular, lotaTitular)
+						.withIdTpConf(ExTipoDeConfiguracao.MOVIMENTAR)
 						.withExTpMov(ExTipoDeMovimentacao.RESTRINGIR_ACESSO),
+				
+				Or.of(
+						And.of(
+								Not.of(new ExEstaFinalizado(doc)),
+								
+								new ExECadastrante(doc, lotaTitular)),
 						
-				new ExPodeMovimentar(mob, titular, lotaTitular),
+						new ExPodeMovimentar(mob.getDoc().getMobilDefaultParaReceberJuntada(), titular, lotaTitular)),			
+				
+				Not.of(new ExEstaEmTransito(mob, titular, lotaTitular)),
 
 				Or.of(
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/logic/ExPodeRestringirAcesso.java
@@ -45,6 +45,8 @@ public class ExPodeRestringirAcesso extends CompositeExpressionSupport {
 
 				new ExPodePorConfiguracao(titular, lotaTitular).withIdTpConf(ExTipoDeConfiguracao.MOVIMENTAR)
 						.withExTpMov(ExTipoDeMovimentacao.RESTRINGIR_ACESSO),
+						
+				new ExPodeMovimentar(mob, titular, lotaTitular),
 
 				Or.of(
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMovimentacaoVO.java
@@ -393,7 +393,7 @@ public class ExMovimentacaoVO extends ExVO {
 								.pode(ExPodeDisponibilizarNoAcompanhamentoDoProtocolo.class, titular, lotaTitular, mov.getExDocumento())) {
 						addAcao(AcaoVO.builder().nome("Disponibilizar no Acompanhamento do Protocolo").nameSpace("/app/expediente/mov").acao("exibir_no_acompanhamento_do_protocolo")
 								.params("sigla",mov.getExMobil().getSigla())
-								.exp(new CpPodeSempre()).msgConfirmacao("Ao clicar em OK o conteúdo deste documento ficará disponível através do número do "
+								.exp(new CpPodeSempre()).msgConfirmacao(mov.getExMobil().isAcessoRestrito() ? "Atenção: Documento com Restrição de Acesso. \\n" : "" + "YYYYAo clicar em OK o conteúdo deste documento ficará disponível através do número do "
 										+ "protocolo de acompanhamento. Deseja continuar?").build());
 					}
 				}

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
@@ -17,6 +17,15 @@
 			<div class="modal-body">${sigaModalAlerta.mensagem}</div>
 		</siga:siga-modal>	
 	</c:when>
+	<c:when test="${not empty sigaModalConfirmacao}">
+		<siga:siga-modal id="sigaModalConfirmacao" centralizar="${sigaModalConfirmacao.centralizar}" abrirAoCarregarPagina="true" exibirRodape="true"  
+			tituloADireita="${empty sigaModalConfirmacao.titulo ? 'Confirmação' : sigaModalConfirmacao.titulo}" 
+			descricaoBotaoFechaModalDoRodape="Não" descricaoBotaoDeAcao="Sim" 
+			linkBotaoDeAcao="${sigaModalConfirmacao.linkBotaoDeAcao}"
+			inverterOrdemBotoes="${sigaModalConfirmacao.inverterBotoes}" classBotaoDeAcao="${sigaModalConfirmacao.classBotaoDeAcao}" classBotaoDeFechar="${sigaModalConfirmacao.classBotaoDeFechar}" >
+				<div class="modal-body">${sigaModalConfirmacao.mensagem}</div>     	
+		</siga:siga-modal>	
+	</c:when>		
 	<c:otherwise>
 		<siga:siga-modal id="sigaModalAlerta" exibirRodape="true" tituloADireita="Alerta">
 			<div class="modal-body">Mensagem de alerta</div>

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
@@ -20,7 +20,7 @@
 	<c:when test="${not empty sigaModalConfirmacao}">
 		<siga:siga-modal id="sigaModalConfirmacao" centralizar="${sigaModalConfirmacao.centralizar}" abrirAoCarregarPagina="true" exibirRodape="true"  
 			tituloADireita="${empty sigaModalConfirmacao.titulo ? 'Confirmação' : sigaModalConfirmacao.titulo}" 
-			descricaoBotaoFechaModalDoRodape="Não" descricaoBotaoDeAcao="Sim" 
+			descricaoBotaoFechaModalDoRodape="${sigaModalConfirmacao.descricaoBotaoFechaModalDoRodape}" descricaoBotaoDeAcao="${sigaModalConfirmacao.descricaoBotaoDeAcao}" 
 			linkBotaoDeAcao="${sigaModalConfirmacao.linkBotaoDeAcao}"
 			inverterOrdemBotoes="${sigaModalConfirmacao.inverterBotoes}" classBotaoDeAcao="${sigaModalConfirmacao.classBotaoDeAcao}" classBotaoDeFechar="${sigaModalConfirmacao.classBotaoDeFechar}" >
 				<div class="modal-body">${sigaModalConfirmacao.mensagem}</div>     	

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/siga-modal.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/siga-modal.tag
@@ -26,11 +26,11 @@
 	description="Texto para o botão de ação, caso não informado, será exibido por padrão o texto 'Ok' Somente será exibido se modal tiver para exibir o rodapé 
 		padrão e também tiver sido adicionado um link através do atributo 'linkBotaoDeAcao'"%>				
 <%@ attribute name="classBotaoDeAcao"
-	description=""%>
+	description="Classe bootstrap para botão de ação da confirmação."%>
 <%@ attribute name="classBotaoDeFechar" 
-	description=""%>	
+	description="Classe bootstrap para botão de Fechar/Cancelar a operação."%>	
 <%@ attribute name="inverterOrdemBotoes"
-	description=""%>					
+	description="Inverter a ordem de apresentação dos botões. Default: Fechar/Confirmar Invertido: Confirmar/Fechar."%>					
 
 <div class="modal  fade" id="${id}" tabindex="-1" role="dialog">
  	<div class="modal-dialog${centralizar ? '  modal-dialog-centered' : ''}${tamanhoGrande ? '  modal-lg' : ''}" role="document">
@@ -58,7 +58,6 @@
       		<jsp:doBody />      		   				     
      		<c:if test="${exibirRodape}">
 	     		<div class="modal-footer">	
-	     			
 	     			<div class="${inverterOrdemBotoes ? 'order-last pl-2' : ''}">      	
 			        	<button type="button" class="btn ${empty classBotaoDeFechar ? 'btn-secondary' : classBotaoDeFechar} siga-modal__btn-fechar-rodape" data-dismiss="modal">${empty descricaoBotaoFechaModalDoRodape ? 'Fechar' : descricaoBotaoFechaModalDoRodape}</button>
 			        </div>	

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/siga-modal.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/siga-modal.tag
@@ -24,7 +24,13 @@
 		do botão será 'Ok', caso deseje uma descrição diferente, basta informar através do atributo 'descricaoBotaoDeAcao'"%>
 <%@ attribute name="descricaoBotaoDeAcao"
 	description="Texto para o botão de ação, caso não informado, será exibido por padrão o texto 'Ok' Somente será exibido se modal tiver para exibir o rodapé 
-		padrão e também tiver sido adicionado um link através do atributo 'linkBotaoDeAcao'"%>							
+		padrão e também tiver sido adicionado um link através do atributo 'linkBotaoDeAcao'"%>				
+<%@ attribute name="classBotaoDeAcao"
+	description=""%>
+<%@ attribute name="classBotaoDeFechar" 
+	description=""%>	
+<%@ attribute name="inverterOrdemBotoes"
+	description=""%>					
 
 <div class="modal  fade" id="${id}" tabindex="-1" role="dialog">
  	<div class="modal-dialog${centralizar ? '  modal-dialog-centered' : ''}${tamanhoGrande ? '  modal-lg' : ''}" role="document">
@@ -51,12 +57,17 @@
       		</div>
       		<jsp:doBody />      		   				     
      		<c:if test="${exibirRodape}">
-	     		<div class="modal-footer">			      	
-			        <button type="button" class="btn btn-secondary  siga-modal__btn-fechar-rodape" data-dismiss="modal">${empty descricaoBotaoFechaModalDoRodape ? 'Fechar' : descricaoBotaoFechaModalDoRodape}</button>
-			        <c:if test="${not empty linkBotaoDeAcao}">		        
-			        	<a href="${linkBotaoDeAcao}" class="btn btn-primary  siga-modal__btn-acao" role="button" aria-pressed="true">
-			        		${empty descricaoBotaoDeAcao ? 'Ok' : descricaoBotaoDeAcao}
-			        	</a>
+	     		<div class="modal-footer">	
+	     			
+	     			<div class="${inverterOrdemBotoes ? 'order-last pl-2' : ''}">      	
+			        	<button type="button" class="btn ${empty classBotaoDeFechar ? 'btn-secondary' : classBotaoDeFechar} siga-modal__btn-fechar-rodape" data-dismiss="modal">${empty descricaoBotaoFechaModalDoRodape ? 'Fechar' : descricaoBotaoFechaModalDoRodape}</button>
+			        </div>	
+			        <c:if test="${not empty linkBotaoDeAcao}">	
+			        	<div>	        
+				        	<a href="${linkBotaoDeAcao}" class="btn ${empty classBotaoDeAcao ? 'btn-primary' : classBotaoDeAcao} siga-modal__btn-acao" role="button" aria-pressed="true">
+				        		${empty descricaoBotaoDeAcao ? 'Ok' : descricaoBotaoDeAcao}
+				        	</a>
+				        </div>
 			        </c:if>				        
 		      </div>
 			</c:if>      

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/edita.jsp
@@ -99,7 +99,7 @@
     
     function cancelar() {
     	document.getElementById("btnOk").disabled = false;
-        sigaModal.fechar('confirmacaoModal');
+        sigaModal.fechar('confirmacaoAlteracaoModal');
     }
 	
 	

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/DocumentosPost.java
@@ -371,7 +371,7 @@ public class DocumentosPost implements IDocumentosPost {
 
 		if (doc.getExMobilPai() != null && Ex.getInstance().getComp().pode(ExPodeRestringirAcesso.class, cadastrante,
 				cadastrante.getLotacao(), doc.getExMobilPai())) {
-			exBL.copiarRestringir(doc.getMobilGeral(), doc.getExMobilPai().getDoc().getMobilGeral(), cadastrante,
+			exBL.herdaRestricaoAcessoDocumentoPai(doc.getMobilGeral(), doc.getExMobilPai().getDoc().getMobilGeral(), cadastrante,
 					ctx.getTitular(), doc.getData());
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -1689,9 +1689,15 @@ public class ExDocumentoController extends ExController {
 			}
 			
 			if(exDocumentoDTO.getDoc().getMobilGeral().isAcessoRestrito()) {
-				if (!exDocumentoDTO.getDoc().getMobilGeral()
-						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
-						.contains(subscritor)) {
+				boolean pessoaEstaRestricaoAcesso = false;
+				//Verifica se Subscritor está na lista de restrição
+				for (DpPessoa pessoaRestrita : exDocumentoDTO.getDoc().getMobilGeral().getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)) {
+					pessoaEstaRestricaoAcesso = pessoaRestrita.equivale(subscritor);
+					if (pessoaEstaRestricaoAcesso) 
+						break;
+				}
+				
+				if (!pessoaEstaRestricaoAcesso) {
 					if (adicionarRestricaoAcessoAntes) {
 						Ex.getInstance()
 							.getBL()

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -1691,7 +1691,7 @@ public class ExDocumentoController extends ExController {
 			if(exDocumentoDTO.getDoc().getMobilGeral().isAcessoRestrito()) {
 				boolean pessoaEstaRestricaoAcesso = false;
 				//Verifica se Subscritor está na lista de restrição
-				for (DpPessoa pessoaRestrita : exDocumentoDTO.getDoc().getMobilGeral().getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)) {
+				for (DpPessoa pessoaRestrita : exDocumentoDTO.getDoc().getMobilGeral().getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)) {
 					pessoaEstaRestricaoAcesso = pessoaRestrita.equivale(subscritor);
 					if (pessoaEstaRestricaoAcesso) 
 						break;

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -1927,7 +1927,7 @@ public class ExDocumentoController extends ExController {
 			}
 			
 			if(exDocumentoDTO.getDoc().getExMobilPai() != null && Ex.getInstance().getComp().pode(ExPodeRestringirAcesso.class, getCadastrante(), getLotaCadastrante(), exDocumentoDTO.getDoc().getExMobilPai())) {
-				exBL.copiarRestringir(exDocumentoDTO.getDoc().getMobilGeral(), exDocumentoDTO.getDoc().getExMobilPai().getDoc().getMobilGeral(), getCadastrante(), getTitular(), exDocumentoDTO.getDoc().getData());
+				exBL.herdaRestricaoAcessoDocumentoPai(exDocumentoDTO.getDoc().getMobilGeral(), exDocumentoDTO.getDoc().getExMobilPai().getDoc().getMobilGeral(), getCadastrante(), getTitular(), exDocumentoDTO.getDoc().getData());
 			}
 
 			if (!exDocumentoDTO.getDoc().isFinalizado()

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -1646,7 +1646,8 @@ public class ExDocumentoController extends ExController {
 	@Post("/app/expediente/doc/gravar")
 	public void gravar(final ExDocumentoDTO exDocumentoDTO,
 			final String[] vars, final String[] campos,
-			final UploadedFile arquivo, final String tokenArquivo) {
+			final UploadedFile arquivo, final String tokenArquivo, 
+			final boolean adicionarRestricaoAcessoAntes) {
 		
 		final Ex ex = Ex.getInstance();
 		final ExBL exBL = ex.getBL();	
@@ -1685,6 +1686,36 @@ public class ExDocumentoController extends ExController {
 						null, null, null, null);
 
 				return;
+			}
+			
+			if(exDocumentoDTO.getDoc().getMobilGeral().isAcessoRestrito()) {
+				if (!exDocumentoDTO.getDoc().getMobilGeral()
+						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
+						.contains(subscritor)) {
+					if (adicionarRestricaoAcessoAntes) {
+						Ex.getInstance()
+							.getBL()
+							.restringirAcessoAntes(exDocumentoDTO.getDoc(),subscritor,getCadastrante(),getLotaCadastrante());	
+					} else {
+						result.include(SigaModal.CONFIRMACAO, 
+								SigaModal
+									.mensagem("Documento Restrito. Usuário não está na lista de restrição de acesso. Deseja incluir?")
+									.titulo("Confirmação")
+									.inverterBotoes()
+									.classBotaoDeAcao("btn-success")
+									.classBotaoDeFechar("btn-danger")
+									.linkBotaoDeAcao("javascript:incluirRestricao(true);"));
+						result.forwardTo(this).edita(exDocumentoDTO, null, vars,
+								exDocumentoDTO.getMobilPaiSel(),
+								exDocumentoDTO.isCriandoAnexo(),
+								exDocumentoDTO.getAutuando(),
+								exDocumentoDTO.getIdMobilAutuado(),
+								exDocumentoDTO.getCriandoSubprocesso(),
+								null, null, null, null);
+
+						return;
+					}
+				}
 			}
 
 			long tempoIni = System.currentTimeMillis();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -1487,7 +1487,9 @@ public class ExMovimentacaoController extends ExController {
 					.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 					.contains(cosignatarioSel.getObjeto())) {
 				if (adicionarRestricaoAcessoAntes) {
-					restringirAcessoAntes(doc,cosignatarioSel.getObjeto());	
+					Ex.getInstance()
+						.getBL()
+						.restringirAcessoAntes(doc,cosignatarioSel.getObjeto(),getCadastrante(),getLotaCadastrante());	
 				} else {
 					gerarModalConfirmacaoInclusaoRestricaoAcesso();
 					result.forwardTo(this).incluirCosignatario(sigla,cosignatarioSel);
@@ -2074,7 +2076,9 @@ public class ExMovimentacaoController extends ExController {
 						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 						.contains(responsavelSel.getObjeto())) {
 					if (adicionarRestricaoAcessoAntes) {
-						restringirAcessoAntes(builder.getMob().getDoc(),responsavelSel.getObjeto());	
+						Ex.getInstance()
+							.getBL()
+							.restringirAcessoAntes(builder.getMob().getDoc(),responsavelSel.getObjeto(),getCadastrante(),getLotaCadastrante());	
 					} else {
 						gerarModalConfirmacaoInclusaoRestricaoAcesso();
 			    		forwardToTransferir(sigla, tipoResponsavel, lotaResponsavelSel, responsavelSel, grupoSel, postback, dtMovString,
@@ -2238,26 +2242,6 @@ public class ExMovimentacaoController extends ExController {
 			result.include("origemRedirectTransferirGravar", true);
 			ExDocumentoController.redirecionarParaExibir(result, builder.getMob().getSigla()); 
 		}
-	}
-	
-	private void restringirAcessoAntes(final ExDocumento documento , final DpPessoa pessoaASerAdicionada) {
-		Ex.getInstance().getComp().afirmar("Não é possível restringir acesso", ExPodeRestringirAcesso.class, getCadastrante(), getLotaCadastrante(), documento.getMobilGeral());
-		
-		final ExMovimentacaoBuilder movimentacaoBuilder = ExMovimentacaoBuilder.novaInstancia();
-		final ExMovimentacao mov = movimentacaoBuilder.construir(dao());	
-		
-		List<DpPessoa> listaPessoasRestricaoAcesso = new ArrayList<DpPessoa>();
-		listaPessoasRestricaoAcesso.add(pessoaASerAdicionada);
-		
-		ExNivelAcesso nivelAcesso = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_PESSOAS, ExNivelAcesso.class, false);
-		
-		
-		Ex.getInstance()
-				.getBL()
-				.restringirAcesso(getCadastrante(), getLotaTitular(), documento,
-						null, mov.getLotaResp(), mov.getResp(),
-						listaPessoasRestricaoAcesso, getTitular(),
-						mov.getNmFuncaoSubscritor(), nivelAcesso);
 	}
 
 	private void forwardToTransferir(final String sigla, final int tipoResponsavel,
@@ -2666,7 +2650,9 @@ public class ExMovimentacaoController extends ExController {
 						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 						.contains(responsavelSel.getObjeto())) {
 					if (adicionarRestricaoAcessoAntes) {
-						restringirAcessoAntes(builder.getMob().getDoc(),responsavelSel.getObjeto());	
+						Ex.getInstance()
+							.getBL()
+							.restringirAcessoAntes(builder.getMob().getDoc(),responsavelSel.getObjeto(),getCadastrante(),getLotaCadastrante());	
 					} else {
 						gerarModalConfirmacaoInclusaoRestricaoAcesso();
 						result.forwardTo(this).aVincularPapel(sigla, responsavelSel, lotaResponsavelSel, tipoResponsavel, idPapel);

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -928,7 +928,7 @@ public class ExMovimentacaoController extends ExController {
 
 		result.include("msgCabecClass", "alert-warning");
 		result.include("mensagemCabec", "Somente os usuários definidos, terão acesso aos documentos. Os usuários que já tiveram acesso ao documento, por tramitações anteriores ou por definição de acompanhamento deixam de ter acesso/visualização ao documento. Inclusive o cadastrante dos documentos, responsáveis pela assinatura e cossignatário");
-		result.forwardTo(ExDocumentoController.class).exibe(false, sigla, null, null, null, false, null);
+		ExDocumentoController.redirecionarParaExibir(result, sigla);
 	}
 
 	@Transacional
@@ -2022,6 +2022,7 @@ public class ExMovimentacaoController extends ExController {
 			
 			return;
 		}
+		
 
 		if(dtDevolucaoMovString != null && !"".equals(dtDevolucaoMovString.trim())) {
 			SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -930,7 +930,7 @@ public class ExMovimentacaoController extends ExController {
 					.getBL()
 					.restringirAcesso(getCadastrante(), getLotaTitular(), doc,
 							null, mov.getLotaResp(), mov.getResp(),
-							listaPessoasRestricaoAcesso, mov.getTitular(),
+							listaPessoasRestricaoAcesso, getTitular(),
 							mov.getNmFuncaoSubscritor(), exTipoSig);
 			
 			removerIndicativoDeMovimentacaoComOrigemPeloBotaoDeRestricaoDeAcesso();
@@ -2256,7 +2256,7 @@ public class ExMovimentacaoController extends ExController {
 				.getBL()
 				.restringirAcesso(getCadastrante(), getLotaTitular(), documento,
 						null, mov.getLotaResp(), mov.getResp(),
-						listaPessoasRestricaoAcesso, mov.getTitular(),
+						listaPessoasRestricaoAcesso, getTitular(),
 						mov.getNmFuncaoSubscritor(), nivelAcesso);
 	}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -1486,7 +1486,7 @@ public class ExMovimentacaoController extends ExController {
 		
 		if(doc.getMobilGeral().isAcessoRestrito()) {
 			if (!doc.getMobilGeral()
-					.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
+					.getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 					.contains(cosignatarioSel.getObjeto())) {
 				if (adicionarRestricaoAcessoAntes) {
 					Ex.getInstance()
@@ -2075,7 +2075,7 @@ public class ExMovimentacaoController extends ExController {
 				return;
 			} else if (tipoResponsavel == 2 ) {
 				if (!builder.getMob().getDoc().getMobilGeral()
-						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
+						.getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 						.contains(responsavelSel.getObjeto())) {
 					if (adicionarRestricaoAcessoAntes) {
 						Ex.getInstance()
@@ -2649,7 +2649,7 @@ public class ExMovimentacaoController extends ExController {
 				
 			} else if (tipoResponsavel == 1 ) {
 				if (!builder.getMob().getDoc().getMobilGeral()
-						.getSubscitoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
+						.getSubscritoresMovimentacoesPorTipo(ExTipoDeMovimentacao.RESTRINGIR_ACESSO, true)
 						.contains(responsavelSel.getObjeto())) {
 					if (adicionarRestricaoAcessoAntes) {
 						Ex.getInstance()

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -882,14 +882,11 @@ public class ExMovimentacaoController extends ExController {
 
 		final ExDocumento doc = buscarDocumento(builder);
 		
-		//Deveria ser o nível de acesso do documento, porém resetado para Limitado entre Lotações conforme Requisito Solicitado
-		ExNivelAcesso exTipoSig = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_LOTACOES, ExNivelAcesso.class, false);
-
 		Ex.getInstance().getComp().afirmar("Não é possível desfazer restrição de acesso", ExPodeDesfazerRestricaoDeAcesso.class, getCadastrante(), getLotaCadastrante(), builder.getMob());
 		
 		Ex.getInstance()
 			.getBL()
-			.desfazerRestringirAcesso(getCadastrante(), getLotaCadastrante(), doc, null,  exTipoSig);
+			.desfazerRestringirAcesso(getCadastrante(), getLotaCadastrante(), doc, null);
 		
 		ExDocumentoController.redirecionarParaExibir(result, sigla);
 	}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -881,7 +881,8 @@ public class ExMovimentacaoController extends ExController {
 				.novaInstancia().setSigla(sigla);
 
 		final ExDocumento doc = buscarDocumento(builder);
-	
+		
+		//Deveria ser o nível de acesso do documento, porém resetado para Limitado entre Lotações conforme Requisito Solicitado
 		ExNivelAcesso exTipoSig = dao().consultar(ExNivelAcesso.ID_LIMITADO_ENTRE_LOTACOES, ExNivelAcesso.class, false);
 
 		Ex.getInstance().getComp().afirmar("Não é possível desfazer restrição de acesso", ExPodeDesfazerRestricaoDeAcesso.class, getCadastrante(), getLotaCadastrante(), builder.getMob());

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/edita.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/edita.jsp
@@ -87,6 +87,7 @@
 						name="cliente" id="cliente" value="${siga_cliente}"> <input
 						type="hidden" id="visualizador"
 						value="${f:resource('/sigaex.pdf.visualizador') }" />
+						<input type="hidden" id="adicionarRestricaoAcessoAntes" name="adicionarRestricaoAcessoAntes" value="false"/>
 					<c:choose>
 						<c:when
 							test="${(exDocumentoDTO.doc.eletronico) && (exDocumentoDTO.doc.numExpediente != null)}">
@@ -972,6 +973,17 @@
 		placement : 'bottom',
 		trigger : 'click'
 	});
+	
+	function incluirRestricao(adicionarRestricaoAcessoAntes) {
+		sigaSpinner.mostrar();
+		
+		if (adicionarRestricaoAcessoAntes === true) {
+			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
+		}
+		sigaModal.fechar('sigaModalConfirmacao');
+		gravarDoc(); 
+	}
+
 </script>
 
 <script type="text/javascript"

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -73,11 +73,11 @@ function popitup_movimentacao() {
 	return false;
 }	
 
-function submeter(adicionarRestricaoAcessoAntesTramite) {
+function submeter(adicionarRestricaoAcessoAntes) {
 	sigaSpinner.mostrar();
 	
-	if (adicionarRestricaoAcessoAntesTramite === true) {
-		document.getElementById("adicionarRestricaoAcessoAntesTramite").value = true;
+	if (adicionarRestricaoAcessoAntes === true) {
+		document.getElementById("adicionarRestricaoAcessoAntes").value = true;
 	}
 	document.getElementById("button_ok").onclick = function(){console.log("Aguarde requisição")};	
 	document.getElementById('frm').submit();
@@ -103,7 +103,7 @@ $(function(){
 				<input type="hidden" name="mobilPaiSel.sigla" value="" id="transferir_gravar_pai" />
 				<input type="hidden" name="despachando" value="" id="transferir_gravar_despachando" />
 				<input type="hidden" name="tipoTramite" value="3"/>
-				<input type="hidden" id="adicionarRestricaoAcessoAntesTramite" name="adicionarRestricaoAcessoAntesTramite" value="false"/>
+				<input type="hidden" id="adicionarRestricaoAcessoAntes" name="adicionarRestricaoAcessoAntes" value="false"/>
 
 				<c:if test="${not doc.eletronico}">
 				<div class="row">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -16,76 +16,81 @@
 
 <script type="text/javascript" language="Javascript1.1">
 	
-function tamanho() {
-	var i = tamanho2();
-	if (i<0) {i=0};
-	$("#Qtd").html('Restam ' + i + ' Caracteres');
-}
-
-function tamanho2() {
-	nota= new String();
-	nota = this.frm.descrMov.value;
-	var i = 400 - nota.length;
-	return i;
-}
-function corrige() {
-	if (tamanho2()<0) {
-		alert('Descrição com mais de 400 caracteres');
-		nota = new String();
-		nota = document.getElementById("descrMov").value;
-		document.getElementById("descrMov").value = nota.substring(0,400);
-	}
-}
-
-function sbmt() {
-	document.getElementById('transferir_gravar_sigla').value= '${mob.sigla}';
-	document.getElementById('transferir_gravar_pai').value= '';
-	frm.action='transferir?sigla=VALOR_SIGLA&popup=true'
-			.replace('VALOR_SIGLA', document.getElementById('transferir_gravar_sigla').value);
-	frm.submit();
-}
-
-var newwindow = '';
-function popitup_movimentacao() {
-	if (!newwindow.closed && newwindow.location) {
-	} else {
-		var popW = 600;
-		var popH = 400;
-		var winleft = (screen.width - popW) / 2;
-		var winUp = (screen.height - popH) / 2;
-		winProp = 'width='+popW+',height='+popH+',left='+winleft+',top='+winUp+',scrollbars=yes,resizable'
-		newwindow=window.open('','${propriedade}',winProp);
-		newwindow.name='mov';
+	function tamanho() {
+		var i = tamanho2();
+		if (i<0) {i=0};
+		$("#Qtd").html('Restam ' + i + ' Caracteres');
 	}
 	
-	newwindow.opener = self;
-	t = frm.target; 
-	a = frm.action;
-	frm.target = newwindow.name;
-	frm.action='${pageContext.request.contextPath}/app/expediente/mov/prever?id=${mov.idMov}';
-	frm.submit();
-	frm.target = t; 
-	frm.action = a;
-	
-	if (window.focus) {
-		newwindow.focus()
+	function tamanho2() {
+		nota= new String();
+		nota = this.frm.descrMov.value;
+		var i = 400 - nota.length;
+		return i;
 	}
-	return false;
-}	
-
-function submeter(adicionarRestricaoAcessoAntes) {
-	sigaSpinner.mostrar();
-	
-	if (adicionarRestricaoAcessoAntes === true) {
-		document.getElementById("adicionarRestricaoAcessoAntes").value = true;
+	function corrige() {
+		if (tamanho2()<0) {
+			alert('Descrição com mais de 400 caracteres');
+			nota = new String();
+			nota = document.getElementById("descrMov").value;
+			document.getElementById("descrMov").value = nota.substring(0,400);
+		}
 	}
-	document.getElementById("button_ok").onclick = function(){console.log("Aguarde requisição")};	
-	document.getElementById('frm').submit();
-}
+	
+	function sbmt() {
+		document.getElementById('transferir_gravar_sigla').value= '${mob.sigla}';
+		document.getElementById('transferir_gravar_pai').value= '';
+		frm.action='transferir?sigla=VALOR_SIGLA&popup=true'
+				.replace('VALOR_SIGLA', document.getElementById('transferir_gravar_sigla').value);
+		frm.submit();
+	}
+	
+	var newwindow = '';
+	function popitup_movimentacao() {
+		if (!newwindow.closed && newwindow.location) {
+		} else {
+			var popW = 600;
+			var popH = 400;
+			var winleft = (screen.width - popW) / 2;
+			var winUp = (screen.height - popH) / 2;
+			winProp = 'width='+popW+',height='+popH+',left='+winleft+',top='+winUp+',scrollbars=yes,resizable'
+			newwindow=window.open('','${propriedade}',winProp);
+			newwindow.name='mov';
+		}
+		
+		newwindow.opener = self;
+		t = frm.target; 
+		a = frm.action;
+		frm.target = newwindow.name;
+		frm.action='${pageContext.request.contextPath}/app/expediente/mov/prever?id=${mov.idMov}';
+		frm.submit();
+		frm.target = t; 
+		frm.action = a;
+		
+		if (window.focus) {
+			newwindow.focus()
+		}
+		return false;
+	}	
+	
+	function submeter() {
+		sigaSpinner.mostrar();
+		document.getElementById("button_ok").onclick = function(){console.log("Aguarde requisição")};	
+		document.getElementById('frm').submit();
+	}
+	
+	$(function(){
+	    $("#formulario_lotaResponsavelSel_sigla").focus();
+	});
+	
+	
+	function incluirRestricao(adicionarRestricaoAcessoAntes) {
+		if (adicionarRestricaoAcessoAntes === true) {
+			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
+		}
+		submeter();
+	}
 
-$(function(){
-    $("#formulario_lotaResponsavelSel_sigla").focus();
-});
 
 </script>
 	<!-- main content -->

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -73,8 +73,12 @@ function popitup_movimentacao() {
 	return false;
 }	
 
-function submeter() {
+function submeter(adicionarRestricaoAcessoAntesTramite) {
 	sigaSpinner.mostrar();
+	
+	if (adicionarRestricaoAcessoAntesTramite === true) {
+		document.getElementById("adicionarRestricaoAcessoAntesTramite").value = true;
+	}
 	document.getElementById("button_ok").onclick = function(){console.log("Aguarde requisição")};	
 	document.getElementById('frm').submit();
 }
@@ -99,6 +103,7 @@ $(function(){
 				<input type="hidden" name="mobilPaiSel.sigla" value="" id="transferir_gravar_pai" />
 				<input type="hidden" name="despachando" value="" id="transferir_gravar_despachando" />
 				<input type="hidden" name="tipoTramite" value="3"/>
+				<input type="hidden" id="adicionarRestricaoAcessoAntesTramite" name="adicionarRestricaoAcessoAntesTramite" value="false"/>
 
 				<c:if test="${not doc.eletronico}">
 				<div class="row">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -88,6 +88,8 @@
 		if (adicionarRestricaoAcessoAntes === true) {
 			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
 		}
+		
+		sigaModal.fechar('sigaModalConfirmacao');
 		submeter();
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aVincularPapel.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aVincularPapel.jsp
@@ -96,7 +96,8 @@
 		if (adicionarRestricaoAcessoAntes === true) {
 			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
 		}
-
+		
+		sigaModal.fechar('sigaModalConfirmacao');
 		document.getElementById('frm').submit();
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aVincularPapel.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aVincularPapel.jsp
@@ -13,82 +13,92 @@
 </c:if>
 
 <script type="text/javascript" language="Javascript1.1">
-function sbmt() {
-	frm.action='${pageContext.request.contextPath}/app/expediente/mov/vincularPapel';
-	frm.submit();
-}
-
-function tamanho() {
-	var i = tamanho2();
-	if (i<0) {i=0};
-	document.getElementById("Qtd").innerText = 'Restam ' + i + ' Caracteres';
-}
-
-function tamanho2() {
-	nota= new String();
-	nota = this.frm.descrMov.value;
-	var i = 255 - nota.length;
-	return i;
-}
-function corrige() {
-	if (tamanho2()<0) {
-		alert('Descrição com mais de 255 caracteres');
-		nota = new String();
-		nota = document.getElementById("descrMov").value;
-		document.getElementById("descrMov").value = nota.substring(0,255);
-	}
-}
-
-var newwindow = '';
-function popitup_movimentacao() {
-	if (!newwindow.closed && newwindow.location) {
-	} else {
-		var popW = 600;
-		var popH = 400;
-		var winleft = (screen.width - popW) / 2;
-		var winUp = (screen.height - popH) / 2;
-		winProp = 'width='+popW+',height='+popH+',left='+winleft+',top='+winUp+',scrollbars=yes,resizable'
-		newwindow=window.open('','${propriedade}',winProp);
-		newwindow.name='mov';
+	function sbmt() {
+		frm.action='${pageContext.request.contextPath}/app/expediente/mov/vincularPapel';
+		frm.submit();
 	}
 	
-	newwindow.opener = self;
-	t = frm.target; 
-	a = frm.action;
-	frm.target = newwindow.name;
-	frm.action='${pageContext.request.contextPath}/app/expediente/mov/prever?id=${mov.idMov}';
-	frm.submit();
-	frm.target = t; 
-	frm.action = a;
-	
-	if (window.focus) {
-		newwindow.focus()
+	function tamanho() {
+		var i = tamanho2();
+		if (i<0) {i=0};
+		document.getElementById("Qtd").innerText = 'Restam ' + i + ' Caracteres';
 	}
-	return false;
-}	
-
-function alteraResponsavel()
-{
-	var objSelecionado = document.getElementById('tipoResponsavel');
 	
-	switch (parseInt(objSelecionado.value))
+	function tamanho2() {
+		nota= new String();
+		nota = this.frm.descrMov.value;
+		var i = 255 - nota.length;
+		return i;
+	}
+	function corrige() {
+		if (tamanho2()<0) {
+			alert('Descrição com mais de 255 caracteres');
+			nota = new String();
+			nota = document.getElementById("descrMov").value;
+			document.getElementById("descrMov").value = nota.substring(0,255);
+		}
+	}
+	
+	var newwindow = '';
+	function popitup_movimentacao() {
+		if (!newwindow.closed && newwindow.location) {
+		} else {
+			var popW = 600;
+			var popH = 400;
+			var winleft = (screen.width - popW) / 2;
+			var winUp = (screen.height - popH) / 2;
+			winProp = 'width='+popW+',height='+popH+',left='+winleft+',top='+winUp+',scrollbars=yes,resizable'
+			newwindow=window.open('','${propriedade}',winProp);
+			newwindow.name='mov';
+		}
+		
+		newwindow.opener = self;
+		t = frm.target; 
+		a = frm.action;
+		frm.target = newwindow.name;
+		frm.action='${pageContext.request.contextPath}/app/expediente/mov/prever?id=${mov.idMov}';
+		frm.submit();
+		frm.target = t; 
+		frm.action = a;
+		
+		if (window.focus) {
+			newwindow.focus()
+		}
+		return false;
+	}	
+	
+	function alteraResponsavel()
 	{
-		case 1:
-			document.getElementById('selecaoResponsavel').style.display = '';
-			document.getElementById('selecaoLotaResponsavel').style.display = 'none';
-			document.getElementById('formulario_lotaResponsavelSel_sigla').value = '';
-			document.getElementById('lotaResponsavelSelSpan').textContent = '';
-			document.getElementById('formulario_lotaResponsavelSel_id').value = '';	
-			break;
-		case 2:
-			document.getElementById('selecaoResponsavel').style.display = 'none';
-			document.getElementById('selecaoLotaResponsavel').style.display = '';
-			document.getElementById('formulario_responsavelSel_sigla').value = '';
-			document.getElementById('responsavelSelSpan').textContent = '';
-			document.getElementById('formulario_responsavelSel_id').value = '';
-			break;
+		var objSelecionado = document.getElementById('tipoResponsavel');
+		
+		switch (parseInt(objSelecionado.value))
+		{
+			case 1:
+				document.getElementById('selecaoResponsavel').style.display = '';
+				document.getElementById('selecaoLotaResponsavel').style.display = 'none';
+				document.getElementById('formulario_lotaResponsavelSel_sigla').value = '';
+				document.getElementById('lotaResponsavelSelSpan').textContent = '';
+				document.getElementById('formulario_lotaResponsavelSel_id').value = '';	
+				break;
+			case 2:
+				document.getElementById('selecaoResponsavel').style.display = 'none';
+				document.getElementById('selecaoLotaResponsavel').style.display = '';
+				document.getElementById('formulario_responsavelSel_sigla').value = '';
+				document.getElementById('responsavelSelSpan').textContent = '';
+				document.getElementById('formulario_responsavelSel_id').value = '';
+				break;
+		}
 	}
-}
+	
+	function incluirRestricao(adicionarRestricaoAcessoAntes) {
+		sigaSpinner.mostrar();
+		
+		if (adicionarRestricaoAcessoAntes === true) {
+			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
+		}
+
+		document.getElementById('frm').submit();
+	}
 
 </script>
 
@@ -102,9 +112,10 @@ function alteraResponsavel()
 				<h5><fmt:message key="documento.vinculacao"/></h5>
 			</div>
 			<div class="card-body">
-				<form name="frm" action="vincularPapel_gravar" method="post">
+				<form id="frm" name="frm" action="vincularPapel_gravar" method="post">
 					<input type="hidden" name="postback" value="1" />
 					<input type="hidden" name="sigla" value="${sigla}"/>
+					<input type="hidden" id="adicionarRestricaoAcessoAntes" name="adicionarRestricaoAcessoAntes" value="false"/>
 					<div class="row">
 						<c:if test="${siga_cliente != 'GOVSP'}">
 						<div class="col-md-2 col-sm-3">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
@@ -6,7 +6,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
 <script type="text/javascript" language="Javascript1.1">
-	function incluirRestricaoECossignatario(adicionarRestricaoAcessoAntes) {
+	function incluirRestricao(adicionarRestricaoAcessoAntes) {
 		sigaSpinner.mostrar();
 		
 		if (adicionarRestricaoAcessoAntes === true) {

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
@@ -12,7 +12,8 @@
 		if (adicionarRestricaoAcessoAntes === true) {
 			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
 		}
-
+		
+		sigaModal.fechar('sigaModalConfirmacao');
 		document.getElementById('frm').submit();
 	}
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/incluirCosignatario.jsp
@@ -6,10 +6,14 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
 <script type="text/javascript" language="Javascript1.1">
-	function sbmt() {
-		ExMovimentacaoForm.page.value = '';
-		ExMovimentacaoForm.acao.value = 'aJuntar';
-		ExMovimentacaoForm.submit();
+	function incluirRestricaoECossignatario(adicionarRestricaoAcessoAntes) {
+		sigaSpinner.mostrar();
+		
+		if (adicionarRestricaoAcessoAntes === true) {
+			document.getElementById("adicionarRestricaoAcessoAntes").value = true;
+		}
+
+		document.getElementById('frm').submit();
 	}
 
 	function displayPersonalizar(thisElement) {
@@ -77,10 +81,12 @@
 				</h5>
 			</div>
 			<div class="card-body">
-				<form action="incluir_cosignatario_gravar" namespace="/expediente/mov" cssClass="form" method="post" onsubmit="return validate();" >
+				<form id="frm" action="incluir_cosignatario_gravar" namespace="/expediente/mov" cssClass="form" method="post" onsubmit="return validate();" >
 					<input type="hidden" name="postback" value="1" />
 					<input type="hidden" name="sigla" value="${sigla}" />
 					<input type="hidden" id="podeIncluirCossigArvoreDocs" name="podeIncluirCossigArvoreDocs" value="${podeIncluirCossigArvoreDocs}"/>
+					<input type="hidden" id="adicionarRestricaoAcessoAntes" name="adicionarRestricaoAcessoAntes" value="false"/>
+					
 					<c:if test="${siga_cliente == 'GOVSP'}">
 					<div class="row">
 						<div class="col-sm-6">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -146,10 +146,10 @@
 					<tbody>
 						<c:forEach var="mov" items="${listaAcessoRestrito}">
 							<tr>
-								<td>${mov.titular }</td>
-								<td>${mov.titular.nomePessoa }</td>
-								<td>${mov.lotaTitular.nomeLotacao }</td>
-								<td>${mov.titular.funcaoString }</td>
+								<td>${mov.subscritor }</td>
+								<td>${mov.subscritor.nomePessoa }</td>
+								<td>${mov.subscritor.lotacao.nomeLotacao }</td>
+								<td>${mov.subscritor.funcaoString }</td>
 								<td><input type="button" value="Excluir" 
 									onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?idMovRestricao=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
 								</td>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -105,8 +105,41 @@
 						</div>
 					</div>	
 					<div class='row bg-light' id="divUsuarios">
-						<!-- Pessoas selecionadas -->						
-					</div>										
+						<!-- Pessoas selecionadas -->		
+						<div class='col-sm-12 mt-3 mb-1'><label><b>Pessoas Selecionadas</b></label></div>				
+					</div>				
+											
+					
+					
+					<div class="table-responsive">
+						<table border="0" class="table table-sm table-striped">
+							<thead class="thead-dark">
+								<tr>
+									<th align="left" width="10%">Matrícula</th>
+									<th align="left">Nome</th>						
+									<th align="left"><fmt:message key="usuario.lotacao"/></th>
+									<th align="left">Função</th>
+									<th align="left"><c:if test="${siga_cliente != 'GOVSP'}">Localidade</c:if></th>
+									<th align="left" width="5%">Excluir</th>					
+								</tr>
+							</thead>
+							<tbody>
+								<c:forEach var="mov" items="${listaAcessoRestrito}">
+									<tr>
+										<td>${mov.subscritor }</td>
+										<td>${mov.subscritor.nomePessoa }</td>
+										<td>${mov.nmLotacao }</td>
+										<td>${mov.nmFuncao }</td>
+										<td><c:if test="${siga_cliente != 'GOVSP'}">${mov.nmLocalidade}</c:if></td>
+										<td><input type="button" value="Excluir" 
+											onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?id=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
+										</td>
+									</tr>
+								</c:forEach>
+							</tbody>
+						</table>
+					</div>
+					
 					
 					<div class="row">
 						<div class="col-sm mt-3">

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -151,7 +151,7 @@
 								<td>${mov.subscritor.lotacao.nomeLotacao }</td>
 								<td>${mov.subscritor.funcaoString }</td>
 								<td><input type="button" value="Excluir" 
-									onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?idMovRestricao=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
+									onclick="javascript:excluirRestricao(${mov.idMov});" class="btn btn-danger"/>					
 								</td>
 							</tr>
 						</c:forEach>
@@ -160,6 +160,16 @@
 			</div>
 		</c:if>
 	</div>
+	
+	<siga:siga-modal id="confirmacaoModal" exibirRodape="false" tituloADireita="Confirmação">
+		<div id="msg" class="modal-body">
+       		Deseja concluir a operação realizada? 
+     	</div>
+     	<div class="modal-footer">
+     	    <a href="#" class="btn btn-success siga-modal__btn-acao" role="button" aria-pressed="true" onclick="">Sim</a>
+       		<button type="button" class="btn btn-danger" data-dismiss="modal" onclick="cancelar();">Não</button>		        
+		</div>
+	</siga:siga-modal>
 </siga:pagina>
 
 
@@ -188,20 +198,38 @@
 	});
 
 	$("#ok").click(function(){
-		
-		//reset restrição acesso
-		if (document.getElementById("chkResetDefault") !== null && document.getElementById("chkResetDefault").checked) {
-			document.getElementById("resetarRestricaoAcesso").value = true;
-			frm.submit();
+		var usuarios = document.getElementById("usu").value;
+		if ((usuarios.length > 1) || (document.getElementById("chkResetDefault") !== null && document.getElementById("chkResetDefault").checked) ) {
+			mostrarModalConfirmacao('javascript:confirmarAlteracao();');
 		} else {
-			var usuarios = document.getElementById("usu").value;
-			if(usuarios.length > 1) {
-				frm.submit();
-			} else {
-				alert("Selecione pelo menos uma pessoa.");
-			}
-		}
+			alert("Selecione pelo menos uma pessoa.");
+		}	
 	});
+	
+	function mostrarModalConfirmacao(acaoBotaoConfirmacao) {
+		sigaModal.alterarLinkBotaoDeAcao('confirmacaoModal',acaoBotaoConfirmacao);
+		sigaModal.abrir('confirmacaoModal'); 
+		sigaModal.reabilitarBotaoAposFecharModal('confirmacaoModal','ok');
+	}
+	
+    function confirmarAlteracao() {
+    	sigaSpinner.mostrar();
+    	//reset restrição acesso
+    	if (document.getElementById("chkResetDefault") !== null && document.getElementById("chkResetDefault").checked) {
+	        document.getElementById("resetarRestricaoAcesso").value = true;
+    	} 
+        sigaModal.fechar('confirmacaoModal');
+        frm.submit();
+    }
+    
+    function excluirRestricao(idMov) {
+    	mostrarModalConfirmacao('${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?idMovRestricao='+ idMov +'&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}');
+    }
+    
+    function cancelar() {
+    	document.getElementById("ok").disabled = false;
+        sigaModal.fechar('confirmacaoModal');
+    }
 
 	function remover(id) {
 		$('#div' + id).remove();

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -1,9 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<%@ page language="java" contentType="text/html; charset=UTF-8"
-	buffer="64kb"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" buffer="64kb"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-
 <%@ taglib uri="http://localhost/jeetags" prefix="siga"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
 <siga:pagina titulo="Restringir Acesso">
 
@@ -74,6 +73,7 @@
 					<input type="hidden" name="postback" value="1" />
 					<input type="hidden" name="sigla" value="${sigla}"/>
        				<input type="hidden" name="usu" id="usu" value=""/>
+       				<input type="hidden" id="resetarRestricaoAcesso" name="resetarRestricaoAcesso" value="false"/>
        				<div class="row">
 						<div class="col-sm-4">
 							<div class="form-group">
@@ -89,6 +89,18 @@
 							    </select>
 							</div>
 						</div>
+						
+						<c:if test="${not empty listaAcessoRestrito}">
+							<div class="col-sm-4">
+								<div class="form-group">
+									<div class="form-check form-check-inline mt-4">
+										<input type="checkbox" id="chkResetDefault" name="chkResetDefault" class="form-check-input ml-3"  />
+										<label class="form-check-label" for="chkResetDefault">Retornar ao Nível de Acesso Padrão</label>
+									</div>
+								</div>
+							</div>
+						</c:if>
+						
 					</div>	
 					<div class="row">
 						<div class="col-sm-12">
@@ -106,50 +118,47 @@
 					</div>	
 					<div class='row bg-light' id="divUsuarios">
 						<!-- Pessoas selecionadas -->		
-						<div class='col-sm-12 mt-3 mb-1'><label><b>Pessoas Selecionadas</b></label></div>				
+									
 					</div>				
-											
-					
-					
-					<div class="table-responsive">
-						<table border="0" class="table table-sm table-striped">
-							<thead class="thead-dark">
-								<tr>
-									<th align="left" width="10%">Matrícula</th>
-									<th align="left">Nome</th>						
-									<th align="left"><fmt:message key="usuario.lotacao"/></th>
-									<th align="left">Função</th>
-									<th align="left"><c:if test="${siga_cliente != 'GOVSP'}">Localidade</c:if></th>
-									<th align="left" width="5%">Excluir</th>					
-								</tr>
-							</thead>
-							<tbody>
-								<c:forEach var="mov" items="${listaAcessoRestrito}">
-									<tr>
-										<td>${mov.subscritor }</td>
-										<td>${mov.subscritor.nomePessoa }</td>
-										<td>${mov.nmLotacao }</td>
-										<td>${mov.nmFuncao }</td>
-										<td><c:if test="${siga_cliente != 'GOVSP'}">${mov.nmLocalidade}</c:if></td>
-										<td><input type="button" value="Excluir" 
-											onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?id=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
-										</td>
-									</tr>
-								</c:forEach>
-							</tbody>
-						</table>
-					</div>
-					
-					
+
 					<div class="row">
 						<div class="col-sm mt-3">
 							<input type="button" value="Ok" id="ok" class="btn btn-primary"/> 
-							<input type="button" value="Voltar" onclick="javascript:history.back();" class="btn btn-cancel ml-2"/> 
+							<input type="button" value="Voltar" onclick="javascript:location.href='${pageContext.request.contextPath}/app/expediente/doc/exibir?sigla=${sigla}';" class="btn btn-cancel ml-2" />
 						</div>
 					</div>
 				</form>
 			</div>
 		</div>
+		<c:if test="${not empty listaAcessoRestrito}">
+			<h4 class="gt-table-head">Lista de Restrição de Acesso</h4>	
+			<div class="table-responsive">
+				<table border="0" class="table table-sm table-striped">
+					<thead class="thead-dark">
+						<tr>
+							<th align="left" width="10%">Matrícula</th>
+							<th align="left">Nome</th>						
+							<th align="left"><fmt:message key="usuario.lotacao"/></th>
+							<th align="left">Função</th>
+							<th align="left" width="5%">Excluir</th>					
+						</tr>
+					</thead>
+					<tbody>
+						<c:forEach var="mov" items="${listaAcessoRestrito}">
+							<tr>
+								<td>${mov.titular }</td>
+								<td>${mov.titular.nomePessoa }</td>
+								<td>${mov.lotaTitular.nomeLotacao }</td>
+								<td>${mov.titular.funcaoString }</td>
+								<td><input type="button" value="Excluir" 
+									onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?id=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
+								</td>
+							</tr>
+						</c:forEach>
+					</tbody>
+				</table>
+			</div>
+		</c:if>
 	</div>
 </siga:pagina>
 
@@ -179,11 +188,18 @@
 	});
 
 	$("#ok").click(function(){
-		var usuarios = document.getElementById("usu").value;
-		if(usuarios.length > 1) {
+		
+		//reset restrição acesso
+		if (document.getElementById("chkResetDefault") !== null && document.getElementById("chkResetDefault").checked) {
+			document.getElementById("resetarRestricaoAcesso").value = true;
 			frm.submit();
 		} else {
-			alert("Selecione pelo menos uma pessoa.");
+			var usuarios = document.getElementById("usu").value;
+			if(usuarios.length > 1) {
+				frm.submit();
+			} else {
+				alert("Selecione pelo menos uma pessoa.");
+			}
 		}
 	});
 

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -193,6 +193,10 @@
 			
 	    	temUsuarioSelecionado = true;
 	    	document.getElementById("usu").value = usu + id + ";";
+	    	
+	    	//Limpa usuário adicionado
+			document.getElementById('formulario_pessoaObjeto_pessoaSel_sigla').value = "";
+			ajax_pessoaObjeto_pessoa();
 		}
 		
 	});
@@ -207,6 +211,7 @@
 	});
 	
 	function mostrarModalConfirmacao(acaoBotaoConfirmacao) {
+		document.getElementById("ok").disabled = true;
 		sigaModal.alterarLinkBotaoDeAcao('confirmacaoModal',acaoBotaoConfirmacao);
 		sigaModal.abrir('confirmacaoModal'); 
 		sigaModal.reabilitarBotaoAposFecharModal('confirmacaoModal','ok');
@@ -219,6 +224,7 @@
 	        document.getElementById("resetarRestricaoAcesso").value = true;
     	} 
         sigaModal.fechar('confirmacaoModal');
+        document.getElementById("ok").disabled = false;
         frm.submit();
     }
     

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/restringirAcesso.jsp
@@ -151,7 +151,7 @@
 								<td>${mov.lotaTitular.nomeLotacao }</td>
 								<td>${mov.titular.funcaoString }</td>
 								<td><input type="button" value="Excluir" 
-									onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?id=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
+									onclick="javascript:sigaSpinner.mostrar();location.href='${pageContext.request.contextPath}/app/expediente/mov/cancelar_restricao_acesso?idMovRestricao=${mov.idMov}&redirectURL=/app/expediente/mov/restringir_acesso?sigla=${sigla}'" class="btn btn-danger"/>					
 								</td>
 							</tr>
 						</c:forEach>

--- a/sigaex/src/main/webapp/WEB-INF/tags/assinatura_botoes.tag
+++ b/sigaex/src/main/webapp/WEB-INF/tags/assinatura_botoes.tag
@@ -149,7 +149,7 @@
 					<script type="text/javascript">
 						function confirmaExibirNoProtocolo(checkbox) {
 						  if (checkbox.checked) {
-						    if (!confirm("Ao clicar em OK o conteúdo deste documento ficará disponível através do número do protocolo de acompanhamento. Deseja continuar? ")) {
+						    if (!confirm(<c:if test="${doc.mobilGeral.acessoRestrito}">"Atenção: Documento com Restrição de Acesso. \n" + </c:if>"Ao clicar em OK o conteúdo deste documento ficará disponível através do número do protocolo de acompanhamento. Deseja continuar? ")) {
 							  checkbox.checked = false;
 						    }
 						  }


### PR DESCRIPTION
Ajuste na rotina pré existente da restrição de acesso com foco principal em manter subscritores e cossignatários na Lista de Restrição caso esteja pendente de assinatura, possibilidade de inclusão e exclusão de pessoas da lista sem precisar de resetar e alertas para adicionar pessoas conforme movimentações forem sendo executadas, como a tramitação e definição de perfil.


![image](https://user-images.githubusercontent.com/20362170/224349043-9b1a0b67-7d28-4311-8e41-d43cd0d3f909.png)

![image](https://user-images.githubusercontent.com/20362170/224349113-bfff75f9-12d1-4af9-9fed-cf109fdeac26.png)


![image](https://user-images.githubusercontent.com/20362170/224349160-882255f5-32bd-4903-8d23-0ab7def41f35.png)


![image](https://user-images.githubusercontent.com/20362170/224349337-5f417024-a971-4d47-822f-52b345f651af.png)

![image](https://user-images.githubusercontent.com/20362170/224349422-753b17f8-c492-404d-9062-b21ecaca67fb.png)


![image](https://user-images.githubusercontent.com/20362170/224349483-44a0e0da-9d36-4444-930a-bcdbf37c27ff.png)


![image](https://user-images.githubusercontent.com/20362170/224349561-18220ad9-0d15-4639-9d95-3f8720c07a98.png)

**Observações**

Foi realizado ajuste na rotina de que empilha o nível de acesso nas movimentações para posterior efeito de cálculo do campo de acesso desnormalizado. Apenas movimentações que alteram o nível de acesso terá o nível registrado e nos cálculos será levado em consideração apenas essas movimentações.