### PR TITLE
2363 doc mostrar lista de pessoas ou lotações que substituem uma lotação na tela de visualização da lotação

### DIFF
--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -232,7 +232,11 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 			}
 		}
 	}
-
+	
+// TODO: Alterar método exibe para passas os dados dos possíveis substitutos pra view e exibir na tela
+// URL acessada: http://localhost:8080/siga/app/lotacao/exibir?sigla=ZZ-LTEST
+// View: page/dplotacao/exibi.jsp
+// Controller que retorna os dados necessários aqui: SubstituicaoController
 	@Get("app/lotacao/exibir")
 	public void exibi(String sigla) throws Exception {
 		StringBuilder sb = new StringBuilder();

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -237,16 +237,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 		}
 	}
 	
-// TODO: Alterar método exibe para passas os dados dos possíveis substitutos pra view e exibir na tela
-// URL acessada: http://localhost:8080/siga/app/lotacao/exibir?sigla=ZZ-LTEST
-// View: page/dplotacao/exibi.jsp
-// Controller que retorna os dados necessários aqui: SubstituicaoController
-	//TODO: O código da substituição fica nesse local, chamar esse código no exibi.jsp do DpLotacaoController
 	@Get("/app/lotacao/exibir")
-	/* public void lista() throws Exception { */
 	public void exibi(String sigla) throws Exception
 	{
-		//Lotação
 		StringBuilder sb = new StringBuilder();
 		if (sigla == null)
 			throw new Exception("sigla deve ser informada.");
@@ -262,37 +255,18 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 		result.include("lotacao", lot);
 		result.include("graph", sb.toString());
 		
-		System.out.println(lot);
-		System.out.println(sigla);
-		
-		//Substitutos
-		//Atual: Está exibindo os dados dos substitutos da lotação do usuário que está logado 
-		//TODO: Precisa exibir os dados dos substitutos da lotação do documento pesquisado
-		//TODO: Alterar o código abaixo para pegar a lotação do documento aberto, não a lotação do usuário logado
 		//TODO: A tela deve exibir soments os campos Substituto, data inicial e data final
 		
 		String substituicao = "false";
 		DpLotacao lotacaoDoCadastrante = getCadastrante().getLotacao();
-		System.out.println(getCadastrante().getLotacao());
-
-		//aqui tem que buscar a lotação do documento: Nome LOTACAO TESTE / Sigla LTEST no exemplo testado
-		//está retornando a lotação do usuário logado, tem que pegar a lotação teste (variavel lot)
 		DpLotacao lotacaoDoTitular = getLotaTitular();
-		lotacaoDoTitular = lot;
-		System.out.println(getLotaTitular());
-		System.out.println(lot);
 		DpPessoa titular =  getTitular();
-		System.out.println(getTitular());
-		System.out.println();
 		
 		if (!getCadastrante().getId().equals(titular.getId())
 				|| !lotacaoDoCadastrante.getId().equals(lotacaoDoTitular.getId())) {
-		//if (!getCadastrante().getId().equals(getTitular().getId())
-		//		|| !getCadastrante().getLotacao().getId().equals(getLotaTitular().getId())) {
 			if(podeCadastrarQualquerSubstituicao()){
 				substituicao = "true";		
 				result.include("itensTitular", buscarSubstitutos(substituicao, titular, lotacaoDoTitular));
-				//result.include("itensTitular", buscarSubstitutos(substituicao, getTitular(), getLotaTitular()));
 			}	
 		}
 		result.include("isSubstituicao", substituicao);
@@ -341,26 +315,6 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 				CpTipoDeConfiguracao.CADASTRAR_QUALQUER_SUBST);
 	}
 	
-// TODO: Apagar código comentado
-/*
-	@Get("app/lotacao/exibir")
-	public void exibi(String sigla) throws Exception {
-		StringBuilder sb = new StringBuilder();
-		if (sigla == null)
-			throw new Exception("sigla deve ser informada.");
-		DpLotacao lot = dao().getLotacaoFromSigla(sigla);
-
-		sb.append("digraph G {");
-
-		sb.append("graph [dpi = 60]; node [shape = rectangle];");
-
-		graphAcrescentarLotacao(sb, lot);
-		sb.append("}");
-
-		result.include("lotacao", lot);
-		result.include("graph", sb.toString());
-	}
-*/
 	private void graphAcrescentarLotacao(StringBuilder sb, DpLotacao lot) {
 		for (DpLotacao lotsub : lot.getDpLotacaoSubordinadosSet()) {
 			if (lotsub.getDataFimLotacao() != null)

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -262,18 +262,41 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 		result.include("lotacao", lot);
 		result.include("graph", sb.toString());
 		
-		//Substitutos
-		String substituicao = "false";
+		System.out.println(lot);
+		System.out.println(sigla);
 		
-		if (!getCadastrante().getId().equals(getTitular().getId())
-				|| !getCadastrante().getLotacao().getId().equals(getLotaTitular().getId())) {
+		//Substitutos
+		//Atual: Está exibindo os dados dos substitutos da lotação do usuário que está logado 
+		//TODO: Precisa exibir os dados dos substitutos da lotação do documento pesquisado
+		//TODO: Alterar o código abaixo para pegar a lotação do documento aberto, não a lotação do usuário logado
+		//TODO: A tela deve exibir soments os campos Substituto, data inicial e data final
+		
+		String substituicao = "false";
+		DpLotacao lotacaoDoCadastrante = getCadastrante().getLotacao();
+		System.out.println(getCadastrante().getLotacao());
+
+		//aqui tem que buscar a lotação do documento: Nome LOTACAO TESTE / Sigla LTEST no exemplo testado
+		//está retornando a lotação do usuário logado, tem que pegar a lotação teste (variavel lot)
+		DpLotacao lotacaoDoTitular = getLotaTitular();
+		lotacaoDoTitular = lot;
+		System.out.println(getLotaTitular());
+		System.out.println(lot);
+		DpPessoa titular =  getTitular();
+		System.out.println(getTitular());
+		System.out.println();
+		
+		if (!getCadastrante().getId().equals(titular.getId())
+				|| !lotacaoDoCadastrante.getId().equals(lotacaoDoTitular.getId())) {
+		//if (!getCadastrante().getId().equals(getTitular().getId())
+		//		|| !getCadastrante().getLotacao().getId().equals(getLotaTitular().getId())) {
 			if(podeCadastrarQualquerSubstituicao()){
-				substituicao = "true";					
-				result.include("itensTitular", buscarSubstitutos(substituicao, getTitular(), getLotaTitular()));
+				substituicao = "true";		
+				result.include("itensTitular", buscarSubstitutos(substituicao, titular, lotacaoDoTitular));
+				//result.include("itensTitular", buscarSubstitutos(substituicao, getTitular(), getLotaTitular()));
 			}	
 		}
 		result.include("isSubstituicao", substituicao);
-		result.include("itens", buscarSubstitutos(substituicao, getCadastrante(), getCadastrante().getLotacao()));
+		result.include("itens", buscarSubstitutos(substituicao, getCadastrante(), lot));
 	}	
 	
 	private List<DpSubstituicao> buscarSubstitutos(String substituicao, DpPessoa pessoa, DpLotacao lotacao) 
@@ -317,6 +340,8 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 				getCadastrante(), getCadastrante().getLotacao(), 
 				CpTipoDeConfiguracao.CADASTRAR_QUALQUER_SUBST);
 	}
+	
+// TODO: Apagar código comentado
 /*
 	@Get("app/lotacao/exibir")
 	public void exibi(String sigla) throws Exception {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -255,8 +255,6 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 		result.include("lotacao", lot);
 		result.include("graph", sb.toString());
 		
-		//TODO: A tela deve exibir soments os campos Substituto, data inicial e data final
-		
 		String substituicao = "false";
 		DpLotacao lotacaoDoCadastrante = getCadastrante().getLotacao();
 		DpLotacao lotacaoDoTitular = getLotaTitular();

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -230,7 +230,7 @@
 											<th align="left">Substituto</th>
 											<th align="center">Data inicial</th>
 											<th align="center">Data final</th>
-											<th align="center">Opções</th>
+											<%--<th align="center">Opções</th>--%>
 										</tr>
 									</thead>
 									<tbody  class="table-bordered">
@@ -258,12 +258,14 @@
 												</td>
 												<td align="center">${substTitular.dtIniSubstDDMMYY}</td>
 												<td align="center">${substTitular.dtFimSubstDDMMYY}</td>
+												<%--
 												<td align="center">
 													<siga:link title="Alterar" url="editar?id=${substTitular.idSubstituicao}" />
 																					
 													<siga:link title="Excluir" url="exclui?id=${substTitular.idSubstituicao}" 
 														popup="excluir" confirm="Deseja excluir configuração?" />										
 												</td>
+												--%>
 											</tr>
 										</c:forEach>
 									</tbody>
@@ -271,6 +273,7 @@
 							</div>
 						</div>		
 					</c:when>
+					<%--
 					<c:otherwise>
 						<div class="row">
 							<div class="col-sm-2">
@@ -278,6 +281,7 @@
 							</div>						
 						</div>
 					</c:otherwise>
+					--%>
 				</c:choose>
 			</div>
 		</div>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -124,7 +124,7 @@
 				</c:forEach>
 			</tbody>
 		</table>
-		<br /> <br />
+		<br />
 		<h3 class="gt-table-head"><fmt:message key="tela.lotacao.magistrados.servidores"/></h3>
 		<table border="0" class="table table-sm table-striped">
 			<thead class="${thead_color}">
@@ -137,7 +137,6 @@
 					<th align="right">Email</th>
 				</tr>
 			</thead>
-
 			<tbody>
 				<c:forEach var="pessoa" items="${lotacao.dpPessoaLotadosSet}">
 					<tr>
@@ -156,7 +155,7 @@
 				</c:forEach>
 			</tbody>
 		</table>
-		<br /> <br />
+		<br />
 		<h3 class="gt-table-head">Substituições Cadastradas</h3>
 		<table border="0" class="gt-table table table-sm table-hover">
 							<thead class="${thead_color}">

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -159,6 +159,9 @@
 		<br /> <br />
 		<h3 class="gt-table-head ${hide_only_GOVSP}">Organograma</h3>
 		<div id="organograma"></div>
+		
+		<%-- TODO: chamar o código de substituição aqui(SubstituicaoController) e exibir na tela --%>
+		
 	</div>
 
 	<script>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -157,21 +157,10 @@
 			</tbody>
 		</table>
 		<br /> <br />
-		
-		<%-- TODO: chamar o código de substituição aqui(SubstituicaoController) e exibir na tela --%>
-			<!-- main content -->
-	<div class="container-fluid">
-		<div class="card bg-light mb-3" >
-			<div class="card-header">
-				<h6>Substituições Cadastradas</h6>
-			</div>
-			<div class="card-body">
-				<div class="row">
-					<div class="col-sm">
-						<table border="0" class="gt-table table table-sm table-hover">
+		<h3 class="gt-table-head">Substituições Cadastradas</h3>
+		<table border="0" class="gt-table table table-sm table-hover">
 							<thead class="${thead_color}">
 								<tr>
-									<th align="left">Titular</th>
 									<th align="left">Substituto</th>
 									<th align="center">Data inicial</th>
 									<th align="center">Data final</th>
@@ -180,16 +169,6 @@
 							<tbody class="table-bordered">
 								<c:forEach var="substituicao" items="${itens}">
 									<tr>
-										<td align="left">
-											<c:choose>
-												<c:when test="${not empty substituicao.titular}">
-													${substituicao.titular.nomePessoa}
-												</c:when>
-												<c:otherwise>
-													${substituicao.lotaTitular.nomeLotacao}
-												</c:otherwise>
-											</c:choose>
-										</td>
 										<td align="left">
 											<c:choose>
 												<c:when test="${not empty substituicao.substituto}">
@@ -206,66 +185,9 @@
 								</c:forEach>
 							</tbody>
 						</table>
-					</div>
-				</div>
-				<c:choose>
-					<c:when test="${(isSubstituicao == 'true')}">			
-						<div class="row">
-							<div class="col-sm">
-								<h6>Substituições cadastradas para o Titular</h6>
-								<table border="0" class="gt-table table table-sm table-hover">
-									<thead class="${thead_color}">
-
-										<tr>
-											<th align="left">Titular</th>
-											<th align="left">Substituto</th>
-											<th align="center">Data inicial</th>
-											<th align="center">Data final</th>
-										</tr>
-									</thead>
-									<tbody  class="table-bordered">
-										<c:forEach var="substTitular" items="${itensTitular}">
-											<tr>
-												<td align="left">
-													<c:choose>
-														<c:when test="${not empty substTitular.titular}">
-																${substTitular.titular.nomePessoa}
-														</c:when>
-														<c:otherwise>
-																${substTitular.lotaTitular.nomeLotacao}
-														</c:otherwise>	
-													</c:choose>
-												</td>
-												<td align="left">
-													<c:choose>
-														<c:when test="${not empty substTitular.substituto}">
-															${substTitular.substituto.nomePessoa}
-														</c:when>
-														<c:otherwise>
-															${substTitular.lotaSubstituto.nomeLotacao}
-														</c:otherwise>
-													</c:choose>
-												</td>
-												<td align="center">${substTitular.dtIniSubstDDMMYY}</td>
-												<td align="center">${substTitular.dtFimSubstDDMMYY}</td>
-											</tr>
-										</c:forEach>
-									</tbody>
-								</table>
-							</div>
-						</div>		
-					</c:when>
-				</c:choose>
-			</div>
-		</div>
-	</div>
-	
 		<br /> <br />
 		<h3 class="gt-table-head ${hide_only_GOVSP}">Organograma</h3>
 		<div id="organograma"></div>
-		
-		
-		
 	</div>
 
 	<script>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -163,12 +163,11 @@
 	<div class="container-fluid">
 		<div class="card bg-light mb-3" >
 			<div class="card-header">
-				<h5>Gerenciar possíveis substitutos</h5>
+				<h6>Substituições Cadastradas</h6>
 			</div>
 			<div class="card-body">
 				<div class="row">
 					<div class="col-sm">
-						<h6>Substituições cadastradas</h5>
 						<table border="0" class="gt-table table table-sm table-hover">
 							<thead class="${thead_color}">
 								<tr>
@@ -176,7 +175,7 @@
 									<th align="left">Substituto</th>
 									<th align="center">Data inicial</th>
 									<th align="center">Data final</th>
-									<th align="center">Opções</th>
+									<%--<th align="center">Opções</th>--%>
 								</tr>
 							</thead>
 							<tbody class="table-bordered">
@@ -204,6 +203,7 @@
 										</td>
 										<td align="center">${substituicao.dtIniSubstDDMMYY}</td>
 										<td align="center">${substituicao.dtFimSubstDDMMYY}</td>
+										<%--
 										<td align="center">
 											<siga:link title="Alterar" url="editar?id=${substituicao.idSubstituicao}" />
 																			
@@ -211,6 +211,7 @@
 												popup="excluir" confirm="Deseja excluir substituição?" />									
 																		
 										</td>
+										--%>
 									</tr>
 								</c:forEach>
 							</tbody>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -157,10 +157,137 @@
 			</tbody>
 		</table>
 		<br /> <br />
+		
+		<%-- TODO: chamar o código de substituição aqui(SubstituicaoController) e exibir na tela --%>
+			<!-- main content -->
+	<div class="container-fluid">
+		<div class="card bg-light mb-3" >
+			<div class="card-header">
+				<h5>Gerenciar possíveis substitutos</h5>
+			</div>
+			<div class="card-body">
+				<div class="row">
+					<div class="col-sm">
+						<h6>Substituições cadastradas</h5>
+						<table border="0" class="gt-table table table-sm table-hover">
+							<thead class="${thead_color}">
+								<tr>
+									<th align="left">Titular</th>
+									<th align="left">Substituto</th>
+									<th align="center">Data inicial</th>
+									<th align="center">Data final</th>
+									<th align="center">Opções</th>
+								</tr>
+							</thead>
+							<tbody class="table-bordered">
+								<c:forEach var="substituicao" items="${itens}">
+									<tr>
+										<td align="left">
+											<c:choose>
+												<c:when test="${not empty substituicao.titular}">
+													${substituicao.titular.nomePessoa}
+												</c:when>
+												<c:otherwise>
+													${substituicao.lotaTitular.nomeLotacao}
+												</c:otherwise>
+											</c:choose>
+										</td>
+										<td align="left">
+											<c:choose>
+												<c:when test="${not empty substituicao.substituto}">
+													${substituicao.substituto.nomePessoa}
+												</c:when>
+												<c:otherwise>
+													${substituicao.lotaSubstituto.nomeLotacao}
+												</c:otherwise>
+											</c:choose>
+										</td>
+										<td align="center">${substituicao.dtIniSubstDDMMYY}</td>
+										<td align="center">${substituicao.dtFimSubstDDMMYY}</td>
+										<td align="center">
+											<siga:link title="Alterar" url="editar?id=${substituicao.idSubstituicao}" />
+																			
+											<siga:link title="Excluir" url="exclui?id=${substituicao.idSubstituicao}" 
+												popup="excluir" confirm="Deseja excluir substituição?" />									
+																		
+										</td>
+									</tr>
+								</c:forEach>
+							</tbody>
+						</table>
+					</div>
+				</div>
+				<c:choose>
+					<c:when test="${(isSubstituicao == 'true')}">			
+						<div class="row">
+							<div class="col-sm">
+								<h6>Substituições cadastradas para o Titular</h6>
+								<table border="0" class="gt-table table table-sm table-hover">
+									<thead class="${thead_color}">
+
+										<tr>
+											<th align="left">Titular</th>
+											<th align="left">Substituto</th>
+											<th align="center">Data inicial</th>
+											<th align="center">Data final</th>
+											<th align="center">Opções</th>
+										</tr>
+									</thead>
+									<tbody  class="table-bordered">
+										<c:forEach var="substTitular" items="${itensTitular}">
+											<tr>
+												<td align="left">
+													<c:choose>
+														<c:when test="${not empty substTitular.titular}">
+																${substTitular.titular.nomePessoa}
+														</c:when>
+														<c:otherwise>
+																${substTitular.lotaTitular.nomeLotacao}
+														</c:otherwise>	
+													</c:choose>
+												</td>
+												<td align="left">
+													<c:choose>
+														<c:when test="${not empty substTitular.substituto}">
+															${substTitular.substituto.nomePessoa}
+														</c:when>
+														<c:otherwise>
+															${substTitular.lotaSubstituto.nomeLotacao}
+														</c:otherwise>
+													</c:choose>
+												</td>
+												<td align="center">${substTitular.dtIniSubstDDMMYY}</td>
+												<td align="center">${substTitular.dtFimSubstDDMMYY}</td>
+												<td align="center">
+													<siga:link title="Alterar" url="editar?id=${substTitular.idSubstituicao}" />
+																					
+													<siga:link title="Excluir" url="exclui?id=${substTitular.idSubstituicao}" 
+														popup="excluir" confirm="Deseja excluir configuração?" />										
+												</td>
+											</tr>
+										</c:forEach>
+									</tbody>
+								</table>
+							</div>
+						</div>		
+					</c:when>
+					<c:otherwise>
+						<div class="row">
+							<div class="col-sm-2">
+								<button type="button"  onclick="javascript:window.location.href='editar'" class="btn btn-primary">Incluir</button>
+							</div>						
+						</div>
+					</c:otherwise>
+				</c:choose>
+			</div>
+		</div>
+	</div>
+	
+		<br /> <br />
 		<h3 class="gt-table-head ${hide_only_GOVSP}">Organograma</h3>
 		<div id="organograma"></div>
 		
-		<%-- TODO: chamar o código de substituição aqui(SubstituicaoController) e exibir na tela --%>
+		
 		
 	</div>
 

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/exibi.jsp
@@ -175,7 +175,6 @@
 									<th align="left">Substituto</th>
 									<th align="center">Data inicial</th>
 									<th align="center">Data final</th>
-									<%--<th align="center">Opções</th>--%>
 								</tr>
 							</thead>
 							<tbody class="table-bordered">
@@ -203,15 +202,6 @@
 										</td>
 										<td align="center">${substituicao.dtIniSubstDDMMYY}</td>
 										<td align="center">${substituicao.dtFimSubstDDMMYY}</td>
-										<%--
-										<td align="center">
-											<siga:link title="Alterar" url="editar?id=${substituicao.idSubstituicao}" />
-																			
-											<siga:link title="Excluir" url="exclui?id=${substituicao.idSubstituicao}" 
-												popup="excluir" confirm="Deseja excluir substituição?" />									
-																		
-										</td>
-										--%>
 									</tr>
 								</c:forEach>
 							</tbody>
@@ -231,7 +221,6 @@
 											<th align="left">Substituto</th>
 											<th align="center">Data inicial</th>
 											<th align="center">Data final</th>
-											<%--<th align="center">Opções</th>--%>
 										</tr>
 									</thead>
 									<tbody  class="table-bordered">
@@ -259,14 +248,6 @@
 												</td>
 												<td align="center">${substTitular.dtIniSubstDDMMYY}</td>
 												<td align="center">${substTitular.dtFimSubstDDMMYY}</td>
-												<%--
-												<td align="center">
-													<siga:link title="Alterar" url="editar?id=${substTitular.idSubstituicao}" />
-																					
-													<siga:link title="Excluir" url="exclui?id=${substTitular.idSubstituicao}" 
-														popup="excluir" confirm="Deseja excluir configuração?" />										
-												</td>
-												--%>
 											</tr>
 										</c:forEach>
 									</tbody>
@@ -274,15 +255,6 @@
 							</div>
 						</div>		
 					</c:when>
-					<%--
-					<c:otherwise>
-						<div class="row">
-							<div class="col-sm-2">
-								<button type="button"  onclick="javascript:window.location.href='editar'" class="btn btn-primary">Incluir</button>
-							</div>						
-						</div>
-					</c:otherwise>
-					--%>
 				</c:choose>
 			</div>
 		</div>


### PR DESCRIPTION
Alterei o quadro de visualização de uma lotação para exibir as lotações e pessoas que podem substituir uma lotação.

Quadro de visualização de uma lotação antes da alteração.
![antes da alteração](https://github.com/projeto-siga/siga/assets/37603843/50912aaf-039c-4669-b5cc-6ce1540d0a49)

Quadro de visualização de uma lotação após a alteração.
![Alterado](https://github.com/projeto-siga/siga/assets/37603843/eb8d2689-5b3d-41ea-882c-6f526cc2f2b1)
