### PR TITLE
EX recurso incluir documento e assinar sem juntar redireciona de volta pro documento assinado ao invés de redirecionar pro documento pai

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -781,12 +781,20 @@ public class ExMovimentacaoController extends ExController {
 		}
 		
 		if (siglaDoDocumentoPai != null) {
-			result.include("siglaDocumentoPrincipal", siglaDoDocumentoPai);
+			
+			//é uma juntada?
+			if (doc.getPai() != null && afJuntada.ativo) {
+				result.include("siglaDocumentoPrincipal", siglaDoDocumentoPai);
+			} else {
+				result.include("siglaDocumentoPrincipal", sigla); 
+			}
 		}
 		
 		if (siglaDoDocumentoPai == null) {
-			result.include("siglaDocumentoPrincipal", sigla); //se não tem doc pai, pega a sigla do documento
+			result.include("siglaDocumentoPrincipal", sigla); 
 		}
+
+				
 		
 		result.include("sigla", sigla);
 		result.include("doc", doc);

--- a/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
+++ b/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
@@ -48,6 +48,7 @@ function TestarAssinaturaDigital() {
 // pagina
 //
 function AssinarDocumentos(copia, politica, juntar, tramitar, exibirNoProtocolo) {
+	
 	if (gAssinando)
 		return;
 	gAssinando = true;
@@ -901,6 +902,38 @@ function Erro(err) {
 	return "Ocorreu um erro durante o processo de assinatura: " + err.message;
 }
 
+function getCheckboxJuntarElement() {
+	// Capture o elemento do checkbox usando document.getElementsByName ou document.getElementById.
+    var checkboxJuntarElement = document.getElementsByName("ad_juntar_0")[0];
+    
+    if(!checkboxJuntarElement) {
+        console.error("Element 'ad_juntar_0' not found");
+        return null;
+    }
+    
+    return checkboxJuntarElement;
+}
+
+function isChecked(element) {
+    if (!element) {
+        return false;
+    }
+    return element.checked;
+}
+
+function getRedirectionTargetElement(isJuntarChecked) {
+    if (isJuntarChecked) {
+    	console.log("Checkbox Juntar está marcado");
+        console.log("Redirecionando para o documento pai");
+        return document.getElementsByName("sigla_documento_principal")[0];
+    }
+    if (!isJuntarChecked){
+    	console.log("Checkbox Juntar não está marcado");
+        console.log("Redirecionando para o documento filho");
+        return document.getElementsByName("ad_url_next")[0];
+    }
+}
+
 function ExecutarAssinarDocumentos(Copia, Juntar, Tramitar, ExibirNoProtocolo) {
 	process.reset();
 
@@ -923,9 +956,10 @@ function ExecutarAssinarDocumentos(Copia, Juntar, Tramitar, ExibirNoProtocolo) {
 		alert("element ad_url_base does not exist");
 		return;
 	}
-
-	//oUrlNext = document.getElementsByName("ad_url_next")[0];
-	oUrlNext = document.getElementsByName("sigla_documento_principal")[0];
+	
+	var checkboxJuntar = getCheckboxJuntarElement();
+	var isCheckBoxJuntarChecked = isChecked(checkboxJuntar);
+	oUrlNext = getRedirectionTargetElement(isCheckBoxJuntarChecked);
 	
 	if (oUrlNext == null) {
 		alert("element ad_url_next does not exist");

--- a/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
+++ b/sigaex/src/main/webapp/public/javascript/assinatura-digital.js
@@ -959,7 +959,15 @@ function ExecutarAssinarDocumentos(Copia, Juntar, Tramitar, ExibirNoProtocolo) {
 	
 	var checkboxJuntar = getCheckboxJuntarElement();
 	var isCheckBoxJuntarChecked = isChecked(checkboxJuntar);
-	oUrlNext = getRedirectionTargetElement(isCheckBoxJuntarChecked);
+	var urlDoRedirecionamento = getRedirectionTargetElement(isCheckBoxJuntarChecked);
+	
+	//Define um valor padrão para o oUrlNext não ficar com o valor null
+	if (urlDoRedirecionamento == null){
+		oUrlNext = document.getElementsByName("ad_url_next")[0];
+	}
+	if (urlDoRedirecionamento != null){
+		oUrlNext = urlDoRedirecionamento;
+	}
 	
 	if (oUrlNext == null) {
 		alert("element ad_url_next does not exist");


### PR DESCRIPTION
EX recurso incluir documento e assinar sem juntar redireciona de volta pro documento assinado ao invés de redirecionar pro documento pai.