### PR TITLE
RM70266 - Ajuste na Proposta de adequação do controle de versionamento do SIGA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			            	<Project-Version>${project.version}</Project-Version>
 			            	
 							<Build-Time>${maven.build.timestamp}</Build-Time>
-							<Build-Label>${project.version}-${git.commit.id.abbrev}</Build-Label>
+							<Build-Label>${git.tags}-${git.commit.id.abbrev}</Build-Label>
 							
 							<SCM-RemoteURL>${git.remote.origin.url}</SCM-RemoteURL>
 							<SCM-CommitId>${git.commit.id}</SCM-CommitId>
@@ -162,25 +162,6 @@
 			<url>https://repository.jboss.org/nexus/content/repositories/deprecated</url>
 		</repository>
 
-		<!-- repositorio adicionado para a swetake
-		<repository>
-			<id>swetake</id>
-			<url>https://itrc.jju.edu.cn/nexus-2.0.6/content/repositories/thirdparty/</url>
-		</repository>
-		 -->
-
-		<!-- repositorio adicionado para a simplecaptcha -->
-		<!-- Edson: removendo pois está quebrado -->
-		<!--<repository>
-			<id>simplecaptcha</id>
-			<url>https://maven.nfms4redd.org/</url>
-		</repository>-->
-		<!-- repositorio adicionado para o dynamic jasper
-		<repository>
-	    	<id>fdvsolution.public</id>
-	    	<url>https://nexus.fdvs.com.ar/content/groups/public/</url>
-	    </repository>
-	     -->
 	</repositories>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>siga-doc</artifactId>
 	<packaging>pom</packaging>
 	<!-- Registro Centralizado da Versão do SIGA -->
-	<version>11.1.0-SNAPSHOT</version>
+	<version>11.1-SNAPSHOT</version>
 
 	<modules>		
 		<module>siga-base</module>

--- a/siga-arq/pom.xml
+++ b/siga-arq/pom.xml
@@ -72,13 +72,13 @@
 		<dependency>
 			<groupId>siga</groupId>
 			<artifactId>siga-jwt</artifactId>
-			<version>11.1.0-SNAPSHOT</version>
+			<version>11.1-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>siga</groupId>
 			<artifactId>siga-base</artifactId>
-			<version>11.1.0-SNAPSHOT</version>
+			<version>11.1-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/siga-base/pom.xml
+++ b/siga-base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>siga</groupId>
 		<artifactId>siga-doc</artifactId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaVersion.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/SigaVersion.java
@@ -19,8 +19,16 @@ public class SigaVersion {
 	
 	public static void loadSigaVersion() {
 		try {
-			SIGA_VERSION = Manifests.read("Build-Label") != null ? Manifests.read("Build-Label") : "SNAPSHOT";
+			SIGA_VERSION = Manifests.read("Build-Label") != null ? Manifests.read("Build-Label")
+					.replace("-SNAPSHOT", "")
+					.replace("-RELEASE", "") : "SNAPSHOT";
+			
 			SIGA_PROJECT_VERSION = Manifests.read("Project-Version") != null ? Manifests.read("Project-Version") : "SNAPSHOT";
+			
+			//Caso release não esteja taggeada, pega do project version
+			if (SIGA_VERSION.startsWith("-")) {
+				SIGA_VERSION = SIGA_PROJECT_VERSION;
+			}
 			
 			SIGA_VERSION_DATE = Manifests.read("Build-Time") != null ? Manifests.read("Build-Time") : "NODATE";
 		} catch (Exception e) {

--- a/siga-cp/pom.xml
+++ b/siga-cp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/siga-dump/pom.xml
+++ b/siga-dump/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>siga-dump</artifactId>

--- a/siga-ex/pom.xml
+++ b/siga-ex/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/siga-ext/pom.xml
+++ b/siga-ext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>siga-doc</artifactId>
         <groupId>siga</groupId>
-        <version>11.1.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/siga-integracao/pom.xml
+++ b/siga-integracao/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>siga</groupId>
 		<artifactId>siga-doc</artifactId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/siga-jwt/pom.xml
+++ b/siga-jwt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>siga</groupId>
 		<artifactId>siga-doc</artifactId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>siga-jwt</artifactId>
 	<name>siga-jwt</name>

--- a/siga-ldap-cli/pom.xml
+++ b/siga-ldap-cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>siga</groupId>
 		<artifactId>siga-doc</artifactId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>siga-ldap-cli</artifactId>

--- a/siga-ldap/pom.xml
+++ b/siga-ldap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>siga-doc</artifactId>
         <groupId>siga</groupId>
-        <version>11.1.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/siga-oidc/pom.xml
+++ b/siga-oidc/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>siga</groupId>
 		<artifactId>siga-doc</artifactId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>siga-oidc</artifactId>

--- a/siga-rel/pom.xml
+++ b/siga-rel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>siga-doc</artifactId>
         <groupId>siga</groupId>
-        <version>11.1.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/siga-sinc-lib/pom.xml
+++ b/siga-sinc-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>siga-doc</artifactId>
         <groupId>siga</groupId>
-        <version>11.1.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/siga-vraptor-module-old/pom.xml
+++ b/siga-vraptor-module-old/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>siga-vraptor-module-old</artifactId>
 	<name>siga-vraptor-module-old</name>

--- a/siga-vraptor-module/pom.xml
+++ b/siga-vraptor-module/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>siga-vraptor-module</artifactId>
 	<name>siga-vraptor-module</name>

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/cabecalho.tag
@@ -390,7 +390,7 @@ ${meta}
 										</c:when>
 									</c:choose>
 								</span>
-								<span >- v.${siga_version}</span>
+								<span >- ${siga_version}</span>
 							</div>
 						</div>
 	

--- a/siga-wf/pom.xml
+++ b/siga-wf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/siga-ws/pom.xml
+++ b/siga-ws/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/siga/pom.xml
+++ b/siga/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<packaging>war</packaging>

--- a/sigaex/pom.xml
+++ b/sigaex/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sigaex</artifactId>

--- a/sigagc/pom.xml
+++ b/sigagc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<packaging>war</packaging>

--- a/sigasr/pom.xml
+++ b/sigasr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sigasr</artifactId>

--- a/sigatp/pom.xml
+++ b/sigatp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sigatp</artifactId>

--- a/sigawf/pom.xml
+++ b/sigawf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>siga-doc</artifactId>
 		<groupId>siga</groupId>
-		<version>11.1.0-SNAPSHOT</version>
+		<version>11.1-SNAPSHOT</version>
 	</parent>
 
 	<packaging>war</packaging>


### PR DESCRIPTION
Ajuste do PR: https://github.com/projeto-siga/siga/pull/2327

Segue uma nova proposta de aperfeiçoamento do PR anterior para evitar trabalho no merge entre release <-> develop.

**Problema atual**
Ao criar um patch na release X.Y.1,  X.Y.2.... e realizar merge para develop, estava requerendo um tratamento para não sobrescrever o padrão da develop X.Y-SNAPSHOT.

Para evitar ter que tratar isso a cada merge, o mais tranquilo seria voltar a controlar o project version com Major.Minor-SNAPSHOT (que era o 1.2-SNAPSHOT) isso em todas as branches e que pode ser tratado no build para adicionar o patch, mas no POM o controle fica muito ruim no dia-a-dia.

**Proposta**
A proposta então é fixar o Project Version em Major.Minor-SNAPSHOT em todas as branches e somente a cada nova versão maior ou menor (release/major.minor) incrementar utilizando os plugins do MVN para auxiliar.
Para exibição e adição no MANIFEST do patch incremental será utilizada a TAG do GIT, onde a cada vez que feche uma versão patch (quando editávamos o cabecalho e version.mf antes) deverá ser criada uma TAG no padrão:

> vMAJOR.MINOR.PATCH

Esse é o mínimo para funcionar. Aí próximos passos poderiam ser a automação do processo. Por exemplo, pode ter um arquivo VERSION.MF e ao dar push nesse arquivo uma Action do GITHUB pode atuar para criar a TAG e testar o build e passos adicionais. Mas estruturalmente é isso. É o project version com MAJOR.MINOR-SNAPSHOT + a TAG Version no padrão acima.

**Comandos Adicionais**
_Para Minor_
`mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}-SNAPSHOT`

E criar a Release: release/major.minor
E criar a TAG inicial major.minor.0

_Para Major_
`mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.nextMajorVersion}.0-SNAPSHOT`

E criar a Release: release/major.minor
E criar a TAG inicial major.0.0


Isso diminui a necessidade mais recorrente de atualizar o Eclipse (Alt+F5) pois todas as version da mesma release estarão iguais nos POMs.

Caso tenha uma nova necessidade, o processo será novamente ajustado