### PR TITLE
FEAT: RM162750 - Corrige mov cancelada transf arquivado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -8996,8 +8996,8 @@ public class ExBL extends CpBL {
 				movArquivamentoNova.setExMovimentacaoRef(movArquivadaACancelar);
 				movArquivamentoNova.setLotaResp(lotaDestinoFinal);
 				movArquivamentoNova.setResp(null);
-				movArquivamentoNova.setSubscritor(null);
-				movArquivamentoNova.setLotaSubscritor(null);
+				movArquivamentoNova.setSubscritor(cadastrante);
+				movArquivamentoNova.setLotaSubscritor(lotaCadastrante);
 				
 				//movArquivamentoNova.setDtIniMov(movArquivadaACancelar.getDtIniMov());
 				movArquivamentoNova.setLotaDestinoFinal(lotaDestinoFinal);


### PR DESCRIPTION
Foi corrigido as movimentações anteriores exibida no painel Administrativo apos realizar uma transferência de documento corrente mais de uma vez, assim exibindo a informação de (Cancelado).

- OBS: Para correção foi observado que a nova movimentação precisa da informação de um cadastrante e subscritor para que a informação de (Cancelado) seja exibido.

Erro:
![image](https://user-images.githubusercontent.com/17768272/235663577-c4e21c7a-03ac-48d8-a318-8dc08b7ab82c.png)

Correção:
![image](https://user-images.githubusercontent.com/17768272/235244065-5d57ea5b-0bb1-4a44-a209-67f7b9c36e4f.png)
