### PR TITLE
2390 siga wf destaque para documentos com workflow usando cor diferente para chamar atenção do usuário para a existência de um workflow associado ao documento

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -289,7 +289,7 @@
 						<c:if
 							test="${ (primeiroMobil == true) and (docVO.tipoFormaDocumento == 'processo_administrativo')}">
 							<div id="${docVO.sigla}" depende=";wf;" class="wf_div"></div>
-							<!--TODO: Alterar a cor de fundo para destacar o campo no CSS dessa div-->
+							<!-- O Ajax abaixo chama esse arquivo: /sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp -->
 							<!--ajax:${doc.codigo}-${i}-->
 							<!--/ajax:${doc.codigo}-${i}-->
 							<c:set var="primeiroMobil" value="${false}" />
@@ -297,7 +297,6 @@
 						<c:if
 							test="${(not m.mob.geral) or (docVO.tipoFormaDocumento != 'processo_administrativo')}">
 							<div id="${m.sigla}" depende=";wf;" class="wf_div"></div>
-							<!--TODO: Alterar a cor de fundo para destacar o campo no CSS dessa div-->
 							<!--ajax:${doc.codigo}-${i}-->
 							<!--/ajax:${doc.codigo}-${i}-->
 						</c:if>

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/exibe.jsp
@@ -289,6 +289,7 @@
 						<c:if
 							test="${ (primeiroMobil == true) and (docVO.tipoFormaDocumento == 'processo_administrativo')}">
 							<div id="${docVO.sigla}" depende=";wf;" class="wf_div"></div>
+							<!--TODO: Alterar a cor de fundo para destacar o campo no CSS dessa div-->
 							<!--ajax:${doc.codigo}-${i}-->
 							<!--/ajax:${doc.codigo}-${i}-->
 							<c:set var="primeiroMobil" value="${false}" />
@@ -296,6 +297,7 @@
 						<c:if
 							test="${(not m.mob.geral) or (docVO.tipoFormaDocumento != 'processo_administrativo')}">
 							<div id="${m.sigla}" depende=";wf;" class="wf_div"></div>
+							<!--TODO: Alterar a cor de fundo para destacar o campo no CSS dessa div-->
 							<!--ajax:${doc.codigo}-${i}-->
 							<!--/ajax:${doc.codigo}-${i}-->
 						</c:if>

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
@@ -10,7 +10,7 @@
 		<c:set var="ajax" value="sim" scope="request" />
 
 		<div class="card mb-3 border-info">
-			<div class="card-header bg-warning text-white">
+			<div class="card-header bg-warning">
 				<a href="${linkTo[WfAppController].procedimento(pi.id)}"
 					style="color: white; text-decoration: underline;">${pi.sigla}</a> - 
 				<strong>${pi.definicaoDeTarefaCorrente.nome}</strong>

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
@@ -10,7 +10,7 @@
 		<c:set var="ajax" value="sim" scope="request" />
 
 		<div class="card mb-3 border-info">
-			<div class="card-header text-white" style="background-color: red;">
+			<div class="card-header text-white" style="background-color: #2f5e5e;">
 				<a href="${linkTo[WfAppController].procedimento(pi.id)}"
 					style="color: white; text-decoration: underline;">${pi.sigla}</a> - 
 				<strong>${pi.definicaoDeTarefaCorrente.nome}</strong>

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
@@ -10,7 +10,7 @@
 		<c:set var="ajax" value="sim" scope="request" />
 
 		<div class="card mb-3 border-info">
-			<div class="card-header text-white" style="background-color: #2f5e5e;">
+			<div class="card-header bg-warning text-white">
 				<a href="${linkTo[WfAppController].procedimento(pi.id)}"
 					style="color: white; text-decoration: underline;">${pi.sigla}</a> - 
 				<strong>${pi.definicaoDeTarefaCorrente.nome}</strong>

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/doc.jsp
@@ -10,7 +10,7 @@
 		<c:set var="ajax" value="sim" scope="request" />
 
 		<div class="card mb-3 border-info">
-			<div class="card-header bg-info text-white">
+			<div class="card-header text-white" style="background-color: red;">
 				<a href="${linkTo[WfAppController].procedimento(pi.id)}"
 					style="color: white; text-decoration: underline;">${pi.sigla}</a> - 
 				<strong>${pi.definicaoDeTarefaCorrente.nome}</strong>

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
@@ -24,8 +24,8 @@
 				</siga:links>
 
 				<c:if test="${pi.pausado || pi.retomando}">
-					<div style="background-color: #2f5e5e"; class="card bg-info mb-3 mt-3">
-						<div style="background-color: #2f5e5e"; class="card-header text-white">
+					<div class="card bg-info mb-3 mt-3">
+						<div class="card-header text-white">
 							<c:if
 								test="${pi.tipoDePrincipal eq 'DOCUMENTO' and not empty pi.principal}">
 								<a

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
@@ -24,8 +24,8 @@
 				</siga:links>
 
 				<c:if test="${pi.pausado || pi.retomando}">
-					<div class="card bg-info mb-3 mt-3">
-						<div class="card-header text-white">
+					<div style="background-color: red"; class="card bg-info mb-3 mt-3">
+						<div style="background-color: red"; class="card-header text-white">
 							<c:if
 								test="${pi.tipoDePrincipal eq 'DOCUMENTO' and not empty pi.principal}">
 								<a

--- a/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
+++ b/sigawf/src/main/webapp/WEB-INF/page/wfApp/procedimento.jsp
@@ -24,8 +24,8 @@
 				</siga:links>
 
 				<c:if test="${pi.pausado || pi.retomando}">
-					<div style="background-color: red"; class="card bg-info mb-3 mt-3">
-						<div style="background-color: red"; class="card-header text-white">
+					<div style="background-color: #2f5e5e"; class="card bg-info mb-3 mt-3">
+						<div style="background-color: #2f5e5e"; class="card-header text-white">
 							<c:if
 								test="${pi.tipoDePrincipal eq 'DOCUMENTO' and not empty pi.principal}">
 								<a


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Mudança proposta | Destacar a existência de um workflow vinculado ao documento e evitar que o usuário adote procedimento equivocado.
-- | --


<!--EndFragment-->
</body>
</html>
<html>
<body>
<!--StartFragment-->

Justificativa | Como o sistema permite o tramite manual de documentos, mesmo tendo um workflow orquestrando a execução (visando permitir  o tratamento de exceções), muitas vezes o usuário acaba não percebendo que existe um workflow vinculado ao documento e realiza uma tramitação manual, ao invés de prosseguir para a próxima tarefa prevista no fluxo.
-- | --


<!--EndFragment-->
</body>
</html>

Ajuste proposto:

 Mudar as cores da caixa da tarefa do workflow para chamar a atenção do usuário de que existe um workflow vinculado ao documento.

![1](https://github.com/projeto-siga/siga/assets/37603843/5982a1ee-d00b-4559-a3e2-489ed5b673b4)
