### PR TITLE
2378 siga wf editar diagrama ajuste mostrar lotacao antes do nome do texto-padrão e agrupar por lotacao

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExPreenchimento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExPreenchimento.java
@@ -93,12 +93,16 @@ public class ExPreenchimento extends AbstractExPreenchimento implements
 		}
 		return this.getIdPreenchimento().compareTo(o.getIdPreenchimento());
 	}
-	
+
 	public String descricaoNaLista(DpLotacao lotCorrente) {
 		if (Utils.equivale(lotCorrente, getDpLotacao()))
 			return getNomePreenchimento();
 		else
 			return (getDpLotacao() != null ? getDpLotacao().getSiglaCompleta() + ": " : "") + getNomePreenchimento();
+	}
+	
+	public String getSiglaDaLotacaoENomedoPreenchimento() {
+		return getDpLotacao().getSigla() + getNomePreenchimento();
 	}
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExPreenchimento.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExPreenchimento.java
@@ -102,7 +102,7 @@ public class ExPreenchimento extends AbstractExPreenchimento implements
 	}
 	
 	public String getSiglaDaLotacaoENomedoPreenchimento() {
-		return getDpLotacao().getSigla() + getNomePreenchimento();
+		return getDpLotacao().getSigla() + " - " + getNomePreenchimento();
 	}
 
 }

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -17,6 +17,8 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 		resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));	
 	}
 	
+	// TODO: agrupar os textos padrão por lotação ao invés de ordem alfabética
+	// TODO: mostrar a lotação antes do nome
 	// Lista todos os preenchimentos, primeiro os preenchimentos da lotação selecionada, depois os das outras
 	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
 	    ExDao dao = ExDao.getInstance();
@@ -25,26 +27,53 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 	    ExPreenchimento filtro = new ExPreenchimento();
 	    filtro.setExModelo(mod);
 	    List<ExPreenchimento> l = dao.consultar(filtro);
+	    
+	    // variaveis para gravar os preenchimentos/textos-padrões
 	    List<PreenchimentoItem> list = new ArrayList<>();
 	    List<PreenchimentoItem> preenchimentosDeOutrasLotacoes = new ArrayList<>();
-
+	    
+	    // variaveis para gravar as siglas das lotações
+	    List siglas = new ArrayList<>();
+	    List siglasDeOutrasLotacoes = new ArrayList<>();
+	    
 	    for (ExPreenchimento i : l) {
 	        PreenchimentoItem item = new PreenchimentoItem();
 	        item.idPreenchimento = Long.toString(i.getIdPreenchimento());
 	        item.nome = i.getNomePreenchimento();
-
+	        
+	        // variaveis para gravar as siglas das lotações
+	        String siglaLotacao = new String();
+	        siglaLotacao = i.getDpLotacao().getSigla();
+	        
 	        // Se a lotação do preenchimento atual corresponder à lotação selecionada, adiciona à lista principal
 	        if (i.getDpLotacao().getId().equals(idLotacao)) {
+	        	//Pegar as siglas das  lotações selecionadas aqui e adicionar em uma lista
 	            list.add(item);
+	            siglas.add(siglaLotacao);
 	        } else {
+	        	//Pegar as siglas das outras lotações aqui e adicionar em uma lista
 	        	preenchimentosDeOutrasLotacoes.add(item);
+	        	siglasDeOutrasLotacoes.add(siglaLotacao);
 	        }
 	    }
 
 	    list.addAll(preenchimentosDeOutrasLotacoes);
-
+	    siglas.addAll(siglasDeOutrasLotacoes);
+	    
+	    //TODO: Concatenar no padrão SIGLA + Preenchimento para montar saida
+	    List<String> resultadoConcatenacao = concatenarSiglasComPreenchimentos(siglas, list);
+	    
+	    //resultado precisa ser do tipo PreenchimentoItem
 	    return list;
 	}
+	
+    public static List<String> concatenarSiglasComPreenchimentos(List<String> siglas, List<PreenchimentoItem> preenchimentos) {
+        List<String> resultado = new ArrayList<String>();
+        for(int i = 0; i < siglas.size(); i++) {
+            resultado.add(siglas.get(i) + " " + preenchimentos.get(i).nome);
+        }
+        return resultado;
+    }
 
 	@Override
 	public String getContext() {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ModelosIdLotacoesIdLotacaoPreenchimentosGet.java
@@ -1,6 +1,7 @@
 package br.gov.jfrj.siga.ex.api.v1;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import br.gov.jfrj.siga.dp.DpLotacao;
@@ -14,14 +15,10 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 
 	@Override
 	public void run(Request req, Response resp, ExApiV1Context ctx) throws Exception {
-
-		//TODO: agrupar os textos padrão por lotação ao invés de ordem alfabética das descrições
-		List<PreenchimentoItem> preenchimentos = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));
-		resp.list = preenchimentos;
+		resp.list = listarPreenchimentos(Long.parseLong(req.id), Long.parseLong(req.idLotacao));
 	}
 	
 	
-	// Lista todos os preenchimentos, primeiro os preenchimentos da lotação selecionada, depois os das outras
 	public static List<PreenchimentoItem> listarPreenchimentos(Long idModelo, Long idLotacao) {
 	    ExDao dao = ExDao.getInstance();
 	    ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
@@ -29,67 +26,36 @@ public class ModelosIdLotacoesIdLotacaoPreenchimentosGet implements IModelosIdLo
 	    ExPreenchimento filtro = new ExPreenchimento();
 	    filtro.setExModelo(mod);
 	    List<ExPreenchimento> l = dao.consultar(filtro);
-	    List<PreenchimentoItem> list = new ArrayList<>();
-	    List<PreenchimentoItem> preenchimentosDeOutrasLotacoes = new ArrayList<>();
+
+	    List<PreenchimentoItem> lotacaoSelecionadaList = new ArrayList<>();
+	    HashMap<Long, List<PreenchimentoItem>> lotacoesMap = new HashMap<>();
 	    for (ExPreenchimento i : l) {
 	        PreenchimentoItem item = new PreenchimentoItem();
 	        item.idPreenchimento = Long.toString(i.getIdPreenchimento());
 	        String nome = i.getNomePreenchimento();
 	        String siglaLotacaoEPreenchimento = i.getSiglaDaLotacaoENomedoPreenchimento();
 	        item.nome = siglaLotacaoEPreenchimento;
+
+	        Long idLotacaoAtual = i.getDpLotacao().getId();
 	        
-	        // Se a lotação do preenchimento atual corresponder à lotação selecionada, adiciona à lista principal
-	        if (i.getDpLotacao().getId().equals(idLotacao)) {
-	            list.add(item);
+	        if (idLotacaoAtual.equals(idLotacao)) {
+	            lotacaoSelecionadaList.add(item);
 	        } else {
-	        	preenchimentosDeOutrasLotacoes.add(item);
-	        }
-	    }
-	    
-	    list.addAll(preenchimentosDeOutrasLotacoes);
-	    return list;
-	}
-	
-	
-	private List<String> listarLotacoes(long idModelo, long idLotacao) {
-	    ExDao dao = ExDao.getInstance();
-	    ExModelo mod = dao.consultar(idModelo, ExModelo.class, false);
-	    mod = dao.consultar(mod.getIdInicial(), ExModelo.class, false);
-	    ExPreenchimento filtro = new ExPreenchimento();
-	    filtro.setExModelo(mod);
-	    List<ExPreenchimento> l = dao.consultar(filtro);
-	    //List<PreenchimentoItem> list = new ArrayList<>();
-	    //List<PreenchimentoItem> preenchimentosDeOutrasLotacoes = new ArrayList<>();
-	    
-	    // variaveis para gravar as siglas das lotações
-	    List siglas = new ArrayList<>();
-	    List siglasDeOutrasLotacoes = new ArrayList<>();
-	    
-	    for (ExPreenchimento i : l) {
-	        PreenchimentoItem item = new PreenchimentoItem();
-	        item.idPreenchimento = Long.toString(i.getIdPreenchimento());
-	        item.nome = i.getNomePreenchimento();
-	        
-	        // variaveis para gravar as siglas das lotações
-	        String siglaLotacao = new String();
-	        siglaLotacao = i.getDpLotacao().getSigla();
-	        
-	        // Se a lotação do preenchimento atual corresponder à lotação selecionada, adiciona à lista principal
-	        if (i.getDpLotacao().getId().equals(idLotacao)) {
-	        	//Pegar as siglas das  lotações selecionadas aqui e adicionar em uma lista
-	            //list.add(item);
-	            siglas.add(siglaLotacao);
-	        } else {
-	        	//Pegar as siglas das outras lotações aqui e adicionar em uma lista
-	        	//preenchimentosDeOutrasLotacoes.add(item);
-	        	siglasDeOutrasLotacoes.add(siglaLotacao);
+	            if (!lotacoesMap.containsKey(idLotacaoAtual)) {
+	                lotacoesMap.put(idLotacaoAtual, new ArrayList<>());
+	            }
+	            lotacoesMap.get(idLotacaoAtual).add(item);
 	        }
 	    }
 
-	    siglas.addAll(siglasDeOutrasLotacoes);
-	    
-	    return siglas;
+	    List<PreenchimentoItem> list = new ArrayList<>();
+	    list.addAll(lotacaoSelecionadaList);
+	    for (Long id : lotacoesMap.keySet()) {
+	        list.addAll(lotacoesMap.get(id));
+	    }
+	    return list;
 	}
+
 	
 
 	@Override


### PR DESCRIPTION
**Alteração na tela editar diagrama:**

1 - Exibir as siglas das lotações na frente das descrições dos textos padrões
2 - Agrupar por lotação

![alteração 2 - exibir as siglas das lotações na frente das descrições dos textos padrões, agrupado por lotação](https://github.com/projeto-siga/siga/assets/37603843/8befed96-d956-4495-ac2b-cc83506ac468)

