### PR TITLE
RM160602 Adequar endpoint numeracao-generica

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -225,6 +225,9 @@ public class Prop {
 		// Propriedade que controla o acesso ao método de conferência de assinaturas de Documentos da API REST
 		provider.addPrivateProperty("/sigaex.auditoria.assinaturas.password", null);
 
+		// Propriedade que controla o acesso ao método de númeração genérica da API REST
+		provider.addPrivateProperty("/sigaex.numeracao.generica.password", null);
+
 		/* Services
 		 * 
 		 * Declaração dos serviços e end-points SOAP e RESTful usados pelo back-end nos módulos

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
@@ -23,22 +23,22 @@ public class NumeracaoGenericaPost implements INumeracaoGenericaPost {
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-        // Verifica o acesso via chave
-        {
-            String auth = SwaggerServlet.getHttpServletRequest().getHeader("Authorization");
-			
-            if (Objects.isNull(auth)) {
-                throw new SwaggerAuthorizationException();
-            }
+		// Verifica o acesso via chave
+		{
+			String auth = SwaggerServlet.getHttpServletRequest().getHeader("Authorization");
+
+			if (Objects.isNull(auth)) {
+				throw new SwaggerAuthorizationException();
+			}
 
 			DpPessoa cadastrante = ctx.getCadastrante();
 			String pwd = Prop.get("/sigaex.numeracao.generica.password");
-			
-            if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
-                throw new SwaggerAuthorizationException("Propriedade sigaex.numeracao.generica.password não " + 
-                        "confere com o valor recebido no cabeçalho Authorization");
-            }
-        }
+
+			if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
+				throw new SwaggerAuthorizationException("Propriedade sigaex.numeracao.generica.password não " + 
+						"confere com o valor recebido no cabeçalho Authorization");
+			}
+		}
         
 		try {
 			final ExBL exBL = Ex.getInstance().getBL();

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
@@ -25,11 +25,17 @@ public class NumeracaoGenericaPost implements INumeracaoGenericaPost {
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
         // Verifica o acesso via chave
         {
-            DpPessoa cadastrante = ctx.getCadastrante();
-            String pwd = Prop.get("/sigaex.numeracao.generica.password");
             String auth = SwaggerServlet.getHttpServletRequest().getHeader("Authorization");
-            if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
+            String pwd = Prop.get("/sigaex.numeracao.generica.password");
+            DpPessoa cadastrante = ctx.getCadastrante();
+
+            if (Objects.isNull(auth)) {
                 throw new SwaggerAuthorizationException();
+            }
+
+            if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
+                throw new SwaggerAuthorizationException("Propriedade sigaex.numeracao.generica.password não " + 
+                        "confere com o valor recebido no cabeçalho Authorization");
             }
         }
         

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
@@ -1,5 +1,9 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
+import br.gov.jfrj.siga.base.Prop;
+import br.gov.jfrj.siga.context.AcessoPublicoEPrivado;
+import br.gov.jfrj.siga.dp.DpPessoa;
+import com.crivano.swaggerservlet.SwaggerAuthorizationException;
 import com.crivano.swaggerservlet.SwaggerException;
 
 import br.gov.jfrj.siga.base.AplicacaoException;
@@ -9,12 +13,26 @@ import br.gov.jfrj.siga.ex.bl.Ex;
 import br.gov.jfrj.siga.ex.bl.ExBL;
 import br.gov.jfrj.siga.hibernate.ExDao;
 import br.gov.jfrj.siga.vraptor.Transacional;
+import com.crivano.swaggerservlet.SwaggerServlet;
 
+import java.util.Objects;
+
+@AcessoPublicoEPrivado
 @Transacional
 public class NumeracaoGenericaPost implements INumeracaoGenericaPost {
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
+        // Verifica o acesso via chave
+        {
+            DpPessoa cadastrante = ctx.getCadastrante();
+            String pwd = Prop.get("/sigaex.numeracao.generica.password");
+            String auth = SwaggerServlet.getHttpServletRequest().getHeader("Authorization");
+            if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
+                throw new SwaggerAuthorizationException();
+            }
+        }
+        
 		try {
 			final ExBL exBL = Ex.getInstance().getBL();
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/NumeracaoGenericaPost.java
@@ -26,13 +26,14 @@ public class NumeracaoGenericaPost implements INumeracaoGenericaPost {
         // Verifica o acesso via chave
         {
             String auth = SwaggerServlet.getHttpServletRequest().getHeader("Authorization");
-            String pwd = Prop.get("/sigaex.numeracao.generica.password");
-            DpPessoa cadastrante = ctx.getCadastrante();
-
+			
             if (Objects.isNull(auth)) {
                 throw new SwaggerAuthorizationException();
             }
 
+			DpPessoa cadastrante = ctx.getCadastrante();
+			String pwd = Prop.get("/sigaex.numeracao.generica.password");
+			
             if (Objects.isNull(cadastrante) && !Objects.equals(pwd, auth)) {
                 throw new SwaggerAuthorizationException("Propriedade sigaex.numeracao.generica.password não " + 
                         "confere com o valor recebido no cabeçalho Authorization");


### PR DESCRIPTION
Foi adicionada a chave sigaex.numeracao.generica.password para viabilizar a integração do SEI ao Código Único

Cadastrar nova chave no standalone.xml
```xml
<property name="sigaex.numeracao.generica.password" value=""/>
```