### PR TITLE
EX assinatura e juntada ao finalizar os procedimentos, redireciona para a tela do do pai (onde foi feita a juntada).

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -774,7 +774,20 @@ public class ExMovimentacaoController extends ExController {
 		afTramite.explicacao = AcaoVO.Helper.produzirExplicacao(podeTramitarPosAssinatura, podeTramitar);
 		
 		Ex.getInstance().getBL().atualizaDataPrimeiraAssinatura(doc, getCadastrante(), getTitular());
-
+		
+		String siglaDoDocumentoPai = null;
+		if (doc != null && doc.getExMobilPai() != null) {
+		    siglaDoDocumentoPai = doc.getExMobilPai().getSigla();
+		}
+		
+		if (siglaDoDocumentoPai != null) {
+			result.include("siglaDocumentoPrincipal", siglaDoDocumentoPai);
+		}
+		
+		if (siglaDoDocumentoPai == null) {
+			result.include("siglaDocumentoPrincipal", sigla); //se não tem doc pai, pega a sigla do documento
+		}
+		
 		result.include("sigla", sigla);
 		result.include("doc", doc);
 		result.include("titular", this.getTitular());

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAssinar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAssinar.jsp
@@ -107,6 +107,10 @@
 					<c:set var="acao" value="assinar_gravar" />
 						<div class="card-footer" style="padding-top: 10px;">
 							<div id="dados-assinatura" style="visible: hidden">
+								<input
+									type="hidden" name="sigla_documento_principal"
+									value="/sigaex/app/expediente/doc/exibir?sigla=${siglaDocumentoPrincipal}" />
+									
 								<input type="hidden" name="ad_url_base" value="" /> <input
 									type="hidden" name="ad_url_next"
 									value="/sigaex/app/expediente/doc/exibir?sigla=${sigla}" /> <input

--- a/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
+++ b/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
@@ -924,7 +924,9 @@ function ExecutarAssinarDocumentos(Copia, Juntar, Tramitar, ExibirNoProtocolo) {
 		return;
 	}
 
-	oUrlNext = document.getElementsByName("ad_url_next")[0];
+	//oUrlNext = document.getElementsByName("ad_url_next")[0];
+	oUrlNext = document.getElementsByName("sigla_documento_principal")[0];
+	
 	if (oUrlNext == null) {
 		alert("element ad_url_next does not exist");
 		return;


### PR DESCRIPTION
Quando da operação de assinatura e juntada de um documento, ao finalizar os procedimentos, o sistema deve redirecionar o usuário para a tela de consulta do documento pai (onde foi feita a juntada).

Demonstração da alteração:
[08247 após a alteração.webm](https://github.com/projeto-siga/siga/assets/37603843/c6beb6e4-be41-4fcd-862a-d4abae0735f0)
