### PR TITLE
#2359 Retirando a Data da devolução ao Tramitar

### DIFF
--- a/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
+++ b/siga-base/src/main/java/br/gov/jfrj/siga/base/Prop.java
@@ -196,6 +196,7 @@ public class Prop {
 		provider.addPublicProperty("/siga.mesa.versao", "2ant");
 		provider.addPublicProperty("/siga.municipios", null);
 		provider.addPublicProperty("/siga.ws.seguranca.token.jwt", "false");
+		provider.addPublicProperty("//sigaex.habilitarExibicaoDataDevolucao", "false"); //TODO
 
 		/* End-points Externos complementares */
 		provider.addPublicProperty("/siga.pagina.inicial.url", null);

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -208,8 +208,9 @@
 					<div class="row">
 						<div class="col col-3">
 							<div class="form-group mb-0">
-								<label>Data da devolução</label> 
-								<input type="text" name="dtDevolucaoMovString" onblur="javascript:verifica_data(this,0);" value="${dtDevolucaoMovString}" class="form-control campoData" autocomplete="off"/>					 
+							     <!-- Campo data de devolução foi desativado por motivo de bug no a devolver fora do prazo --> <!--  TODO -->
+								<!--  <label>Data da devolução</label> --> 
+								<input type="hidden" name="dtDevolucaoMovString" onblur="javascript:verifica_data(this,0);" value="${dtDevolucaoMovString}" class="form-control campoData" autocomplete="off" disabled="disabled"/>					 
 							</div>
 						</div>
 					</div>	
@@ -217,7 +218,7 @@
 				<c:if test="${siga_cliente != 'GOVSP'}">			
 					<div class="row">
 						<div class="col col-12">
-								<small class="form-text text-muted">Atenção: somente preencher a data de devolução se a intenção for, realmente, que o documento seja devolvido até esta data.</small>
+								<!--   <small class="form-text text-muted">Atenção: somente preencher a data de devolução se a intenção for, realmente, que o documento seja devolvido até esta data.</small> -->
 						</div>				
 					</div>
 				</c:if>				


### PR DESCRIPTION
Desabilitando o campo Data da devolução da tela ao Tramitar 
e desabilitando o campos da busca por banco de dados 
A devolver, Agradando devolução, A devolver (Fora do prazo), Aguardando devolução (Fora do prazo)

Scritps que foram montados para desativar as marcas levando em conta os ids da base do TRF2

UPDATE `corporativo`.`cp_marcador` SET `HIS_ATIVO` = '0', `LISTAVEL_PESQUISA_DEFAULT` = '0' WHERE (`ID_MARCADOR` = '56');
UPDATE `corporativo`.`cp_marcador` SET `HIS_ATIVO` = '0', `LISTAVEL_PESQUISA_DEFAULT` = '0' WHERE (`ID_MARCADOR` = '57');
UPDATE `corporativo`.`cp_marcador` SET `HIS_ATIVO` = '0', `LISTAVEL_PESQUISA_DEFAULT` = '0' WHERE (`ID_MARCADOR` = '58');
UPDATE `corporativo`.`cp_marcador` SET `HIS_ATIVO` = '0', `LISTAVEL_PESQUISA_DEFAULT` = '0' WHERE (`ID_MARCADOR` = '59');