### PR TITLE
Fix para gerar id movimentacao no encerrarVolume

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -7307,6 +7307,7 @@ public class ExBL extends CpBL {
 					ExTipoDeMovimentacao.ENCERRAMENTO_DE_VOLUME, cadastrante, lotaCadastrante, mob,
 					dtMov, subscritor, null, titular, null, null);
 
+			gerarIdDeMovimentacao(mov);
 			mov.setNmFuncaoSubscritor(nmFuncaoSubscritor);
 
 			// Gravar o Html


### PR DESCRIPTION
Ao encerrar o volume automaticamente foi detectado erro que após investigação de log verificou-se que necessitaria da criacao do Id Movimentacao