### PR TITLE
Feature/govsp/rm160619 Bloqueia campo órgão do compoente

### DIFF
--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/busca.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/busca.jsp
@@ -88,14 +88,15 @@
 				<h5>Dados da <fmt:message key="usuario.lotacao"/></h5>
 			</div>
 			<div class="card-body">
-				<form name="frm" action="${request.contextPath}/app/lotacao/buscar" class="form" method="POST">
+				<form name="frm" id="frm" action="${request.contextPath}/app/lotacao/buscar" class="form" method="POST">
 					<input type="hidden" name="buscarFechadas" value="${param['buscarFechadas']}" /> 
 					<input type="hidden" name="buscarTodosOrgaos" value="true" /> 
 					<input type="hidden" name="propriedade" value="${param.propriedade}" /> 
 					<input type="hidden" name="postback" value="1" /> 
 					<input type="hidden" name="paramoffset" value="0" />
 					<input type="hidden" name="p.offset" value="0" />
-					<input type="hidden" name="modal" value="${param['modal']}" />				
+					<input type="hidden" name="modal" value="${param['modal']}" />
+					<input type="hidden" name="campoOrgaoDesabilitado" value="${param['campoOrgaoDesabilitado']}" />			
 					<div class="row">
 						<div class="col-sm">
 							<div class="form-group">
@@ -109,8 +110,8 @@
 						<div class="col-sm">
 							<div class="form-group">
 								<label for="idOrgaoUsu">Órgão</label>
-								<select name="idOrgaoUsu" value="${idOrgaoUsu}" class="form-control  siga-select2" >
-										<option value="">[Todos]</option>
+								<select name="idOrgaoUsu" id="idOrgaoUsu" value="${idOrgaoUsu}" class="form-control  siga-select2" >
+										<option value="${item.idOrgaoUsu}">[Todos]</option>
 										<c:forEach items="${orgaosUsu}" var="item">
 											<option value="${item.idOrgaoUsu}"
 												${item.idOrgaoUsu == idOrgaoUsu ? 'selected' : ''}>
@@ -164,6 +165,16 @@
 		</c:if>
 	</div>
 	
+<script type="text/javascript" language="Javascript1.1">
+	
+	if (${param.campoOrgaoDesabilitado == true}) {
+		$('#idOrgaoUsu').prop('disabled', true);
+	
+		$('#frm').on('submit', function() {
+		    $('#idOrgaoUsu').prop('disabled', false);
+		});
+	}
+</script>
 <script type="text/javascript" src="/siga/javascript/select2/select2.min.js"></script>
 <script type="text/javascript" src="/siga/javascript/select2/i18n/pt-BR.js"></script>
 <script type="text/javascript" src="/siga/javascript/siga.select2.js"></script>	

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/buscar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/buscar.jsp
@@ -89,6 +89,7 @@
 					<input type="hidden" name="p.offset" value="0" />
 					<input type="hidden" name="buscarFechadas" value="${param['buscarFechadas']}" />
 					<input type="hidden" name="modal" value="${param['modal']}" />
+					<input type="hidden" name="campoOrgaoDesabilitado" value="${param['campoOrgaoDesabilitado']}" />
 					<div class="row">
 						<div class="col-sm">
 							<div class="form-group">
@@ -103,10 +104,10 @@
 							<div class="form-group">
 								<c:choose>
 									<c:when test="${siga_cliente == 'GOVSP'}">
-										<siga:selecao titulo="Unidade" urlAcao="buscar" propriedade="lotacao" modulo="siga" onchange="valida()" onblur="valida()"/>
+										<siga:selecao titulo="Unidade" urlAcao="buscar" propriedade="lotacao" paramList="campoOrgaoDesabilitado=${param['campoOrgaoDesabilitado']}" modulo="siga" onchange="valida()" onblur="valida()"/>
 									</c:when>
 									<c:otherwise>
-										<siga:selecao titulo="Lotação" urlAcao="buscar" propriedade="lotacao" modulo="siga" onchange="valida()" onblur="valida()"/>
+										<siga:selecao titulo="Lotação" urlAcao="buscar" propriedade="lotacao" paramList="campoOrgaoDesabilitado=${param['campoOrgaoDesabilitado']}" modulo="siga" onchange="valida()" onblur="valida()"/>
 									</c:otherwise>	
 								</c:choose>	
 								<c:choose>
@@ -185,7 +186,16 @@
 		</c:if>
 
 	</div>
+<script type="text/javascript" language="Javascript1.1">
 
+	if (${param.campoOrgaoDesabilitado == true}) {
+		$('#idOrgaoUsu').prop('disabled', true);
+	
+		$('#frm').on('submit', function() {
+		    $('#idOrgaoUsu').prop('disabled', false);
+		});
+	}
+</script>
 <script type="text/javascript" src="/siga/javascript/select2/select2.min.js"></script>
 <script type="text/javascript" src="/siga/javascript/select2/i18n/pt-BR.js"></script>
 <script type="text/javascript" src="/siga/javascript/siga.select2.js"></script>	

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirDocArquivadoLote.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferirDocArquivadoLote.jsp
@@ -52,18 +52,18 @@
 								<label>&nbsp;</label> 
 								<c:if test="${tipoResponsavel == 1}">
 									 <div id="lotaResponsavel" style="display:">
-										<siga:selecao propriedade="lotaResponsavel" tema="simple" modulo="siga"/>
+										<siga:selecao propriedade="lotaResponsavel" tema="simple" paramList="campoOrgaoDesabilitado=true" modulo="siga"/>
 									</div> 
-									<div id="responsavel" style="display: none;"> 
-										<siga:selecao propriedade="responsavel" tema="simple" modulo="siga"/>
+									<div id="responsavel" style="display: none;">
+										<siga:selecao propriedade="responsavel" tema="simple" paramList="campoOrgaoDesabilitado=true" modulo="siga"/>
 									</div>
 								</c:if>
 								<c:if test="${tipoResponsavel == 2}">
 									<div id="lotaResponsavel" style="display: none">
-										<siga:selecao propriedade="lotaResponsavel" tema="simple" modulo="siga"/>
+										<siga:selecao propriedade="lotaResponsavel" tema="simple" paramList="campoOrgaoDesabilitado=true" modulo="siga"/>
 									</div> 
-									<div id="responsavel" style="display:"> 
-										<siga:selecao propriedade="responsavel" tema="simple" modulo="siga"/>
+									<div id="responsavel" style="display:">
+										<siga:selecao propriedade="responsavel" tema="simple" paramList="campoOrgaoDesabilitado=true" modulo="siga"/>
 									</div>
 								</c:if>
 							</div>


### PR DESCRIPTION
Bloqueio do campo órgão

- Foi implementado o bloqueio opcional do campo ÓRGÃO nos componentes de pesquisa de Usuário/unidade.

Para implementação da função um novo paramento "**campoOrgaoDesabilitado**" foi adicionado nas JSPs (**dpLotacao/busca.jsp** e **dpPessoa.busca.jsp**) que pode ser passado opcionalmente na chamada do componente siga:selecao, utilizando a propriedade: paramList="campoOrgaoDesabilitado=true"

Correção:
![bloqueio campo orgao](https://user-images.githubusercontent.com/17768272/231240737-89b0d867-8f93-4fc0-b81f-375e24b766a2.gif)

Testes em outras telas que utiliza o mesmo componente:
Usuário:
![image](https://user-images.githubusercontent.com/17768272/231243553-ecbb3720-d716-4efe-af1b-33f8d6f30d21.png)

Unidade:
![image](https://user-images.githubusercontent.com/17768272/231243697-d390d68d-25e4-4358-b8a0-897919dc747a.png)


Informações de referência:
https://pt.stackoverflow.com/questions/128188/como-aplicar-readonly-em-um-select
https://stackoverflow.com/questions/368813/html-form-readonly-select-tag-input