### PR TITLE
JFRJ-SR-2023/04045-2378-siga wf ajuste retirar filtro da seleção de texto padrão na edição do diagrama

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -14,10 +14,37 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-		resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));
+		//novo código
+		//lista todos os preenchimentos, independente da lotação selecionada
+		resp.list = listarPreenchimentosSemFiltroLotacao(Long.parseLong(req.id));
+		
+		//código original
+		//lista os preenchimentos filtrados por Lotação
+		//resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));
+		
+		
 	}
-
+	
+	// Validei que esse é o código executado quando o usuário executa a seguinte operação
+		/*
+		 * USUÁRIO SELECIONA FILTRO POR LOTAÇÃO
+		 * 
+		 */
+	
+	//Lista todos os preenchimentos de 1 lotação específica.
+	
+	//URL: https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/lotacoes/86761/preenchimentos
+	//GET
+	
+	//public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
 	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
+		//se tirar o idLotacao do filtro, ele deve listar todos
+		// faz select pelo modelo e lotação
+		//após alteração deve exibir o resultado sem o filtro de lotação
+		//o resultado com o filtro de lotação deve ser exibido 1º
+		//
+		//na sequencia, exibir todas as outras opções em ordem alfabetica
+		//qual o filtro que mostra todos?
 		ExDao dao = ExDao.getInstance();
 		ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
 		mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
@@ -26,6 +53,8 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 		ExPreenchimento filtro = new ExPreenchimento();
 		filtro.setExModelo(mod);
+		
+		//alterando a linha abaixo tira o filtro de lotação
 		filtro.setDpLotacao(lota);
 		List<ExPreenchimento> l = dao.consultar(filtro);
 		List<PreenchimentoItem> list = new ArrayList<>();
@@ -35,8 +64,55 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 			item.nome = i.getNomePreenchimento();
 			list.add(item);
 		}
+		
+		
+		/*
+		Ajuste proposto:
+
+			Na seleção do texto padrão, exibir todos os textos existentes, independentemente da lotação selecionada, conforme já ocorre ao selecionar como responsável a "Lotação do titular".(AO [TIPO_RESPONSAVEL] = TITULAR)
+
+			Retornar a lista em ordem alfabética, filtrando o resultado a cada letra digitada (como já ocorre na seleção do modelo), porém, trazendo os textos padrão da lotação responsável pela tarefa na frente e os das demais lotações na sequencia, conforme exemplo abaixo:
+		*/
+		//System.out.println("########################################");
+		//System.out.println("Lista todos os preenchimentos de 1 lotação específica.");
+		//System.out.println("https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/lotacoes/86761/preenchimentos");
+		//System.out.println("########################################");
 		return list;
 	}
+	
+	// Validei que esse é o código executado quando o usuário executa a seguinte operação
+		/*
+		 * Na seleção do texto padrão, exibir todos os textos existentes, 
+		 * independentemente da lotação selecionada, 
+		 * conforme já ocorre ao selecionar como responsável a "Lotação do titular".
+		 * 
+		 */
+		
+		
+		//Lista os preenchimentos sem filtrar por lotações
+		//filtra apenas por modelos
+		public static List<PreenchimentoItem> listarPreenchimentosSemFiltroLotacao(Long idModelo) {
+			ExDao dao = ExDao.getInstance();
+			ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
+			mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
+
+			ExPreenchimento filtro = new ExPreenchimento();
+			filtro.setExModelo(mod);
+			List<ExPreenchimento> l = dao.consultar(filtro);
+			List<PreenchimentoItem> list = new ArrayList<>();
+			for (ExPreenchimento i : l) {
+				PreenchimentoItem item = new PreenchimentoItem();
+				item.idPreenchimento = Long.toString(i.getIdPreenchimento());
+				item.nome = i.getNomePreenchimento();
+				list.add(item);
+			}
+			
+			//System.out.println("########################################");
+			//System.out.println("Lista todos os preenchimentos de todas as lotações:");
+			//System.out.println("https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/preenchimentos");
+			//System.out.println("########################################");
+			return list;
+		}
 
 	@Override
 	public String getContext() {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -14,13 +14,11 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-		
-		//TODO: Refatoração: reduzir repetição de código
-		resp.list = listarPreenchimentosPriorizandoLotacao(Long.parseLong(req.id), Long.parseLong(req.idLotacao));	
+		resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));	
 	}
 	
 	// Lista todos os preenchimentos, primeiro os preenchimentos da lotação selecionada, depois os das outras
-	public static List<PreenchimentoItem> listarPreenchimentosPriorizandoLotacao(Long idModelo, Long idLotacao) {
+	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
 	    ExDao dao = ExDao.getInstance();
 	    ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
 	    mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
@@ -47,51 +45,6 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	    return list;
 	}
-
-	
-	//Lista todos os preenchimentos de 1 lotação específica.
-	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
-		ExDao dao = ExDao.getInstance();
-		ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
-		mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
-		DpLotacao lota = dao.consultar(idLotacao, DpLotacao.class, false);
-		lota = dao.consultar(lota.getIdInicial(), DpLotacao.class, false);
-
-		ExPreenchimento filtro = new ExPreenchimento();
-		filtro.setExModelo(mod);
-		filtro.setDpLotacao(lota);
-		List<ExPreenchimento> l = dao.consultar(filtro);
-		List<PreenchimentoItem> list = new ArrayList<>();
-		for (ExPreenchimento i : l) {
-			PreenchimentoItem item = new PreenchimentoItem();
-			item.idPreenchimento = Long.toString(i.getIdPreenchimento());
-			item.nome = i.getNomePreenchimento();
-			list.add(item);
-		}
-		
-
-		return list;
-	}
-	
-		//Lista os preenchimentos sem filtrar por lotações, filtra apenas por modelos
-		public static List<PreenchimentoItem> listarPreenchimentosSemFiltroLotacao(Long idModelo) {
-			ExDao dao = ExDao.getInstance();
-			ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
-			mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
-
-			ExPreenchimento filtro = new ExPreenchimento();
-			filtro.setExModelo(mod);
-			List<ExPreenchimento> l = dao.consultar(filtro);
-			List<PreenchimentoItem> list = new ArrayList<>();
-			for (ExPreenchimento i : l) {
-				PreenchimentoItem item = new PreenchimentoItem();
-				item.idPreenchimento = Long.toString(i.getIdPreenchimento());
-				item.nome = i.getNomePreenchimento();
-				list.add(item);
-			}
-			
-			return list;
-		}
 
 	@Override
 	public String getContext() {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -14,37 +14,23 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-		//novo código
-		//lista todos os preenchimentos, independente da lotação selecionada
+		//TODO: Listar os preenchimentos da lotação selecionada na frente e os das outras lotações depois
+		//TODO: Listar os preenchimentos em ordem alfabetica
+		//TODO: Refatoração: reduzir comentarios desnecessários
+		//TODO: Refatoração: reduzir repetição de código
+		
+		//novo código: lista todos os preenchimentos, independente da lotação selecionada
 		resp.list = listarPreenchimentosSemFiltroLotacao(Long.parseLong(req.id));
 		
-		//código original
-		//lista os preenchimentos filtrados por Lotação
-		//resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));
-		
-		
+		//código anterior: lista os preenchimentos filtrados por Lotação
+		//resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));	
 	}
 	
-	// Validei que esse é o código executado quando o usuário executa a seguinte operação
-		/*
-		 * USUÁRIO SELECIONA FILTRO POR LOTAÇÃO
-		 * 
-		 */
-	
 	//Lista todos os preenchimentos de 1 lotação específica.
-	
-	//URL: https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/lotacoes/86761/preenchimentos
-	//GET
-	
-	//public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
 	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
-		//se tirar o idLotacao do filtro, ele deve listar todos
-		// faz select pelo modelo e lotação
-		//após alteração deve exibir o resultado sem o filtro de lotação
 		//o resultado com o filtro de lotação deve ser exibido 1º
-		//
 		//na sequencia, exibir todas as outras opções em ordem alfabetica
-		//qual o filtro que mostra todos?
+
 		ExDao dao = ExDao.getInstance();
 		ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
 		mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
@@ -53,8 +39,6 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 		ExPreenchimento filtro = new ExPreenchimento();
 		filtro.setExModelo(mod);
-		
-		//alterando a linha abaixo tira o filtro de lotação
 		filtro.setDpLotacao(lota);
 		List<ExPreenchimento> l = dao.consultar(filtro);
 		List<PreenchimentoItem> list = new ArrayList<>();
@@ -65,32 +49,11 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 			list.add(item);
 		}
 		
-		
-		/*
-		Ajuste proposto:
 
-			Na seleção do texto padrão, exibir todos os textos existentes, independentemente da lotação selecionada, conforme já ocorre ao selecionar como responsável a "Lotação do titular".(AO [TIPO_RESPONSAVEL] = TITULAR)
-
-			Retornar a lista em ordem alfabética, filtrando o resultado a cada letra digitada (como já ocorre na seleção do modelo), porém, trazendo os textos padrão da lotação responsável pela tarefa na frente e os das demais lotações na sequencia, conforme exemplo abaixo:
-		*/
-		//System.out.println("########################################");
-		//System.out.println("Lista todos os preenchimentos de 1 lotação específica.");
-		//System.out.println("https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/lotacoes/86761/preenchimentos");
-		//System.out.println("########################################");
 		return list;
 	}
 	
-	// Validei que esse é o código executado quando o usuário executa a seguinte operação
-		/*
-		 * Na seleção do texto padrão, exibir todos os textos existentes, 
-		 * independentemente da lotação selecionada, 
-		 * conforme já ocorre ao selecionar como responsável a "Lotação do titular".
-		 * 
-		 */
-		
-		
-		//Lista os preenchimentos sem filtrar por lotações
-		//filtra apenas por modelos
+		//Lista os preenchimentos sem filtrar por lotações, filtra apenas por modelos
 		public static List<PreenchimentoItem> listarPreenchimentosSemFiltroLotacao(Long idModelo) {
 			ExDao dao = ExDao.getInstance();
 			ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
@@ -107,10 +70,6 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 				list.add(item);
 			}
 			
-			//System.out.println("########################################");
-			//System.out.println("Lista todos os preenchimentos de todas as lotações:");
-			//System.out.println("https://sigatms.jfrj.jus.br/sigaex/api/v1/modelos/82210/preenchimentos");
-			//System.out.println("########################################");
 			return list;
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -27,7 +27,7 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 	    ExPreenchimento filtro = new ExPreenchimento();
 	    filtro.setExModelo(mod);
 	    List<ExPreenchimento> l = dao.consultar(filtro);
-	    List<PreenchimentoItem> listaDePreenchimentos = new ArrayList<>();
+	    List<PreenchimentoItem> list = new ArrayList<>();
 	    List<PreenchimentoItem> preenchimentosDeOutrasLotacoes = new ArrayList<>();
 
 	    for (ExPreenchimento i : l) {
@@ -37,15 +37,15 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	        // Se a lotação do preenchimento atual corresponder à lotação selecionada, adiciona à lista principal
 	        if (i.getDpLotacao().getId().equals(idLotacao)) {
-	            listaDePreenchimentos.add(item);
+	            list.add(item);
 	        } else {
 	        	preenchimentosDeOutrasLotacoes.add(item);
 	        }
 	    }
 
-	    listaDePreenchimentos.addAll(preenchimentosDeOutrasLotacoes);
+	    list.addAll(preenchimentosDeOutrasLotacoes);
 
-	    return listaDePreenchimentos;
+	    return list;
 	}
 
 	

--- a/sigawf/src/main/webapp/WEB-INF/page/wfDiagrama/edita.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfDiagrama/edita.jsp
@@ -415,7 +415,7 @@ pageContext.setAttribute("tipoDeAcesso", WfTipoDeAcessoDeVariavel.values());
 								<section ng-if="tarefaItem.tipo == 'CRIAR_DOCUMENTO' || tarefaItem.tipo == 'AUTUAR_DOCUMENTO'"
 									ng-if="tarefaItem.preenchimentos"
 									class="col col-12 col-md-3 col-lg-3 form-group"> <label
-									for="ref2" title="" class="label mb-0">Preenchimento</label> <select
+									for="ref2" title="" class="label mb-0">Texto Padrão</label> <select
 									ng-model="tarefaItem.ref2"
 									ng-options="item.idPreenchimento as item.nome for item in tarefaItem.preenchimentos"
 									class="form-control"></select> </section>


### PR DESCRIPTION
**Módulo:**	 SIGA-WF - Workflow - referente a issue #2378
**Funcionalidade:** Editar Diagrama (/sigawf/app/diagrama/editar)

**Realizadas as seguintes alterações:** 

Exibir todos os textos padrão existentes para seleção, no tipo de tarefa "Criar Doc"

Na seleção do texto padrão, exibir todos os textos existentes, independentemente da lotação selecionada, conforme já ocorre ao selecionar como responsável a "Lotação do titular".

Retornar a lista em ordem alfabética, filtrando o resultado a cada letra digitada (como já ocorre na seleção do modelo), porém, trazendo os textos padrão da lotação responsável pela tarefa na frente e os das demais lotações na sequencia.

Substituir também o label "Preenchimento" por "Texto padrão"

**Justificativa:**
Agilizar a elaboração de diagramas, permtindo a inclusão de textos padrão sem depender da criação dos respectivos textos por outras unidades. Um digrama que passe por 10 unidades, por exemplo, exige hoje a interação com 10 áreas diferentes para que cada uma crie o respectivo texto padrão, onerando o processo de criação do workflow pelo gestor do diagrama.
